### PR TITLE
feat(auth): invite code gating + onboarding flow fixes

### DIFF
--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -1,7 +1,7 @@
 // Onboarding Routes
 // REST endpoints for new user onboarding flow:
-// - POST /start   -> Acknowledge readiness (near no-op)
-// - POST /handoff -> Create workspace, provision sandbox, scaffold, create default domain + channel
+// - POST /start   -> Acknowledge readiness (no-op, kept for compatibility)
+// - POST /handoff -> Create workspace + domain + channel + sandbox + seed conversation
 
 import { Router, Response, NextFunction } from 'express';
 import { AuthenticatedRequest } from '../../types';
@@ -21,6 +21,15 @@ export function setOnboardingDeps(deps: { sandboxService: SandboxService }): voi
 }
 
 import { slugify } from '../../shared/slugify';
+
+// Template messages seeded into the first conversation so /chat shows the Xerus intro
+function buildTemplateMessages(firstName: string): Array<{ role: 'assistant'; content: string }> {
+    return [
+        { role: 'assistant', content: `Hey ${firstName}! I\u2019m Xerus \u2014 think of me as your co-CEO.` },
+        { role: 'assistant', content: `Quick intro to how this place works \u2014 you and I run a virtual office together. I manage a team of AI agents, each one like a dedicated employee. Researchers, writers, social media managers, data analysts\u2026 you pick who you need from the marketplace, connect them to apps you already use \u2014 Gmail, Slack, Notion, Sheets \u2014 and they get to work.\n\nThe best part? They don\u2019t just sit around waiting for instructions. They check in on their own, spot things that need your attention, and post updates in your channels. Your workspace keeps everything organized into projects so you always know what\u2019s happening across the board.` },
+        { role: 'assistant', content: `Now let\u2019s build your office. I\u2019ll walk you through it step by step \u2014 just a few questions so I can set things up right for you.\n\nAre you starting fresh, or bringing an existing company onboard?` },
+    ];
+}
 
 // -------------------------------------------------------------------------
 // POST /api/v1/onboarding/start
@@ -44,8 +53,10 @@ router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, nex
 
 // -------------------------------------------------------------------------
 // POST /api/v1/onboarding/handoff
-// Heavy lifting: create workspace row, provision sandbox, create default domain + channel.
-// Body: { workspace: string, project: string, choice?: string }
+// Creates workspace + domain + channel + provisions sandbox + seeds conversation.
+// Called when user submits the workspace name form.
+// Screen 2 (visual progress animation) plays while this runs.
+// Body: { workspace: string, project: string }
 // -------------------------------------------------------------------------
 
 router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
@@ -94,7 +105,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         );
         const domain = domainResult.rows[0] as { id: string; slug: string; name: string };
 
-        // 5. Create #general channel in the domain
+        // 3. Create #general channel in the domain
         const channelResult = await query(
             `INSERT INTO channels (domain_id, user_id, slug, name, description)
              VALUES ($1, $2, 'general', 'General', 'Default channel for team communication')
@@ -106,8 +117,30 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         );
         const channel = channelResult.rows[0] as { id: string };
 
-        // 6. Provision sandbox (async — don't block response if slow)
-        // The sandbox will be created on first execution if not ready yet.
+        // 4. Seed first conversation with template messages (shows in /chat)
+        const userName = req.user?.name || 'there';
+        const firstNameForGreeting = userName.split(' ')[0] || 'there';
+        const templateMsgs = buildTemplateMessages(firstNameForGreeting);
+
+        const convResult = await query(
+            `INSERT INTO conversations (user_id, agent_slug, title, message_count, last_message_at)
+             VALUES ($1, 'xerus-master', 'Onboarding', $2, NOW())
+             RETURNING id::text`,
+            [userId, templateMsgs.length],
+        );
+        const conversationId = (convResult.rows[0] as { id: string }).id;
+
+        // Insert template messages as execution_session rows so /chat can load them
+        for (const msg of templateMsgs) {
+            await query(
+                `INSERT INTO execution_sessions
+                 (id, workspace_id, agent_slug, status, trigger_type, conversation_id, agent_response, started_at, completed_at, created_at)
+                 VALUES (gen_random_uuid(), $1, 'xerus-master', 'completed', 'onboarding', $2, $3, NOW(), NOW(), NOW())`,
+                [workspace.id, conversationId, msg.content],
+            );
+        }
+
+        // 5. Provision sandbox (runs in background — Screen 2 animation covers the wait)
         let sandboxProvisioned = false;
         if (sandboxService) {
             try {
@@ -123,6 +156,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
             workspace: { id: workspace.id, slug: workspace.slug, name: workspace.name },
             domain: { id: domain.id, slug: domain.slug, name: domain.name },
             channel: { id: channel.id, slug: 'general', name: 'General' },
+            conversation_id: conversationId,
             sandbox_provisioned: sandboxProvisioned,
         }, startTime);
     } catch (err) {

--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -24,13 +24,20 @@ export function setOnboardingDeps(deps: { sandboxService: SandboxService }): voi
 
 import { slugify } from '../../shared/slugify';
 
-// Template messages seeded into the first conversation so /chat shows the Xerus intro
-function buildTemplateMessages(firstName: string): Array<{ role: 'assistant'; content: string }> {
-    return [
-        { role: 'assistant', content: `Hey ${firstName}! I\u2019m Xerus \u2014 think of me as your co-CEO.` },
-        { role: 'assistant', content: `Quick intro to how this place works \u2014 you and I run a virtual office together. I manage a team of AI agents, each one like a dedicated employee. Researchers, writers, social media managers, data analysts\u2026 you pick who you need from the marketplace, connect them to apps you already use \u2014 Gmail, Slack, Notion, Sheets \u2014 and they get to work.\n\nThe best part? They don\u2019t just sit around waiting for instructions. They check in on their own, spot things that need your attention, and post updates in your channels. Your workspace keeps everything organized into projects so you always know what\u2019s happening across the board.` },
-        { role: 'assistant', content: `Now let\u2019s build your office. I\u2019ll walk you through it step by step \u2014 just a few questions so I can set things up right for you.\n\nAre you starting fresh, or bringing an existing company onboard?` },
-    ];
+// Single contextual welcome message seeded into /chat post-onboarding.
+// References BOOTSTRAP.md checklist items so the agent can continue from here.
+function buildWelcomeMessage(firstName: string, workspaceName: string, projectName: string): string {
+    return `Hey ${firstName}! Welcome to **${workspaceName}** \u2014 your AI office is all set up.
+
+I\u2019ve created your **${projectName}** project with a #general channel. Now I need to learn about your business so I can build the right team for you.
+
+Here\u2019s what I\u2019ll do next:
+\u2022 Learn about your business and top priorities
+\u2022 Set up your company knowledge base
+\u2022 Suggest the right AI agents for your needs
+\u2022 Get your first deliverable rolling within 24 hours
+
+**Tell me \u2014 what\u2019s your business about, and what are your top 3 goals for the next 90 days?**`;
 }
 
 // -------------------------------------------------------------------------
@@ -85,7 +92,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         // Steps 1-5 in a single transaction — all-or-nothing
         const safeName = (req.user?.name || 'there').replace(/[<>&"']/g, '');
         const firstNameForGreeting = safeName.split(' ')[0] || 'there';
-        const templateMsgs = buildTemplateMessages(firstNameForGreeting);
+        const welcomeMessage = buildWelcomeMessage(firstNameForGreeting, workspaceName, projectDisplayName);
 
         const result = await transaction(async (client: PoolClient) => {
             // 1. Create workspace row
@@ -121,7 +128,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
             );
             const channel = channelResult.rows[0] as { id: string };
 
-            // 4. Seed conversation (idempotent — skip if already exists from a previous attempt)
+            // 4. Seed conversation with welcome message (idempotent — skip if exists)
             const existingConv = await client.query(
                 `SELECT id::text FROM conversations WHERE user_id = $1 AND title = 'Onboarding' LIMIT 1`,
                 [userId],
@@ -132,28 +139,19 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
             } else {
                 const convResult = await client.query(
                     `INSERT INTO conversations (user_id, agent_slug, title, message_count, last_message_at)
-                     VALUES ($1, 'xerus-master', 'Onboarding', $2, NOW())
+                     VALUES ($1, 'xerus-master', 'Onboarding', 1, NOW())
                      RETURNING id::text`,
-                    [userId, templateMsgs.length],
+                    [userId],
                 );
                 conversationId = (convResult.rows[0] as { id: string }).id;
 
-                // 5. Batch insert template messages (only for new conversations)
-            const msgValues: unknown[] = [];
-            const msgPlaceholders: string[] = [];
-            templateMsgs.forEach((msg, i) => {
-                const offset = i * 3;
-                msgPlaceholders.push(
-                    `(gen_random_uuid(), $${offset + 1}, 'xerus-master', 'completed', NULL, $${offset + 2}, $${offset + 3}, NOW(), NOW(), NOW())`
+                // 5. Single welcome message referencing BOOTSTRAP.md guidance
+                await client.query(
+                    `INSERT INTO execution_sessions
+                     (id, workspace_id, agent_slug, status, trigger_type, conversation_id, agent_response, started_at, completed_at, created_at)
+                     VALUES (gen_random_uuid(), $1, 'xerus-master', 'completed', NULL, $2, $3, NOW(), NOW(), NOW())`,
+                    [workspace.id, conversationId, welcomeMessage],
                 );
-                msgValues.push(workspace.id, conversationId, msg.content);
-            });
-            await client.query(
-                `INSERT INTO execution_sessions
-                 (id, workspace_id, agent_slug, status, trigger_type, conversation_id, agent_response, started_at, completed_at, created_at)
-                 VALUES ${msgPlaceholders.join(', ')}`,
-                msgValues,
-            );
             }
 
             return { workspace, domain, channel, conversationId };

--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -7,6 +7,7 @@ import { Router, Response, NextFunction } from 'express';
 import { AuthenticatedRequest } from '../../types';
 import { sendResponse } from '../../utils/response';
 import { authenticateFirebaseToken } from '../../middleware/auth';
+import { UnauthorizedError, BadRequestError } from '../../utils/errors';
 import { transaction } from '../../database/connection';
 import { PoolClient } from 'pg';
 import type { SandboxService } from '../execution';
@@ -42,8 +43,7 @@ router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, nex
     try {
         const userId = req.user?.uid;
         if (!userId) {
-            res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: 'Authentication required' } });
-            return;
+            throw new UnauthorizedError('Authentication required');
         }
 
         sendResponse(res, 200, { status: 'ready' }, startTime);
@@ -65,16 +65,17 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
     try {
         const userId = req.user?.uid;
         if (!userId) {
-            res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: 'Authentication required' } });
-            return;
+            throw new UnauthorizedError('Authentication required');
         }
 
         const workspaceName = (req.body.workspace as string || '').trim();
         const projectName = (req.body.project as string || '').trim();
 
-        if (!workspaceName) {
-            res.status(400).json({ success: false, error: { code: 'BAD_REQUEST', message: 'workspace name is required' } });
-            return;
+        if (!workspaceName || workspaceName.length > 100) {
+            throw new BadRequestError('workspace name is required (max 100 chars)');
+        }
+        if (projectName.length > 100) {
+            throw new BadRequestError('project name too long (max 100 chars)');
         }
 
         const workspaceSlug = slugify(workspaceName);
@@ -82,8 +83,8 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         const projectDisplayName = projectName || 'Default';
 
         // Steps 1-5 in a single transaction — all-or-nothing
-        const userName = req.user?.name || 'there';
-        const firstNameForGreeting = userName.split(' ')[0] || 'there';
+        const safeName = (req.user?.name || 'there').replace(/[<>&"']/g, '');
+        const firstNameForGreeting = safeName.split(' ')[0] || 'there';
         const templateMsgs = buildTemplateMessages(firstNameForGreeting);
 
         const result = await transaction(async (client: PoolClient) => {
@@ -120,16 +121,24 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
             );
             const channel = channelResult.rows[0] as { id: string };
 
-            // 4. Seed conversation with template messages (shows in /chat)
-            const convResult = await client.query(
-                `INSERT INTO conversations (user_id, agent_slug, title, message_count, last_message_at)
-                 VALUES ($1, 'xerus-master', 'Onboarding', $2, NOW())
-                 RETURNING id::text`,
-                [userId, templateMsgs.length],
+            // 4. Seed conversation (idempotent — skip if already exists from a previous attempt)
+            const existingConv = await client.query(
+                `SELECT id::text FROM conversations WHERE user_id = $1 AND title = 'Onboarding' LIMIT 1`,
+                [userId],
             );
-            const conversationId = (convResult.rows[0] as { id: string }).id;
+            let conversationId: string;
+            if (existingConv.rows.length > 0) {
+                conversationId = (existingConv.rows[0] as { id: string }).id;
+            } else {
+                const convResult = await client.query(
+                    `INSERT INTO conversations (user_id, agent_slug, title, message_count, last_message_at)
+                     VALUES ($1, 'xerus-master', 'Onboarding', $2, NOW())
+                     RETURNING id::text`,
+                    [userId, templateMsgs.length],
+                );
+                conversationId = (convResult.rows[0] as { id: string }).id;
 
-            // 5. Batch insert template messages (trigger_type NULL — these are seed data, not real executions)
+                // 5. Batch insert template messages (only for new conversations)
             const msgValues: unknown[] = [];
             const msgPlaceholders: string[] = [];
             templateMsgs.forEach((msg, i) => {
@@ -145,6 +154,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
                  VALUES ${msgPlaceholders.join(', ')}`,
                 msgValues,
             );
+            }
 
             return { workspace, domain, channel, conversationId };
         });

--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -1,7 +1,7 @@
 // Onboarding Routes
 // REST endpoints for new user onboarding flow:
-// - POST /start   -> Acknowledge readiness (near no-op)
-// - POST /handoff -> Create workspace, provision sandbox, scaffold, create default domain + channel
+// - POST /start   -> Create default workspace + provision sandbox (must complete before AI conversation)
+// - POST /handoff -> Rename workspace, create domain + channel (after AI guides user through naming)
 
 import { Router, Response, NextFunction } from 'express';
 import { AuthenticatedRequest } from '../../types';
@@ -24,7 +24,8 @@ import { slugify } from '../../shared/slugify';
 
 // -------------------------------------------------------------------------
 // POST /api/v1/onboarding/start
-// Frontend calls this on mount. Returns ok so template flow can continue.
+// Creates a default workspace row + provisions sandbox so the AI conversation
+// can run inside it. Called on mount — template messages play while this completes.
 // -------------------------------------------------------------------------
 
 router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
@@ -36,7 +37,43 @@ router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, nex
             return;
         }
 
-        sendResponse(res, 200, { status: 'ready' }, startTime);
+        // Check if workspace already exists (idempotent — safe to call multiple times)
+        const existing = await query(
+            'SELECT id::text FROM workspaces WHERE user_id = $1 LIMIT 1',
+            [userId],
+        );
+
+        let workspaceId: string;
+        if (existing.rows.length > 0) {
+            workspaceId = String(existing.rows[0].id);
+        } else {
+            // Create default workspace row so execution pipeline can find it
+            const wsResult = await query(
+                `INSERT INTO workspaces (user_id, slug, name)
+                 VALUES ($1, 'default', 'My Workspace')
+                 ON CONFLICT (user_id) DO NOTHING
+                 RETURNING id::text`,
+                [userId],
+            );
+            workspaceId = String(wsResult.rows[0]?.id ?? '');
+        }
+
+        // Provision sandbox (this is the slow part — ~9s)
+        let sandboxReady = false;
+        if (sandboxService) {
+            try {
+                await sandboxService.getOrCreateSandbox({ userId });
+                sandboxReady = true;
+            } catch (err) {
+                console.warn(`[Onboarding] Sandbox provisioning failed for user ${userId}: ${(err as Error).message}`);
+            }
+        }
+
+        sendResponse(res, 200, {
+            status: 'ready',
+            workspace_id: workspaceId,
+            sandbox_ready: sandboxReady,
+        }, startTime);
     } catch (err) {
         next(err);
     }
@@ -44,8 +81,9 @@ router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, nex
 
 // -------------------------------------------------------------------------
 // POST /api/v1/onboarding/handoff
-// Heavy lifting: create workspace row, provision sandbox, create default domain + channel.
-// Body: { workspace: string, project: string, choice?: string }
+// Rename workspace, create default domain + channel.
+// Workspace row + sandbox already exist from /start.
+// Body: { workspace: string, project: string }
 // -------------------------------------------------------------------------
 
 router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
@@ -69,7 +107,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         const projectSlug = projectName ? slugify(projectName) : 'default';
         const projectDisplayName = projectName || 'Default';
 
-        // 1. Create workspace row (idempotent via ON CONFLICT)
+        // 1. Update workspace name (row already created by /start)
         const wsResult = await query(
             `INSERT INTO workspaces (user_id, slug, name)
              VALUES ($1, $2, $3)
@@ -94,7 +132,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         );
         const domain = domainResult.rows[0] as { id: string; slug: string; name: string };
 
-        // 5. Create #general channel in the domain
+        // 3. Create #general channel in the domain
         const channelResult = await query(
             `INSERT INTO channels (domain_id, user_id, slug, name, description)
              VALUES ($1, $2, 'general', 'General', 'Default channel for team communication')
@@ -106,24 +144,10 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         );
         const channel = channelResult.rows[0] as { id: string };
 
-        // 6. Provision sandbox (async — don't block response if slow)
-        // The sandbox will be created on first execution if not ready yet.
-        let sandboxProvisioned = false;
-        if (sandboxService) {
-            try {
-                await sandboxService.getOrCreateSandbox({ userId });
-                sandboxProvisioned = true;
-            } catch (err) {
-                console.warn(`[Onboarding] Sandbox provisioning deferred for user ${userId}: ${(err as Error).message}`);
-                sandboxProvisioned = false;
-            }
-        }
-
         sendResponse(res, 200, {
             workspace: { id: workspace.id, slug: workspace.slug, name: workspace.name },
             domain: { id: domain.id, slug: domain.slug, name: domain.name },
             channel: { id: channel.id, slug: 'general', name: 'General' },
-            sandbox_provisioned: sandboxProvisioned,
         }, startTime);
     } catch (err) {
         next(err);

--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -1,7 +1,7 @@
 // Onboarding Routes
 // REST endpoints for new user onboarding flow:
-// - POST /start   -> Create default workspace + provision sandbox (must complete before AI conversation)
-// - POST /handoff -> Rename workspace, create domain + channel (after AI guides user through naming)
+// - POST /start   -> Acknowledge readiness (near no-op)
+// - POST /handoff -> Create workspace, provision sandbox, scaffold, create default domain + channel
 
 import { Router, Response, NextFunction } from 'express';
 import { AuthenticatedRequest } from '../../types';
@@ -24,8 +24,7 @@ import { slugify } from '../../shared/slugify';
 
 // -------------------------------------------------------------------------
 // POST /api/v1/onboarding/start
-// Creates a default workspace row + provisions sandbox so the AI conversation
-// can run inside it. Called on mount — template messages play while this completes.
+// Frontend calls this on mount. Returns ok so template flow can continue.
 // -------------------------------------------------------------------------
 
 router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
@@ -37,43 +36,7 @@ router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, nex
             return;
         }
 
-        // Check if workspace already exists (idempotent — safe to call multiple times)
-        const existing = await query(
-            'SELECT id::text FROM workspaces WHERE user_id = $1 LIMIT 1',
-            [userId],
-        );
-
-        let workspaceId: string;
-        if (existing.rows.length > 0) {
-            workspaceId = String(existing.rows[0].id);
-        } else {
-            // Create default workspace row so execution pipeline can find it
-            const wsResult = await query(
-                `INSERT INTO workspaces (user_id, slug, name)
-                 VALUES ($1, 'default', 'My Workspace')
-                 ON CONFLICT (user_id) DO NOTHING
-                 RETURNING id::text`,
-                [userId],
-            );
-            workspaceId = String(wsResult.rows[0]?.id ?? '');
-        }
-
-        // Provision sandbox (this is the slow part — ~9s)
-        let sandboxReady = false;
-        if (sandboxService) {
-            try {
-                await sandboxService.getOrCreateSandbox({ userId });
-                sandboxReady = true;
-            } catch (err) {
-                console.warn(`[Onboarding] Sandbox provisioning failed for user ${userId}: ${(err as Error).message}`);
-            }
-        }
-
-        sendResponse(res, 200, {
-            status: 'ready',
-            workspace_id: workspaceId,
-            sandbox_ready: sandboxReady,
-        }, startTime);
+        sendResponse(res, 200, { status: 'ready' }, startTime);
     } catch (err) {
         next(err);
     }
@@ -81,9 +44,8 @@ router.post('/start', auth, async (req: AuthenticatedRequest, res: Response, nex
 
 // -------------------------------------------------------------------------
 // POST /api/v1/onboarding/handoff
-// Rename workspace, create default domain + channel.
-// Workspace row + sandbox already exist from /start.
-// Body: { workspace: string, project: string }
+// Heavy lifting: create workspace row, provision sandbox, create default domain + channel.
+// Body: { workspace: string, project: string, choice?: string }
 // -------------------------------------------------------------------------
 
 router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
@@ -107,7 +69,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         const projectSlug = projectName ? slugify(projectName) : 'default';
         const projectDisplayName = projectName || 'Default';
 
-        // 1. Update workspace name (row already created by /start)
+        // 1. Create workspace row (idempotent via ON CONFLICT)
         const wsResult = await query(
             `INSERT INTO workspaces (user_id, slug, name)
              VALUES ($1, $2, $3)
@@ -132,7 +94,7 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         );
         const domain = domainResult.rows[0] as { id: string; slug: string; name: string };
 
-        // 3. Create #general channel in the domain
+        // 5. Create #general channel in the domain
         const channelResult = await query(
             `INSERT INTO channels (domain_id, user_id, slug, name, description)
              VALUES ($1, $2, 'general', 'General', 'Default channel for team communication')
@@ -144,10 +106,24 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         );
         const channel = channelResult.rows[0] as { id: string };
 
+        // 6. Provision sandbox (async — don't block response if slow)
+        // The sandbox will be created on first execution if not ready yet.
+        let sandboxProvisioned = false;
+        if (sandboxService) {
+            try {
+                await sandboxService.getOrCreateSandbox({ userId });
+                sandboxProvisioned = true;
+            } catch (err) {
+                console.warn(`[Onboarding] Sandbox provisioning deferred for user ${userId}: ${(err as Error).message}`);
+                sandboxProvisioned = false;
+            }
+        }
+
         sendResponse(res, 200, {
             workspace: { id: workspace.id, slug: workspace.slug, name: workspace.name },
             domain: { id: domain.id, slug: domain.slug, name: domain.name },
             channel: { id: channel.id, slug: 'general', name: 'General' },
+            sandbox_provisioned: sandboxProvisioned,
         }, startTime);
     } catch (err) {
         next(err);

--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -7,7 +7,8 @@ import { Router, Response, NextFunction } from 'express';
 import { AuthenticatedRequest } from '../../types';
 import { sendResponse } from '../../utils/response';
 import { authenticateFirebaseToken } from '../../middleware/auth';
-import { query } from '../../database/connection';
+import { transaction } from '../../database/connection';
+import { PoolClient } from 'pg';
 import type { SandboxService } from '../execution';
 
 const router = Router();
@@ -80,67 +81,75 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         const projectSlug = projectName ? slugify(projectName) : 'default';
         const projectDisplayName = projectName || 'Default';
 
-        // 1. Create workspace row (idempotent via ON CONFLICT)
-        const wsResult = await query(
-            `INSERT INTO workspaces (user_id, slug, name)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (user_id) DO UPDATE SET
-                 name = EXCLUDED.name,
-                 slug = EXCLUDED.slug,
-                 updated_at = NOW()
-             RETURNING id::text, slug, name`,
-            [userId, workspaceSlug, workspaceName],
-        );
-        const workspace = wsResult.rows[0] as { id: string; slug: string; name: string };
-
-        // 2. Create default domain
-        const domainResult = await query(
-            `INSERT INTO domains (user_id, workspace_id, slug, name, description)
-             VALUES ($1, $2, $3, $4, $5)
-             ON CONFLICT (workspace_id, slug) DO UPDATE SET
-                 name = EXCLUDED.name,
-                 updated_at = NOW()
-             RETURNING id::text, slug, name`,
-            [userId, workspace.id, projectSlug, projectDisplayName, `${projectDisplayName} department`],
-        );
-        const domain = domainResult.rows[0] as { id: string; slug: string; name: string };
-
-        // 3. Create #general channel in the domain
-        const channelResult = await query(
-            `INSERT INTO channels (domain_id, user_id, slug, name, description)
-             VALUES ($1, $2, 'general', 'General', 'Default channel for team communication')
-             ON CONFLICT (domain_id, slug) DO UPDATE SET
-                 name = EXCLUDED.name,
-                 updated_at = NOW()
-             RETURNING id::text`,
-            [domain.id, userId],
-        );
-        const channel = channelResult.rows[0] as { id: string };
-
-        // 4. Seed first conversation with template messages (shows in /chat)
+        // Steps 1-5 in a single transaction — all-or-nothing
         const userName = req.user?.name || 'there';
         const firstNameForGreeting = userName.split(' ')[0] || 'there';
         const templateMsgs = buildTemplateMessages(firstNameForGreeting);
 
-        const convResult = await query(
-            `INSERT INTO conversations (user_id, agent_slug, title, message_count, last_message_at)
-             VALUES ($1, 'xerus-master', 'Onboarding', $2, NOW())
-             RETURNING id::text`,
-            [userId, templateMsgs.length],
-        );
-        const conversationId = (convResult.rows[0] as { id: string }).id;
+        const result = await transaction(async (client: PoolClient) => {
+            // 1. Create workspace row
+            const wsResult = await client.query(
+                `INSERT INTO workspaces (user_id, slug, name)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (user_id) DO UPDATE SET
+                     name = EXCLUDED.name, slug = EXCLUDED.slug, updated_at = NOW()
+                 RETURNING id::text, slug, name`,
+                [userId, workspaceSlug, workspaceName],
+            );
+            const workspace = wsResult.rows[0] as { id: string; slug: string; name: string };
 
-        // Insert template messages as execution_session rows so /chat can load them
-        for (const msg of templateMsgs) {
-            await query(
+            // 2. Create default domain
+            const domainResult = await client.query(
+                `INSERT INTO domains (user_id, workspace_id, slug, name, description)
+                 VALUES ($1, $2, $3, $4, $5)
+                 ON CONFLICT (workspace_id, slug) DO UPDATE SET
+                     name = EXCLUDED.name, updated_at = NOW()
+                 RETURNING id::text, slug, name`,
+                [userId, workspace.id, projectSlug, projectDisplayName, `${projectDisplayName} department`],
+            );
+            const domain = domainResult.rows[0] as { id: string; slug: string; name: string };
+
+            // 3. Create #general channel
+            const channelResult = await client.query(
+                `INSERT INTO channels (domain_id, user_id, slug, name, description)
+                 VALUES ($1, $2, 'general', 'General', 'Default channel for team communication')
+                 ON CONFLICT (domain_id, slug) DO UPDATE SET
+                     name = EXCLUDED.name, updated_at = NOW()
+                 RETURNING id::text`,
+                [domain.id, userId],
+            );
+            const channel = channelResult.rows[0] as { id: string };
+
+            // 4. Seed conversation with template messages (shows in /chat)
+            const convResult = await client.query(
+                `INSERT INTO conversations (user_id, agent_slug, title, message_count, last_message_at)
+                 VALUES ($1, 'xerus-master', 'Onboarding', $2, NOW())
+                 RETURNING id::text`,
+                [userId, templateMsgs.length],
+            );
+            const conversationId = (convResult.rows[0] as { id: string }).id;
+
+            // 5. Batch insert template messages (trigger_type NULL — these are seed data, not real executions)
+            const msgValues: unknown[] = [];
+            const msgPlaceholders: string[] = [];
+            templateMsgs.forEach((msg, i) => {
+                const offset = i * 3;
+                msgPlaceholders.push(
+                    `(gen_random_uuid(), $${offset + 1}, 'xerus-master', 'completed', NULL, $${offset + 2}, $${offset + 3}, NOW(), NOW(), NOW())`
+                );
+                msgValues.push(workspace.id, conversationId, msg.content);
+            });
+            await client.query(
                 `INSERT INTO execution_sessions
                  (id, workspace_id, agent_slug, status, trigger_type, conversation_id, agent_response, started_at, completed_at, created_at)
-                 VALUES (gen_random_uuid(), $1, 'xerus-master', 'completed', 'onboarding', $2, $3, NOW(), NOW(), NOW())`,
-                [workspace.id, conversationId, msg.content],
+                 VALUES ${msgPlaceholders.join(', ')}`,
+                msgValues,
             );
-        }
 
-        // 5. Provision sandbox (runs in background — Screen 2 animation covers the wait)
+            return { workspace, domain, channel, conversationId };
+        });
+
+        // 6. Provision sandbox (outside transaction — Screen 2 animation covers the wait)
         let sandboxProvisioned = false;
         if (sandboxService) {
             try {
@@ -153,10 +162,10 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         }
 
         sendResponse(res, 200, {
-            workspace: { id: workspace.id, slug: workspace.slug, name: workspace.name },
-            domain: { id: domain.id, slug: domain.slug, name: domain.name },
-            channel: { id: channel.id, slug: 'general', name: 'General' },
-            conversation_id: conversationId,
+            workspace: { id: result.workspace.id, slug: result.workspace.slug, name: result.workspace.name },
+            domain: { id: result.domain.id, slug: result.domain.slug, name: result.domain.name },
+            channel: { id: result.channel.id, slug: 'general', name: 'General' },
+            conversation_id: result.conversationId,
             sandbox_provisioned: sandboxProvisioned,
         }, startTime);
     } catch (err) {

--- a/xerus_backend/src/middleware/rate-limit.ts
+++ b/xerus_backend/src/middleware/rate-limit.ts
@@ -28,13 +28,13 @@ export const strictRateLimit = rateLimit({
 export const inviteCodeRateLimit = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5,                     // 5 attempts per window per user
-    keyGenerator: (req: Request) => (req as AuthenticatedRequest).user?.uid ?? req.ip ?? 'anonymous',
+    keyGenerator: (req: Request) => (req as AuthenticatedRequest).user?.uid ?? 'anonymous',
     standardHeaders: true,
     legacyHeaders: false,
     handler: () => {
         throw new RateLimitError();
     },
-    validate: { xForwardedForHeader: false },
+    validate: { xForwardedForHeader: false, keyGeneratorIpFallback: false },
 });
 
 export const uploadRateLimit = rateLimit({

--- a/xerus_web/app/globals.css
+++ b/xerus_web/app/globals.css
@@ -221,6 +221,19 @@
   100% { width: 0%; margin-left: 100%; }
 }
 
+/* Subtle entrance for chat messages on first load — GPU-accelerated (opacity + transform only) */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .animate-\[fadeInUp_0\.4s_ease-out\] {
+    animation: none !important;
+  }
+}
+
 /* Blob animation for backgrounds */
 @keyframes blob {
   0% {

--- a/xerus_web/components/InviteCodeGate.tsx
+++ b/xerus_web/components/InviteCodeGate.tsx
@@ -174,7 +174,7 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
                 maxLength={9}
                 autoFocus
                 disabled={isSubmitting}
-                className={`w-full py-3.5 px-5 font-mono text-xl tracking-[0.25em] text-center uppercase border rounded-xl bg-surface-hover transition-all duration-300 outline-none ${
+                className={`w-full py-4 px-5 font-mono text-3xl font-bold tracking-[0.3em] text-center uppercase border rounded-xl bg-surface-hover transition-all duration-300 outline-none ${
                   error
                     ? 'border-red-400 focus:border-red-400 focus:shadow-[0_4px_20px_rgba(239,68,68,0.1)]'
                     : 'border-surface-active focus:border-[#FF6600]/40 focus:shadow-[0_4px_20px_rgba(255,102,0,0.1)]'

--- a/xerus_web/components/InviteCodeGate.tsx
+++ b/xerus_web/components/InviteCodeGate.tsx
@@ -89,11 +89,8 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
             </>
           ) : (
             <>
-              <h1 className="text-4xl md:text-5xl font-serif font-medium text-text mb-4 tracking-tight">
-                Early access
-              </h1>
               <p className="text-text-secondary text-lg font-sans max-w-sm mx-auto">
-                Xerus is currently invite-only. Enter your code below to get started.
+                Xerus is currently invite-only. Enter your code below to get started, or join the waitlist.
               </p>
             </>
           )}

--- a/xerus_web/components/InviteCodeGate.tsx
+++ b/xerus_web/components/InviteCodeGate.tsx
@@ -7,6 +7,10 @@ import { signOut } from 'firebase/auth'
 import { GradientBackground } from './GradientBackground'
 import type { ApiError } from '@/lib/api/client'
 
+// Hoisted regex — avoid re-creation on every keystroke (js-hoist-regexp)
+const NON_ALPHANUMERIC = /[^A-Za-z0-9]/g
+const HYPHEN = /-/g
+
 interface InviteCodeGateProps {
   email: string
 }
@@ -20,7 +24,7 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
   const [requestSent, setRequestSent] = useState(false)
 
   const handleCodeChange = (value: string) => {
-    const cleaned = value.replace(/[^A-Za-z0-9]/g, '').toUpperCase().slice(0, 8)
+    const cleaned = value.replace(NON_ALPHANUMERIC, '').toUpperCase().slice(0, 8)
     setCode(cleaned)
     setError(null)
   }
@@ -141,7 +145,7 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
                 type="text"
                 value={displayCode}
                 onChange={(e) => {
-                  const raw = e.target.value.replace(/-/g, '')
+                  const raw = e.target.value.replace(HYPHEN, '')
                   handleCodeChange(raw)
                 }}
                 placeholder="XXXX-XXXX"

--- a/xerus_web/components/InviteCodeGate.tsx
+++ b/xerus_web/components/InviteCodeGate.tsx
@@ -15,7 +15,6 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
   const [code, setCode] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
   const [showRequestAccess, setShowRequestAccess] = useState(false)
   const [requestEmail, setRequestEmail] = useState(email)
   const [requestSent, setRequestSent] = useState(false)
@@ -35,10 +34,7 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
 
     try {
       await redeemInviteCode(code)
-      setSuccess(true)
-      setTimeout(() => {
-        window.location.reload()
-      }, 1200)
+      window.location.reload()
     } catch (err) {
       const apiError = err as ApiError
       if (apiError.status === 429) {
@@ -78,36 +74,14 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
             <img src="/logo/logo-svg.svg" alt="Xerus Logo" className="h-10 mt-3" />
           </div>
 
-          {success ? (
-            <>
-              <h1 className="text-4xl md:text-5xl font-serif font-medium text-text mb-4 tracking-tight">
-                You're in!
-              </h1>
-              <p className="text-text-secondary text-lg font-sans">
-                Setting up your workspace...
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-text-secondary text-lg font-sans max-w-sm mx-auto">
-                Xerus is currently invite-only. Enter your code below to get started, or join the waitlist.
-              </p>
-            </>
-          )}
+          <p className="text-text-secondary text-lg font-sans max-w-sm mx-auto">
+            Xerus is currently invite-only. Enter your code below to get started, or join the waitlist.
+          </p>
         </div>
 
         {/* Card */}
         <div className="w-full bg-surface p-8 rounded-[32px] shadow-sm border border-[#FFE4D6]">
-          {success ? (
-            <div className="flex flex-col items-center gap-4 py-4">
-              <div className="w-16 h-16 rounded-full bg-green-50 flex items-center justify-center">
-                <svg className="w-8 h-8 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-              </div>
-              <p className="text-text font-medium text-[15px]">Welcome to Xerus</p>
-            </div>
-          ) : showRequestAccess ? (
+          {showRequestAccess ? (
             // Request access form
             <div>
               <p className="text-text-secondary text-[15px] leading-relaxed mb-6 text-center">
@@ -214,19 +188,17 @@ export function InviteCodeGate({ email }: InviteCodeGateProps) {
         </div>
 
         {/* Footer */}
-        {!success && (
-          <div className="mt-8 text-center">
-            <p className="text-xs text-[#9CA3AF] font-sans">
-              Not you?{' '}
-              <button
-                onClick={handleLogout}
-                className="text-[#FF6600] hover:text-[#E65C00] transition-colors hover:underline"
-              >
-                Sign out
-              </button>
-            </p>
-          </div>
-        )}
+        <div className="mt-8 text-center">
+          <p className="text-xs text-[#9CA3AF] font-sans">
+            Not you?{' '}
+            <button
+              onClick={handleLogout}
+              className="text-[#FF6600] hover:text-[#E65C00] transition-colors hover:underline"
+            >
+              Sign out
+            </button>
+          </p>
+        </div>
       </div>
     </div>
   )

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -185,6 +185,7 @@ export function ChatContainer({
     projects: chat.projects,
     conversationId: state.conversationId,
     selectedChannel: state.selectedChannel,
+    isLoading: chat.isLoadingAgents,
     handleSelectConversation: chat.handleSelectConversation,
     handleNewConversation: chat.handleNewConversation,
     handleDeleteConversation: chat.handleDeleteConversation,
@@ -195,6 +196,7 @@ export function ChatContainer({
     projects: chat.projects,
     conversationId: state.conversationId,
     selectedChannel: state.selectedChannel,
+    isLoading: chat.isLoadingAgents,
     handleSelectConversation: chat.handleSelectConversation,
     handleNewConversation: chat.handleNewConversation,
     handleDeleteConversation: chat.handleDeleteConversation,
@@ -220,6 +222,7 @@ export function ChatContainer({
         onNewConversation={p.handleNewConversation}
         onDeleteConversation={p.handleDeleteConversation}
         isCollapsed={false}
+        isLoading={p.isLoading}
         selectedChannel={p.selectedChannel}
         onSelectChannel={p.handleSelectChannel}
         onClearChannel={p.handleClearChannel}
@@ -230,7 +233,7 @@ export function ChatContainer({
   // When sidebar-relevant data changes, poke the sidebar to re-render
   useEffect(() => {
     sidebarForceUpdateRef.current()
-  }, [chat.projects, state.conversationId, state.selectedChannel])
+  }, [chat.projects, state.conversationId, state.selectedChannel, chat.isLoadingAgents])
 
   useSidebarSlotRegister('chat-sidebar', ChatSidebarSlot)
 

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { MessageList } from './MessageList'
 import { ChatInput } from './ChatInput'
@@ -177,6 +177,10 @@ export function ChatContainer({
   }, [])
 
   // ---- Sidebar slot ----
+  // The slot system renders a stable component ref inside AppSidebar.
+  // To avoid infinite re-render loops, the slot component is stable (useCallback []).
+  // Data is passed via ref + a forceUpdate callback so the sidebar re-renders
+  // when conversations load WITHOUT triggering context cascades.
   const sidebarPropsRef = useRef({
     projects: chat.projects,
     conversationId: state.conversationId,
@@ -198,7 +202,15 @@ export function ChatContainer({
     handleClearChannel: chat.handleClearChannel,
   }
 
+  // Holds the forceUpdate function from the wrapper rendered inside AppSidebar
+  const sidebarForceUpdateRef = useRef<() => void>(() => {})
+
   const ChatSidebarSlot = useCallback(() => {
+    // This hook runs inside the AppSidebar render tree, not ChatContainer.
+    // The reducer gives us a stable forceUpdate that re-renders just this subtree.
+    const [, forceUpdate] = useState(0)
+    sidebarForceUpdateRef.current = () => forceUpdate(v => v + 1)
+
     const p = sidebarPropsRef.current
     return (
       <ConversationSidebar
@@ -214,6 +226,11 @@ export function ChatContainer({
       />
     )
   }, [])
+
+  // When sidebar-relevant data changes, poke the sidebar to re-render
+  useEffect(() => {
+    sidebarForceUpdateRef.current()
+  }, [chat.projects, state.conversationId, state.selectedChannel])
 
   useSidebarSlotRegister('chat-sidebar', ChatSidebarSlot)
 

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -44,6 +44,39 @@ function extToViewerType(ext: string): ViewerContentType {
   return EXT_TO_VIEWER[ext] ?? 'text'
 }
 
+// Top-level component rendered inside AppSidebar via the slot system.
+// Reads from a ref (latest data) and uses useState for forceUpdate.
+// Defined at module scope so React treats it as a proper component (hooks are legal).
+interface SidebarPropsRef {
+  projects: import('./types').ProjectGroup[]
+  conversationId: string | null
+  selectedChannel?: import('./types').SelectedChannel | null
+  isLoading: boolean
+  handleSelectConversation: (id: string) => void
+  handleNewConversation: () => void
+  handleDeleteConversation: (id: string) => void
+  handleSelectChannel: (ch: import('./types').SelectedChannel) => void
+  handleClearChannel: () => void
+}
+
+function ChatSidebarSlotComponent({ propsRef }: { propsRef: React.RefObject<SidebarPropsRef> }) {
+  const p = propsRef.current!
+  return (
+    <ConversationSidebar
+      projects={p.projects}
+      currentConversationId={p.conversationId}
+      onSelectConversation={p.handleSelectConversation}
+      onNewConversation={p.handleNewConversation}
+      onDeleteConversation={p.handleDeleteConversation}
+      isCollapsed={false}
+      isLoading={p.isLoading}
+      selectedChannel={p.selectedChannel}
+      onSelectChannel={p.handleSelectChannel}
+      onClearChannel={p.handleClearChannel}
+    />
+  )
+}
+
 interface ChatContainerProps {
   initialAgentId?: string
   conversationId?: string
@@ -204,36 +237,11 @@ export function ChatContainer({
     handleClearChannel: chat.handleClearChannel,
   }
 
-  // Holds the forceUpdate function from the wrapper rendered inside AppSidebar
-  const sidebarForceUpdateRef = useRef<() => void>(() => {})
-
-  const ChatSidebarSlot = useCallback(() => {
-    // This hook runs inside the AppSidebar render tree, not ChatContainer.
-    // The reducer gives us a stable forceUpdate that re-renders just this subtree.
-    const [, forceUpdate] = useState(0)
-    sidebarForceUpdateRef.current = () => forceUpdate(v => v + 1)
-
-    const p = sidebarPropsRef.current
-    return (
-      <ConversationSidebar
-        projects={p.projects}
-        currentConversationId={p.conversationId}
-        onSelectConversation={p.handleSelectConversation}
-        onNewConversation={p.handleNewConversation}
-        onDeleteConversation={p.handleDeleteConversation}
-        isCollapsed={false}
-        isLoading={p.isLoading}
-        selectedChannel={p.selectedChannel}
-        onSelectChannel={p.handleSelectChannel}
-        onClearChannel={p.handleClearChannel}
-      />
-    )
-  }, [])
-
-  // When sidebar-relevant data changes, poke the sidebar to re-render
-  useEffect(() => {
-    sidebarForceUpdateRef.current()
-  }, [chat.projects, state.conversationId, state.selectedChannel, chat.isLoadingAgents])
+  // Slot component: reads from ref on every render.
+  // Stable reference via useRef — no context cascades.
+  const ChatSidebarSlot = useRef(() => (
+    <ChatSidebarSlotComponent propsRef={sidebarPropsRef} />
+  )).current
 
   useSidebarSlotRegister('chat-sidebar', ChatSidebarSlot)
 

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -59,7 +59,12 @@ interface SidebarPropsRef {
   handleClearChannel: () => void
 }
 
-function ChatSidebarSlotComponent({ propsRef }: { propsRef: React.RefObject<SidebarPropsRef> }) {
+function ChatSidebarSlotComponent({ propsRef, forceUpdateRef }: {
+  propsRef: React.RefObject<SidebarPropsRef>
+  forceUpdateRef: React.MutableRefObject<() => void>
+}) {
+  const [, setTick] = useState(0)
+  forceUpdateRef.current = () => setTick(t => t + 1)
   const p = propsRef.current!
   return (
     <ConversationSidebar
@@ -237,11 +242,19 @@ export function ChatContainer({
     handleClearChannel: chat.handleClearChannel,
   }
 
-  // Slot component: reads from ref on every render.
-  // Stable reference via useRef — no context cascades.
+  // forceUpdate ref: ChatSidebarSlotComponent stores its updater here on mount.
+  // ChatContainer calls it when sidebar-relevant data changes.
+  const sidebarForceUpdateRef = useRef<() => void>(() => {})
+
+  // Stable slot component — registered once, re-renders via forceUpdate ref
   const ChatSidebarSlot = useRef(() => (
-    <ChatSidebarSlotComponent propsRef={sidebarPropsRef} />
+    <ChatSidebarSlotComponent propsRef={sidebarPropsRef} forceUpdateRef={sidebarForceUpdateRef} />
   )).current
+
+  // Poke sidebar to re-render when data changes (ref was updated above)
+  useEffect(() => {
+    sidebarForceUpdateRef.current()
+  }, [chat.projects, state.conversationId, state.selectedChannel, chat.isLoadingAgents])
 
   useSidebarSlotRegister('chat-sidebar', ChatSidebarSlot)
 

--- a/xerus_web/components/chat/ConversationSidebar.tsx
+++ b/xerus_web/components/chat/ConversationSidebar.tsx
@@ -26,6 +26,7 @@ interface ConversationSidebarProps {
   onNewConversation: () => void
   onDeleteConversation?: (id: string) => void
   isCollapsed?: boolean
+  isLoading?: boolean
   onToggleCollapse?: () => void
   className?: string
   selectedChannel?: SelectedChannel | null
@@ -337,6 +338,7 @@ export function ConversationSidebar({
   onNewConversation,
   onDeleteConversation,
   isCollapsed = false,
+  isLoading = false,
   onToggleCollapse,
   className,
   selectedChannel,
@@ -453,11 +455,19 @@ export function ConversationSidebar({
       <ScrollArea className="flex-1 px-2 pt-1">
         {filteredProjects.length === 0 ? (
           <div className="px-3 py-8 text-center">
-            <p className="text-sm text-text-muted">
-              {searchQuery ? 'No matching sessions' : 'No conversations yet'}
-            </p>
-            {!searchQuery && (
-              <p className="text-xs text-text-muted mt-1">Send a message to get started</p>
+            {isLoading ? (
+              <div className="space-y-3 px-2 animate-pulse">
+                <div className="h-3 bg-surface-active/40 rounded-full w-24" />
+                <div className="h-8 bg-surface-active/30 rounded-lg" />
+                <div className="h-8 bg-surface-active/20 rounded-lg" />
+              </div>
+            ) : searchQuery ? (
+              <p className="text-sm text-text-muted">No matching sessions</p>
+            ) : (
+              <>
+                <p className="text-sm text-text-muted">No conversations yet</p>
+                <p className="text-xs text-text-muted mt-1">Send a message to get started</p>
+              </>
             )}
           </div>
         ) : (

--- a/xerus_web/components/chat/MessageList.tsx
+++ b/xerus_web/components/chat/MessageList.tsx
@@ -95,7 +95,7 @@ export function MessageList({
 
   return (
     <div className={cn('flex-1 overflow-y-auto scrollbar-thin', className)}>
-      <div className="max-w-3xl mx-auto pb-4">
+      <div className="max-w-3xl mx-auto pb-4 animate-[fadeInUp_0.4s_ease-out]">
         {/* Messages */}
         <div className="divide-y divide-surface-active/50">
           {allMessages.map((message) => (

--- a/xerus_web/components/chat/useChatState.ts
+++ b/xerus_web/components/chat/useChatState.ts
@@ -238,7 +238,10 @@ export function useChatState({ initialAgentId, conversationId, initialMessage }:
     }
 
     loadAll()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      hasLoadedRef.current = false // Reset so Strict Mode remount can re-load
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runs once when auth is ready, refs handle changing deps
   }, [isAuthReady])
 

--- a/xerus_web/components/chat/useChatState.ts
+++ b/xerus_web/components/chat/useChatState.ts
@@ -218,7 +218,9 @@ export function useChatState({ initialAgentId, conversationId, initialMessage }:
       if (convResult.status === 'fulfilled') {
         const convs: Conversation[] = convResult.value.conversations.map(mapConversation)
         setState((prev) => ({ ...prev, conversations: convs }))
-        if (conversationId) loadConversationDetailsRef.current(conversationId)
+        // Auto-select: if no conversation was specified, load the most recent one
+        const targetConvId = conversationId || convs[0]?.id
+        if (targetConvId) loadConversationDetailsRef.current(targetConvId)
       } else {
         console.error('Failed to load conversations:', convResult.reason)
       }

--- a/xerus_web/components/layout/AppLayout.tsx
+++ b/xerus_web/components/layout/AppLayout.tsx
@@ -21,18 +21,29 @@ const LoginOverlay = dynamic(
   { ssr: false }
 )
 
-// Loading screen shown during auth check and initial hydration
-function LoadingScreen() {
+// Contextual loading screen — shows appropriate message per gate
+function LoadingScreen({ title, subtitle }: { title?: string; subtitle?: string }) {
   return (
     <div className="flex h-screen items-center justify-center bg-surface-alt">
-      <div className="flex flex-col items-center gap-6">
-        <img src="/logo/xerus.svg" alt="Xerus" className="w-14 h-14 animate-pulse" />
-        <div className="flex flex-col items-center gap-2">
-          <p className="text-sm font-medium text-text">Getting your workspace ready</p>
-          <div className="w-48 h-1 bg-surface-active rounded-full overflow-hidden">
-            <div className="h-full bg-[#FF6600] rounded-full animate-[loading_1.5s_ease-in-out_infinite]" />
+      <div className="flex flex-col items-center gap-8 animate-tab-in">
+        <img src="/logo/xerus.svg" alt="Xerus" className="w-20 h-20 animate-pulse" />
+
+        {title ? (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-lg font-semibold text-text">{title}</p>
+            {subtitle && (
+              <p className="text-sm text-text-secondary">{subtitle}</p>
+            )}
+            <div className="w-56 h-1.5 bg-surface-active rounded-full overflow-hidden mt-1">
+              <div className="h-full bg-[#FF6600] rounded-full animate-[loading_1.5s_ease-in-out_infinite]" />
+            </div>
           </div>
-        </div>
+        ) : (
+          /* Minimal: no text — used during hydration & login auth check */
+          <div className="w-40 h-1 bg-surface-active rounded-full overflow-hidden">
+            <div className="h-full bg-[#FF6600]/70 rounded-full animate-[loading_1.5s_ease-in-out_infinite]" />
+          </div>
+        )}
       </div>
     </div>
   )
@@ -74,12 +85,14 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
 
   // Show loading screen while auth state is resolving
   if (!isAuthReady) {
-    return <LoadingScreen />
+    return isLoginPage
+      ? <LoadingScreen />
+      : <LoadingScreen title="Loading your workspace" subtitle="Verifying your session..." />
   }
 
   // Not authenticated — show loading while redirect to /login fires
   if (!user && !isLoginPage) {
-    return <LoadingScreen />
+    return <LoadingScreen title="Session expired" subtitle="Redirecting to sign in..." />
   }
 
   // User authenticated but needs invite code (checked BEFORE workspace redirect)
@@ -89,7 +102,18 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
 
   // Not onboarded — show loading while redirect to /onboarding fires
   if (user && !hasWorkspace && !isOnboardingPage && !isLoginPage) {
-    return <LoadingScreen />
+    return <LoadingScreen title="Setting up your workspace" subtitle="Preparing your AI workforce..." />
+  }
+
+  // Onboarding page: no sidebar, full-screen onboarding chat
+  if (isOnboardingPage && user) {
+    return (
+      <div className="flex h-screen overflow-hidden bg-surface-alt">
+        <main className="flex-1 relative h-screen overflow-y-auto">
+          {children}
+        </main>
+      </div>
+    )
   }
 
   // Login page: no sidebar, overlay

--- a/xerus_web/components/onboarding/OnboardingChat.tsx
+++ b/xerus_web/components/onboarding/OnboardingChat.tsx
@@ -98,11 +98,10 @@ export function OnboardingChat() {
     if (saved === 'template') return saved as Phase
     return 'logo'
   })
-  const setPhaseRef = useRef((p: Phase) => {
+  const setPhase = useCallback((p: Phase) => {
     setPhaseRaw(p)
     sessionStorage.setItem('xerus_onboarding_phase', p)
-  })
-  const setPhase = setPhaseRef.current
+  }, [])
   const [messages, setMessages] = useState<OnboardingMessage[]>([])
   const [templateIndex, setTemplateIndex] = useState(0)
   const [templateTypingDone, setTemplateTypingDone] = useState(-1)
@@ -119,7 +118,7 @@ export function OnboardingChat() {
     if (phase !== 'logo') return
     const timer = setTimeout(() => setPhase('template'), 2500)
     return () => clearTimeout(timer)
-  }, [phase])
+  }, [phase, setPhase])
 
   // Sequential template messages
   useEffect(() => {
@@ -225,7 +224,7 @@ export function OnboardingChat() {
     }
 
     collapseCard(messageId, '')
-  }, [collapseCard, createWorkspace])
+  }, [collapseCard, createWorkspace, setPhase])
 
   const handleSetupComplete = useCallback(() => {
     stream.completeOnboarding()

--- a/xerus_web/components/onboarding/OnboardingChat.tsx
+++ b/xerus_web/components/onboarding/OnboardingChat.tsx
@@ -187,7 +187,7 @@ export function OnboardingChat() {
         id: `workspace-card`,
         role: 'assistant' as const,
         content: 'Great choice! Let\u2019s name your workspace and first project.',
-        source: 'template' as const,
+        source: 'stream' as const,
         ui: {
           type: 'workspace-setup',
           props: {},

--- a/xerus_web/components/onboarding/OnboardingChat.tsx
+++ b/xerus_web/components/onboarding/OnboardingChat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo, useRef, FormEvent } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAuth } from '@/utils/AuthContext'
@@ -11,7 +11,7 @@ import { OnboardingMessages } from './OnboardingMessages'
 import { OnboardingSteps } from './OnboardingSteps'
 import type { OnboardingMessage, OnboardingTemplateMessage } from './types'
 
-type Phase = 'logo' | 'template' | 'workspace-form' | 'setup'
+type Phase = 'logo' | 'template' | 'setup'
 
 // Preset agents shown during the onboarding setup wizard step
 const SETUP_AGENTS = [
@@ -107,12 +107,7 @@ export function OnboardingChat() {
   const [templateIndex, setTemplateIndex] = useState(0)
   const [templateTypingDone, setTemplateTypingDone] = useState(-1)
   const [quickReplies, setQuickReplies] = useState<typeof INITIAL_QUICK_REPLIES>([])
-  const [logoReady, setLogoReady] = useState(false)
   const [workspaceData, setWorkspaceData] = useState<{ workspace: string; project: string } | null>(null)
-  const [workspaceName, setWorkspaceName] = useState('')
-  const [projectName, setProjectName] = useState('')
-  const [isProvisioning, setIsProvisioning] = useState(false)
-  const [provisionError, setProvisionError] = useState<string | null>(null)
   const hasNavigatedRef = useRef(false)
   const quickReplyTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
@@ -173,10 +168,11 @@ export function OnboardingChat() {
 
   useEffect(() => () => clearTimeout(quickReplyTimerRef.current), [])
 
-  // User clicks "Start fresh" / "Bring my company" → show workspace form
+  // User clicks "Start fresh" / "Bring my company" → add workspace setup card to chat
   const handleQuickReply = useCallback((value: string) => {
     const reply = INITIAL_QUICK_REPLIES.find((r) => r.value === value)
     const label = reply?.label || value
+    // Add user's choice as a message
     setMessages((prev) => [...prev, {
       id: `user-${Date.now()}`,
       role: 'user' as const,
@@ -184,33 +180,52 @@ export function OnboardingChat() {
       source: 'template' as const,
     }])
     setQuickReplies([])
-    setPhase('workspace-form')
+
+    // Add Xerus response with the workspace setup card — same chat UI
+    setTimeout(() => {
+      setMessages((prev) => [...prev, {
+        id: `workspace-card`,
+        role: 'assistant' as const,
+        content: 'Great choice! Let\u2019s name your workspace and first project.',
+        source: 'template' as const,
+        ui: {
+          type: 'workspace-setup',
+          props: {},
+        },
+      }])
+    }, 600)
   }, [])
 
-  // Submit workspace form → immediately show Screen 2 → handoff in background
-  const handleWorkspaceSubmit = useCallback(async (e: FormEvent) => {
-    e.preventDefault()
-    const ws = workspaceName.trim() || 'My Workspace'
-    const proj = projectName.trim() || 'Default'
+  const collapseCard = useCallback((messageId: string, collapsedText: string) => {
+    setMessages((prev) =>
+      prev.map((m) => {
+        if (m.id !== messageId || !m.ui) return m
+        return { ...m, ui: { ...m.ui, collapsed: true, collapsedText } }
+      })
+    )
+  }, [])
 
-    setWorkspaceData({ workspace: ws, project: proj })
-    setIsProvisioning(true)
-    setProvisionError(null)
-    setPhase('setup')
+  // Handle workspace card submit → collapse card, show Screen 2, handoff in background
+  const { createWorkspace } = stream
+  const handleUIAction = useCallback(async (messageId: string, action: string, data: Record<string, unknown>) => {
+    if (action === 'create-workspace') {
+      const workspace = String(data.workspace ?? '')
+      const project = String(data.project ?? '')
+      setWorkspaceData({ workspace, project })
+      collapseCard(messageId, `${workspace} \u2014 ${project}`)
+      setPhase('setup')
 
-    // Background: create workspace + domain + channel + sandbox + seed conversation
-    try {
-      const result = await stream.createWorkspace(ws, proj)
-      if (!result) {
-        setProvisionError('Failed to create workspace')
+      // Background: POST /onboarding/handoff (creates workspace + domain + channel + sandbox)
+      try {
+        await createWorkspace(workspace, project)
+      } catch (err) {
+        console.error('[Onboarding] Workspace creation failed:', err)
       }
-    } catch (err) {
-      console.error('[Onboarding] Workspace creation failed:', err)
-      setProvisionError('Something went wrong. Please try again.')
-    } finally {
-      setIsProvisioning(false)
+      return
     }
-  }, [workspaceName, projectName, stream])
+
+    collapseCard(messageId, '')
+  }, [collapseCard, createWorkspace])
 
   const handleSetupComplete = useCallback(() => {
     stream.completeOnboarding()
@@ -232,7 +247,7 @@ export function OnboardingChat() {
       <BlobBackground />
 
       <AnimatePresence mode="wait">
-        {/* ── Chat phases (logo + template messages) ── */}
+        {/* ── Chat phases (logo + template messages + workspace card) ── */}
         {showChat && (
           <motion.div
             key="chat"
@@ -261,73 +276,14 @@ export function OnboardingChat() {
               >
                 <OnboardingMessages
                   messages={messages}
-                  onLogoReady={() => setLogoReady(true)}
+                  onLogoReady={() => {}}
                   onTypingComplete={handleTypingComplete}
-                  onUIAction={() => {}}
+                  onUIAction={handleUIAction}
                   quickReplies={quickReplies.length > 0 ? quickReplies : undefined}
                   onQuickReply={handleQuickReply}
                 />
               </motion.div>
             )}
-          </motion.div>
-        )}
-
-        {/* ── Workspace name form ── */}
-        {phase === 'workspace-form' && (
-          <motion.div
-            key="workspace-form"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.4 }}
-            className="flex-1 flex items-center justify-center px-6"
-          >
-            <div className="w-full max-w-md">
-              <div className="text-center mb-8">
-                <h2 className="font-serif text-3xl sm:text-4xl text-text">
-                  Name your office
-                </h2>
-                <p className="text-base text-text-secondary mt-2">
-                  You can always change this later.
-                </p>
-              </div>
-
-              <form onSubmit={handleWorkspaceSubmit} className="space-y-4">
-                <div>
-                  <label className="block text-[13px] font-medium text-text-secondary mb-2">
-                    Workspace name
-                  </label>
-                  <input
-                    type="text"
-                    value={workspaceName}
-                    onChange={(e) => setWorkspaceName(e.target.value)}
-                    placeholder="My Company"
-                    autoFocus
-                    className="w-full py-3.5 px-4 text-[15px] border border-surface-active rounded-xl bg-surface transition-all duration-200 outline-none focus:border-[#FF6600]/40 focus:shadow-[0_4px_20px_rgba(255,102,0,0.1)]"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-[13px] font-medium text-text-secondary mb-2">
-                    First project
-                  </label>
-                  <input
-                    type="text"
-                    value={projectName}
-                    onChange={(e) => setProjectName(e.target.value)}
-                    placeholder="Marketing"
-                    className="w-full py-3.5 px-4 text-[15px] border border-surface-active rounded-xl bg-surface transition-all duration-200 outline-none focus:border-[#FF6600]/40 focus:shadow-[0_4px_20px_rgba(255,102,0,0.1)]"
-                  />
-                </div>
-
-                <button
-                  type="submit"
-                  className="w-full flex items-center justify-center gap-2 py-3.5 px-6 mt-2 bg-[#18181B] text-white rounded-xl font-medium text-[15px] hover:bg-[#27272A] transition-all duration-200 transform hover:-translate-y-0.5"
-                >
-                  Set up my office
-                </button>
-              </form>
-            </div>
           </motion.div>
         )}
 

--- a/xerus_web/components/onboarding/OnboardingChat.tsx
+++ b/xerus_web/components/onboarding/OnboardingChat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAuth } from '@/utils/AuthContext'
@@ -11,7 +11,7 @@ import { OnboardingMessages } from './OnboardingMessages'
 import { OnboardingSteps } from './OnboardingSteps'
 import type { OnboardingMessage, OnboardingTemplateMessage } from './types'
 
-type Phase = 'logo' | 'template' | 'live' | 'setup'
+type Phase = 'logo' | 'template' | 'workspace-form' | 'setup'
 
 // Preset agents shown during the onboarding setup wizard step
 const SETUP_AGENTS = [
@@ -92,15 +92,12 @@ export function OnboardingChat() {
   const firstName = user?.display_name?.split(' ')[0] || 'there'
   const userId = user?.uid || ''
 
-  // Restore phase from sessionStorage on refresh (skip logo/template if already past them)
   const [phase, setPhaseRaw] = useState<Phase>(() => {
     if (typeof window === 'undefined') return 'logo'
     const saved = sessionStorage.getItem('xerus_onboarding_phase')
-    // Only restore 'template' or 'live' — 'setup' requires workspaceData which is lost
-    if (saved === 'template' || saved === 'live') return saved as Phase
+    if (saved === 'template') return saved as Phase
     return 'logo'
   })
-  // Wrapper that persists phase to sessionStorage (stable identity via ref)
   const setPhaseRef = useRef((p: Phase) => {
     setPhaseRaw(p)
     sessionStorage.setItem('xerus_onboarding_phase', p)
@@ -112,18 +109,15 @@ export function OnboardingChat() {
   const [quickReplies, setQuickReplies] = useState<typeof INITIAL_QUICK_REPLIES>([])
   const [logoReady, setLogoReady] = useState(false)
   const [workspaceData, setWorkspaceData] = useState<{ workspace: string; project: string } | null>(null)
+  const [workspaceName, setWorkspaceName] = useState('')
+  const [projectName, setProjectName] = useState('')
+  const [isProvisioning, setIsProvisioning] = useState(false)
+  const [provisionError, setProvisionError] = useState<string | null>(null)
   const hasNavigatedRef = useRef(false)
   const quickReplyTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
   const stream = useOnboardingStream({ userId, onWorkspaceCreated: markWorkspaceReady })
   const templateMessages = useMemo(() => buildTemplateMessages(firstName), [firstName])
-
-  // Provision sandbox in background on mount
-  // startProvisioning has stable identity (useCallback with [] deps)
-  const { startProvisioning } = stream
-  useEffect(() => {
-    if (userId) startProvisioning().catch(() => { /* non-critical: /onboarding/start is a readiness check */ })
-  }, [userId, startProvisioning])
 
   // Logo phase: hold for 2.5s then transition to template
   useEffect(() => {
@@ -177,86 +171,52 @@ export function OnboardingChat() {
     }
   }, [templateMessages.length])
 
-  // Clean up quick reply timer on unmount
   useEffect(() => () => clearTimeout(quickReplyTimerRef.current), [])
 
-  // Merge streamed messages from the hook
-  useEffect(() => {
-    if (stream.streamedMessages.length === 0) return
-    setMessages((prev) => {
-      const nonStreamed = prev.filter((m) => m.source !== 'stream')
-      return [...nonStreamed, ...stream.streamedMessages]
-    })
-  }, [stream.streamedMessages])
-
-  const messagesRef = useRef(messages)
-  messagesRef.current = messages
-
+  // User clicks "Start fresh" / "Bring my company" → show workspace form
   const handleQuickReply = useCallback((value: string) => {
     const reply = INITIAL_QUICK_REPLIES.find((r) => r.value === value)
     const label = reply?.label || value
-    const userMsg: OnboardingMessage = {
+    setMessages((prev) => [...prev, {
       id: `user-${Date.now()}`,
-      role: 'user',
+      role: 'user' as const,
       content: label,
-      source: 'template',
-    }
-    setMessages((prev) => [...prev, userMsg])
+      source: 'template' as const,
+    }])
     setQuickReplies([])
-    setPhase('live')
-    stream.handoff(value, [...messagesRef.current, userMsg])
-  }, [stream])
-
-  const handleSend = useCallback((content: string) => {
-    const userMsg: OnboardingMessage = {
-      id: `user-${Date.now()}`,
-      role: 'user',
-      content,
-      source: phase === 'live' ? 'stream' : 'template',
-    }
-    setMessages((prev) => [...prev, userMsg])
-    if (phase === 'live') stream.sendMessage(content)
-  }, [phase, stream])
-
-  const collapseCard = useCallback((messageId: string, collapsedText: string) => {
-    setMessages((prev) =>
-      prev.map((m) => {
-        if (m.id !== messageId || !m.ui) return m
-        return { ...m, ui: { ...m.ui, collapsed: true, collapsedText } }
-      })
-    )
+    setPhase('workspace-form')
   }, [])
 
-  const handleUIAction = useCallback(async (messageId: string, action: string, data: Record<string, unknown>) => {
-    // Workspace creation → await backend, collapse card only on success
-    if (action === 'create-workspace') {
-      const workspace = String(data.workspace ?? '')
-      const project = String(data.project ?? '')
-      setWorkspaceData({ workspace, project })
-      const result = await stream.createWorkspace(workspace, project)
-      if (!result) return // createWorkspace throws on error, toast shown by error handler
-      collapseCard(messageId, `${workspace} created with ${project} project`)
-      setPhase('setup')
-      return
-    }
+  // Submit workspace form → immediately show Screen 2 → handoff in background
+  const handleWorkspaceSubmit = useCallback(async (e: FormEvent) => {
+    e.preventDefault()
+    const ws = workspaceName.trim() || 'My Workspace'
+    const proj = projectName.trim() || 'Default'
 
-    // Other UI actions — collapse immediately
-    collapseCard(messageId, '')
+    setWorkspaceData({ workspace: ws, project: proj })
+    setIsProvisioning(true)
+    setProvisionError(null)
+    setPhase('setup')
 
-    // Forward to stream
-    if (phase === 'live') {
-      stream.sendMessage(`[action:${action}] ${JSON.stringify(data)}`)
+    // Background: create workspace + domain + channel + sandbox + seed conversation
+    try {
+      const result = await stream.createWorkspace(ws, proj)
+      if (!result) {
+        setProvisionError('Failed to create workspace')
+      }
+    } catch (err) {
+      console.error('[Onboarding] Workspace creation failed:', err)
+      setProvisionError('Something went wrong. Please try again.')
+    } finally {
+      setIsProvisioning(false)
     }
-  }, [phase, stream, collapseCard])
+  }, [workspaceName, projectName, stream])
 
   const handleSetupComplete = useCallback(() => {
     stream.completeOnboarding()
-    // Navigation is deferred to useEffect below — React must flush
-    // setHasWorkspace(true) before LayoutShell renders on '/'
   }, [stream])
 
-  // Navigate after onboarding completes and hasWorkspace is flushed
-  // Guard with ref to prevent double-fire in React Strict Mode
+  // Navigate after onboarding completes
   useEffect(() => {
     if (stream.mode === 'complete' && !hasNavigatedRef.current) {
       hasNavigatedRef.current = true
@@ -265,14 +225,14 @@ export function OnboardingChat() {
     }
   }, [stream.mode, router])
 
-  const showChat = phase === 'logo' || phase === 'template' || phase === 'live'
+  const showChat = phase === 'logo' || phase === 'template'
 
   return (
     <div className="fixed inset-0 flex flex-col bg-surface-alt">
       <BlobBackground />
 
       <AnimatePresence mode="wait">
-        {/* ── Chat phases ── */}
+        {/* ── Chat phases (logo + template messages) ── */}
         {showChat && (
           <motion.div
             key="chat"
@@ -280,7 +240,6 @@ export function OnboardingChat() {
             transition={{ duration: 0.4 }}
             className="flex-1 flex flex-col min-h-0"
           >
-            {/* Logo splash */}
             <AnimatePresence>
               {phase === 'logo' && (
                 <motion.div
@@ -293,8 +252,7 @@ export function OnboardingChat() {
               )}
             </AnimatePresence>
 
-            {/* Messages */}
-            {phase !== 'logo' && (
+            {phase === 'template' && (
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
@@ -305,31 +263,75 @@ export function OnboardingChat() {
                   messages={messages}
                   onLogoReady={() => setLogoReady(true)}
                   onTypingComplete={handleTypingComplete}
-                  onUIAction={handleUIAction}
+                  onUIAction={() => {}}
                   quickReplies={quickReplies.length > 0 ? quickReplies : undefined}
                   onQuickReply={handleQuickReply}
                 />
-
-                {/* SSE error with retry — like ChatGPT/Claude pattern */}
-                {stream.error ? (
-                  <div className="flex items-center justify-center gap-3 py-4 px-6">
-                    <p className="text-sm text-text-muted">{stream.error}</p>
-                    <button
-                      onClick={stream.retryHandoff}
-                      className="text-sm font-medium text-[#FF6600] hover:text-[#E65C00] transition-colors"
-                    >
-                      Try again
-                    </button>
-                  </div>
-                ) : null}
               </motion.div>
             )}
-
-            {/* Input bar removed — onboarding uses generative UI only */}
           </motion.div>
         )}
 
-        {/* ── Setup wizard ── */}
+        {/* ── Workspace name form ── */}
+        {phase === 'workspace-form' && (
+          <motion.div
+            key="workspace-form"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+            className="flex-1 flex items-center justify-center px-6"
+          >
+            <div className="w-full max-w-md">
+              <div className="text-center mb-8">
+                <h2 className="font-serif text-3xl sm:text-4xl text-text">
+                  Name your office
+                </h2>
+                <p className="text-base text-text-secondary mt-2">
+                  You can always change this later.
+                </p>
+              </div>
+
+              <form onSubmit={handleWorkspaceSubmit} className="space-y-4">
+                <div>
+                  <label className="block text-[13px] font-medium text-text-secondary mb-2">
+                    Workspace name
+                  </label>
+                  <input
+                    type="text"
+                    value={workspaceName}
+                    onChange={(e) => setWorkspaceName(e.target.value)}
+                    placeholder="My Company"
+                    autoFocus
+                    className="w-full py-3.5 px-4 text-[15px] border border-surface-active rounded-xl bg-surface transition-all duration-200 outline-none focus:border-[#FF6600]/40 focus:shadow-[0_4px_20px_rgba(255,102,0,0.1)]"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[13px] font-medium text-text-secondary mb-2">
+                    First project
+                  </label>
+                  <input
+                    type="text"
+                    value={projectName}
+                    onChange={(e) => setProjectName(e.target.value)}
+                    placeholder="Marketing"
+                    className="w-full py-3.5 px-4 text-[15px] border border-surface-active rounded-xl bg-surface transition-all duration-200 outline-none focus:border-[#FF6600]/40 focus:shadow-[0_4px_20px_rgba(255,102,0,0.1)]"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  className="w-full flex items-center justify-center gap-2 py-3.5 px-6 mt-2 bg-[#18181B] text-white rounded-xl font-medium text-[15px] hover:bg-[#27272A] transition-all duration-200 transform hover:-translate-y-0.5"
+                >
+                  Set up my office
+                </button>
+              </form>
+            </div>
+          </motion.div>
+        )}
+
+        {/* ── Setup wizard (Screen 2 — visual progress + provisioning in background) ── */}
         {phase === 'setup' && workspaceData && (
           <motion.div
             key="setup"
@@ -349,4 +351,3 @@ export function OnboardingChat() {
     </div>
   )
 }
-

--- a/xerus_web/hooks/useOnboardingStream.ts
+++ b/xerus_web/hooks/useOnboardingStream.ts
@@ -45,7 +45,6 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
   const eventSourceRef = useRef<EventSource | null>(null)
   const lastHandoffRef = useRef<{ choice: string; history: OnboardingMessage[] } | null>(null)
   const sseTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
-  const provisioningPromiseRef = useRef<Promise<void>>(Promise.resolve())
 
   // Clean up EventSource, abort pending requests, and clear timers on unmount
   useEffect(() => {
@@ -57,26 +56,22 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
   }, [])
 
   const startProvisioning = useCallback(async () => {
-    const promise = (async () => {
-      try {
-        const baseUrl = await getApiBaseUrl()
-        const headers = await getApiHeaders()
-        const res = await fetch(`${baseUrl}/onboarding/start`, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({}),
-        })
-        if (res.ok) {
-          setSandboxReady(true)
-          setMode('ready')
-        }
-      } catch (err) {
-        console.error('[useOnboardingStream] startProvisioning failed:', err)
-        throw err
+    try {
+      const baseUrl = await getApiBaseUrl()
+      const headers = await getApiHeaders()
+      const res = await fetch(`${baseUrl}/onboarding/start`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({}),
+      })
+      if (res.ok) {
+        setSandboxReady(true)
+        setMode('ready')
       }
-    })()
-    provisioningPromiseRef.current = promise
-    return promise
+    } catch (err) {
+      console.error('[useOnboardingStream] startProvisioning failed:', err)
+      throw err
+    }
   }, [])
 
   const createWorkspace = useCallback(async (workspace: string, project: string): Promise<OnboardingHandoffResult | null> => {
@@ -113,13 +108,6 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
     abortRef.current = new AbortController()
 
     try {
-      // Wait for sandbox provisioning if it hasn't completed yet.
-      // startProvisioning runs on mount — by the time user clicks a quick reply
-      // (after logo + 3 template messages), it should be done. If not, we wait.
-      if (!sandboxReady) {
-        await provisioningPromiseRef.current
-      }
-
       // 1. Create conversation + fetch SSE token in parallel (independent operations)
       const [conversation, token] = await Promise.all([
         createConversationApi('xerus-master', 'Onboarding'),
@@ -200,7 +188,7 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
       setError('Something went wrong. Please try again.')
       setMode('ready')
     }
-  }, [sandboxReady])
+  }, [])
 
   const retryHandoff = useCallback(() => {
     if (!lastHandoffRef.current) return

--- a/xerus_web/hooks/useOnboardingStream.ts
+++ b/xerus_web/hooks/useOnboardingStream.ts
@@ -45,6 +45,7 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
   const eventSourceRef = useRef<EventSource | null>(null)
   const lastHandoffRef = useRef<{ choice: string; history: OnboardingMessage[] } | null>(null)
   const sseTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+  const provisioningPromiseRef = useRef<Promise<void>>(Promise.resolve())
 
   // Clean up EventSource, abort pending requests, and clear timers on unmount
   useEffect(() => {
@@ -56,22 +57,26 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
   }, [])
 
   const startProvisioning = useCallback(async () => {
-    try {
-      const baseUrl = await getApiBaseUrl()
-      const headers = await getApiHeaders()
-      const res = await fetch(`${baseUrl}/onboarding/start`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({}),
-      })
-      if (res.ok) {
-        setSandboxReady(true)
-        setMode('ready')
+    const promise = (async () => {
+      try {
+        const baseUrl = await getApiBaseUrl()
+        const headers = await getApiHeaders()
+        const res = await fetch(`${baseUrl}/onboarding/start`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({}),
+        })
+        if (res.ok) {
+          setSandboxReady(true)
+          setMode('ready')
+        }
+      } catch (err) {
+        console.error('[useOnboardingStream] startProvisioning failed:', err)
+        throw err
       }
-    } catch (err) {
-      console.error('[useOnboardingStream] startProvisioning failed:', err)
-      throw err
-    }
+    })()
+    provisioningPromiseRef.current = promise
+    return promise
   }, [])
 
   const createWorkspace = useCallback(async (workspace: string, project: string): Promise<OnboardingHandoffResult | null> => {
@@ -108,6 +113,13 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
     abortRef.current = new AbortController()
 
     try {
+      // Wait for sandbox provisioning if it hasn't completed yet.
+      // startProvisioning runs on mount — by the time user clicks a quick reply
+      // (after logo + 3 template messages), it should be done. If not, we wait.
+      if (!sandboxReady) {
+        await provisioningPromiseRef.current
+      }
+
       // 1. Create conversation + fetch SSE token in parallel (independent operations)
       const [conversation, token] = await Promise.all([
         createConversationApi('xerus-master', 'Onboarding'),
@@ -188,7 +200,7 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
       setError('Something went wrong. Please try again.')
       setMode('ready')
     }
-  }, [])
+  }, [sandboxReady])
 
   const retryHandoff = useCallback(() => {
     if (!lastHandoffRef.current) return

--- a/xerus_web/utils/AuthContext.tsx
+++ b/xerus_web/utils/AuthContext.tsx
@@ -73,13 +73,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             if (isMountedRef.current) {
               setInviteRequired(true)
             }
-          } else if (profile.has_workspace) {
-            // Ensure sandbox is running (non-blocking, only if workspace exists and user active)
-            try {
-              const { ensureSandbox } = await import('@/lib/api/workspace')
-              await ensureSandbox()
-            } catch (err) {
-              console.warn('[AuthContext] ensureSandbox failed (non-blocking):', err)
+          } else {
+            if (isMountedRef.current) {
+              setInviteRequired(false)
+            }
+            if (profile.has_workspace) {
+              // Ensure sandbox is running (non-blocking, only if workspace exists and user active)
+              try {
+                const { ensureSandbox } = await import('@/lib/api/workspace')
+                await ensureSandbox()
+              } catch (err) {
+                console.warn('[AuthContext] ensureSandbox failed (non-blocking):', err)
+              }
             }
           }
         } else {


### PR DESCRIPTION
## Summary

- **Invite code gating**: When `INVITE_ONLY_MODE=true`, new users must enter a single-use invite code after Google sign-in to activate their account. Existing users are grandfathered.
- **Onboarding flow fix**: Removed AI conversation from onboarding. Static template messages → workspace name form (existing WorkspaceSetupCard) → Screen 2 visual animation → handoff creates workspace + domain + channel + sandbox in background.
- **Chat welcome message**: Seeded contextual welcome referencing BOOTSTRAP.md guidance so /chat shows Xerus intro on first visit.
- **Landing page**: Added "Sign in" links for invite code holders (Hero, Navbar, CTA section).

## What's new

### Backend
- New `invite-codes` domain (7 files: types, errors, validators, repository, service, routes, index)
- Migration 079: `invite_codes` table + indexes
- Migration 080: FK ON DELETE fixes + redundant index removal
- `verifyFirebaseToken` middleware (JWT-only, no DB lookup) for pre-registration endpoints
- `inviteCodeRateLimit`: 5 attempts/15min, keyed by user UID
- `activateUser()` on UserService (cross-domain boundary respect)
- Atomic code redemption (UPDATE...RETURNING in transaction, race-condition safe)
- Banned user reactivation prevention (hasUserRedeemedBefore check)
- Onboarding handoff wrapped in transaction (all-or-nothing)
- trigger_type NULL for seed data (was 'onboarding' which violated CHECK constraint)
- Contextual welcome message with workspace/project name + BOOTSTRAP.md guidance

### Frontend
- `InviteCodeGate` component matching LoginOverlay aesthetic
- `GradientBackground` shared component (extracted from both overlays)
- AuthContext: `inviteRequired` state + explicit clear on resolution
- AppLayout: invite gate → onboarding (no sidebar) → app gating sequence
- OnboardingChat: static template messages → WorkspaceSetupCard in chat → Screen 2
- Chat sidebar: forceUpdate pattern for async data loading
- Loading skeleton in ConversationSidebar (no "No conversations" flash)
- Auto-select most recent conversation on /chat first load
- fadeInUp CSS animation with prefers-reduced-motion support
- hasLoadedRef Strict Mode fix

## Test plan

- [x] Sign in with new Google account → invite gate shown
- [x] Enter valid code → account activated → redirect to onboarding
- [x] Onboarding: template messages → "Start fresh" → workspace card → Screen 2
- [x] After onboarding → /chat shows contextual welcome message
- [x] Existing active users skip invite gate entirely
- [x] `INVITE_ONLY_MODE=false` → no gate for anyone
- [x] Invalid/used/expired code → clear error message
- [x] Rate limited after 5 attempts in 15 minutes
- [x] Landing page: "Sign in" links visible in Hero, Navbar, CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)