### PR TITLE
feat: Pod branding, unified upload panel, agent config normalization

### DIFF
--- a/xerus_backend/.env.example
+++ b/xerus_backend/.env.example
@@ -103,3 +103,6 @@ MNEMOSYNE_API_KEY=mn_xxx
 # Connectors (replaced by Pipedream Connect)
 CONNECTORS_API_URL=http://localhost:3000
 CONNECTORS_PLATFORM_KEY=xxx
+
+# Invite-only gating (set to true to require invite codes for new signups)
+INVITE_ONLY_MODE=true

--- a/xerus_backend/src/domains/agents/agent-filesystem.repository.ts
+++ b/xerus_backend/src/domains/agents/agent-filesystem.repository.ts
@@ -4,6 +4,7 @@
 
 import { DriveService } from '../drive/drive.service';
 import type { PublicMetadata } from './types';
+import { generateMascotConfig } from './avatar';
 
 // Daytona SDK throws generic errors for missing files — match by message
 function isFileNotFoundError(err: unknown): boolean {
@@ -79,6 +80,24 @@ interface AgentIndexDocument {
     updated_at: string;
 }
 
+// Normalize raw config JSON to AgentConfigFile shape.
+// Handles field name mismatches between marketplace/template configs and canonical schema:
+//   - "model" -> "ai_model"
+//   - missing "mascot" -> generate one
+// Returns { config, dirty } so callers can persist back if needed.
+function normalizeConfig(raw: Record<string, unknown>): { config: AgentConfigFile; dirty: boolean } {
+    let dirty = false;
+    if (!raw.ai_model && raw.model) {
+        raw.ai_model = raw.model;
+        dirty = true;
+    }
+    if (!raw.mascot) {
+        raw.mascot = generateMascotConfig();
+        dirty = true;
+    }
+    return { config: raw as unknown as AgentConfigFile, dirty };
+}
+
 export class AgentFilesystemRepository {
     constructor(private readonly driveService: DriveService) {}
 
@@ -91,7 +110,12 @@ export class AgentFilesystemRepository {
             if (isFileNotFoundError(err)) return null;
             throw err;
         }
-        return JSON.parse(raw) as AgentConfigFile;
+        const { config, dirty } = normalizeConfig(JSON.parse(raw));
+        if (dirty) {
+            // Persist normalized fields so they stay stable across reads
+            this.putAgentConfig(userId, slug, config).catch(() => {});
+        }
+        return config;
     }
 
     async getAgentConfigs(userId: string, slugs: string[]): Promise<Map<string, AgentConfigFile>> {
@@ -183,7 +207,7 @@ export class AgentFilesystemRepository {
             if (isFileNotFoundError(err)) return null;
             throw err;
         }
-        return JSON.parse(raw) as AgentConfigFile;
+        return normalizeConfig(JSON.parse(raw)).config;
     }
 
     // List all marketplace agents by scanning category dirs under marketplace/agents/

--- a/xerus_web/app/ai-agents/[id]/client.tsx
+++ b/xerus_web/app/ai-agents/[id]/client.tsx
@@ -166,7 +166,7 @@ export default function AgentDetailsClient({ agentId }: AgentDetailsClientProps)
 
   if (!agent) {
     return (
-      <div className="min-h-screen bg-surface-alt flex flex-col items-center justify-center gap-6 px-4">
+      <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
         <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />
         <div className="text-center">
           <h1 className="text-lg font-serif text-text mb-1">Agent not found</h1>
@@ -183,7 +183,7 @@ export default function AgentDetailsClient({ agentId }: AgentDetailsClientProps)
   }
 
   return (
-    <div className="min-h-screen bg-surface-alt text-text font-sans">
+    <div className="min-h-screen text-text font-sans">
       <div className="max-w-5xl mx-auto px-6 py-12">
 
         {/* Top Navigation Row */}

--- a/xerus_web/app/ai-agents/create/client.tsx
+++ b/xerus_web/app/ai-agents/create/client.tsx
@@ -8,7 +8,7 @@ import { getFeaturedModels, type ModelEntry } from '@/lib/api/models'
 import { ModelIcon } from '@/components/agents/AgentAvatar'
 import { formatModelName } from '@/utils/models'
 import { slugify } from '@/utils/slugify'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 const DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6'
 
@@ -73,7 +73,7 @@ export default function CreateAIAgentClient() {
 
     const handleWriteWithAI = async () => {
         if (!form.system_prompt.trim()) {
-            toast.error('Add some text first')
+            toast.error('Missing content', { description: 'Describe what you want your agent to do.' })
             return
         }
         setIsFormatting(true)
@@ -93,7 +93,7 @@ export default function CreateAIAgentClient() {
 
     const handleCreate = async () => {
         if (!form.name.trim()) {
-            toast.error('Give your agent a name')
+            toast.error('Name required', { description: 'Every agent needs a name to get started.' })
             return
         }
 

--- a/xerus_web/app/ai-agents/create/client.tsx
+++ b/xerus_web/app/ai-agents/create/client.tsx
@@ -115,7 +115,7 @@ export default function CreateAIAgentClient() {
     }
 
     return (
-        <div className="min-h-screen bg-surface-alt">
+        <div className="min-h-screen">
             <div className="max-w-3xl mx-auto px-4 py-8">
                 {/* Header */}
                 <div className="flex items-center justify-between mb-8">

--- a/xerus_web/app/error.tsx
+++ b/xerus_web/app/error.tsx
@@ -10,7 +10,7 @@ export default function GlobalError({
   reset: () => void
 }) {
   return (
-    <div className="min-h-screen bg-surface-alt flex flex-col items-center justify-center gap-6 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
       <Image
         src="/logo/xerus.svg"
         alt="Xerus"

--- a/xerus_web/app/inbox/error.tsx
+++ b/xerus_web/app/inbox/error.tsx
@@ -10,7 +10,7 @@ export default function InboxError({
   reset: () => void
 }) {
   return (
-    <div className="min-h-screen bg-surface-alt flex flex-col items-center justify-center gap-6 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
       <Image
         src="/logo/xerus.svg"
         alt="Xerus"

--- a/xerus_web/app/layout.tsx
+++ b/xerus_web/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css'
 import type { Metadata, Viewport } from 'next'
 import { Playfair_Display } from 'next/font/google'
 import AppLayout from '@/components/layout/AppLayout'
-import { Toaster } from 'sonner'
+import { NotificationProvider } from '@/components/ui/NotificationProvider'
 
 const playfair = Playfair_Display({
   subsets: ['latin'],
@@ -50,28 +50,7 @@ export default function RootLayout({
         <AppLayout>
           {children}
         </AppLayout>
-        <Toaster
-          position="top-right"
-          gap={10}
-          toastOptions={{
-            unstyled: true,
-            duration: 6000,
-            classNames: {
-              toast: 'flex items-center gap-3 pl-3 pr-2 py-2.5 rounded-[18px] shadow-[0_8px_30px_rgb(0,0,0,0.12)] border border-surface-active/60 max-w-[26rem] font-sans bg-white/95 backdrop-blur-sm transition-all hover:shadow-[0_8px_30px_rgb(0,0,0,0.16)]',
-              title: 'text-sm font-semibold text-text leading-none',
-              description: 'text-xs text-text-muted font-medium leading-tight mt-0.5',
-              icon: 'shrink-0 w-7 h-7 rounded-full flex items-center justify-center ring-4 ring-white [&_svg]:w-3.5 [&_svg]:h-3.5 [&_svg]:stroke-[2.5]',
-              actionButton: 'text-[0.7rem] font-semibold px-2.5 py-1 rounded-md bg-[#1a1a1a] text-white border-transparent hover:bg-black transition-all',
-              cancelButton: 'text-[0.7rem] font-semibold px-2.5 py-1 rounded-md bg-white text-text border border-surface-active hover:bg-surface-hover transition-all',
-              closeButton: 'shrink-0 w-6 h-6 flex items-center justify-center rounded-full text-text-muted hover:text-text hover:bg-surface-hover/80 border border-transparent hover:border-surface-active transition-all',
-              success: '[&>[data-icon]]:bg-emerald-50 [&>[data-icon]_svg]:text-emerald-600',
-              error: '[&>[data-icon]]:bg-red-50 [&>[data-icon]_svg]:text-red-600',
-              warning: '[&>[data-icon]]:bg-amber-50 [&>[data-icon]_svg]:text-amber-600',
-              info: '[&>[data-icon]]:bg-indigo-50 [&>[data-icon]_svg]:text-indigo-600',
-            },
-          }}
-          closeButton
-        />
+        <NotificationProvider />
       </body>
     </html>
   )

--- a/xerus_web/app/not-found.tsx
+++ b/xerus_web/app/not-found.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-surface-alt flex flex-col items-center justify-center gap-6 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
       <Image
         src="/logo/xerus.svg"
         alt="Xerus"

--- a/xerus_web/app/settings/api-keys/page.tsx
+++ b/xerus_web/app/settings/api-keys/page.tsx
@@ -1,14 +1,11 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { ExternalLink, Eye, EyeOff, RefreshCw, Network, Server, Shield, ArrowUpRight } from 'lucide-react'
+import { ExternalLink, Eye, EyeOff, RefreshCw, Network, Shield, ArrowUpRight } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 import { useRedirectIfNotAuth } from '@/utils/AuthContext'
 import { saveApiKey, checkApiKeyStatus, deleteApiKey, getAllApiKeys } from '@/lib/api/user'
-import { getStatus as getWorkspaceStatus } from '@/lib/api/workspace'
-import type { WorkspaceStatus } from '@/lib/api/workspace'
-import { cn } from '@/lib/utils'
 
 const PROVIDERS = [
   {
@@ -21,15 +18,6 @@ const PROVIDERS = [
     usageUrl: 'https://openrouter.ai/activity',
     modelsUrl: 'https://openrouter.ai/models',
   },
-  {
-    id: 'daytona',
-    name: 'Daytona',
-    description: 'Persistent cloud sandboxes where agents execute code.',
-    Icon: Server,
-    keyUrl: 'https://app.daytona.io/dashboard/keys',
-    docsUrl: 'https://www.daytona.io/docs',
-    dashboardUrl: 'https://app.daytona.io/dashboard',
-  },
 ]
 
 export default function ApiKeysPage() {
@@ -40,7 +28,6 @@ export default function ApiKeysPage() {
   const [apiKeyStatus, setApiKeyStatus] = useState<Record<string, boolean>>({})
   const [apiKeys, setApiKeys] = useState<Record<string, string | null>>({})
   const [isHydrated, setIsHydrated] = useState(false)
-  const [sandboxStatus, setSandboxStatus] = useState<WorkspaceStatus | null>(null)
 
   const updateApiKeyStatus = (newStatus: Record<string, boolean>) => {
     setApiKeyStatus(newStatus)
@@ -61,7 +48,6 @@ export default function ApiKeysPage() {
     if (!user) return
     checkApiKeyStatus().then(updateApiKeyStatus)
     getAllApiKeys().then(setApiKeys)
-    getWorkspaceStatus().then(setSandboxStatus).catch(() => {})
   }, [user])
 
   const getMaskedPreview = (provider: string): string | undefined => {
@@ -228,132 +214,52 @@ export default function ApiKeysPage() {
                 </div>
               </div>
 
-              {/* Contextual info panel */}
+              {/* OpenRouter info panel */}
               <div className="border-t border-surface-active/30 bg-surface-hover/20 px-5 py-4">
-                {provider.id === 'openrouter' && (
-                  <div>
-                    <p className="text-[11px] font-medium text-text-secondary mb-2">
-                      Available Models
-                    </p>
-                    <div className="flex flex-wrap gap-1.5 mb-3">
-                      {['Claude 4.5', 'GPT-5', 'Gemini 2.5', 'DeepSeek V3', 'Qwen 3'].map(
-                        (model) => (
-                          <span
-                            key={model}
-                            className="text-[10px] font-medium text-text-secondary bg-white/80 border border-surface-active/40 px-2 py-0.5 rounded-md"
-                          >
-                            {model}
-                          </span>
-                        )
-                      )}
-                      <span className="text-[10px] font-medium text-text-secondary px-1 py-0.5">
-                        +230 more
+                <p className="text-[11px] font-medium text-text-secondary mb-2">
+                  Available Models
+                </p>
+                <div className="flex flex-wrap gap-1.5 mb-3">
+                  {['Claude 4.5', 'GPT-5', 'Gemini 2.5', 'DeepSeek V3', 'Qwen 3'].map(
+                    (model) => (
+                      <span
+                        key={model}
+                        className="text-[10px] font-medium text-text-secondary bg-white/80 border border-surface-active/40 px-2 py-0.5 rounded-md"
+                      >
+                        {model}
                       </span>
-                    </div>
-                    <div className="flex gap-4">
-                      <a
-                        href={provider.modelsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
-                      >
-                        View all models <ExternalLink className="w-2.5 h-2.5" />
-                      </a>
-                      <a
-                        href={provider.usageUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
-                      >
-                        Check usage <ExternalLink className="w-2.5 h-2.5" />
-                      </a>
-                      <a
-                        href={provider.docsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
-                      >
-                        Docs <ExternalLink className="w-2.5 h-2.5" />
-                      </a>
-                    </div>
-                  </div>
-                )}
-
-                {provider.id === 'daytona' && (
-                  <div>
-                    <p className="text-[11px] font-medium text-text-secondary mb-2">
-                      Sandbox Environment
-                    </p>
-
-                    {isSet && sandboxStatus ? (
-                      <div className="flex items-center gap-3 mb-3">
-                        <div className="flex items-center gap-1.5">
-                          <span
-                            className={cn(
-                              'w-1.5 h-1.5 rounded-full',
-                              sandboxStatus.sandbox_running
-                                ? 'bg-emerald-500'
-                                : 'bg-text-muted/40'
-                            )}
-                          />
-                          <span className="text-[11px] font-medium text-text">
-                            {sandboxStatus.sandbox_running ? 'Running' : 'Stopped'}
-                          </span>
-                        </div>
-                        {sandboxStatus.sandbox_id && (
-                          <span className="text-[10px] text-text-secondary font-mono">
-                            {sandboxStatus.sandbox_id}
-                          </span>
-                        )}
-                      </div>
-                    ) : isSet ? (
-                      <p className="text-[11px] text-text-secondary mb-3">
-                        Key connected. Sandbox will start on first agent execution.
-                      </p>
-                    ) : (
-                      <p className="text-[11px] text-text-secondary mb-3">
-                        Connect your key to provision a persistent sandbox.
-                      </p>
-                    )}
-
-                    <div className="flex flex-wrap gap-1.5 mb-3">
-                      {[
-                        'Persistent volumes',
-                        'Terminal access',
-                        'Browser preview',
-                        'File system',
-                      ].map((cap) => (
-                        <span
-                          key={cap}
-                          className="text-[10px] font-medium text-text-secondary bg-white/80 border border-surface-active/40 px-2 py-0.5 rounded-md"
-                        >
-                          {cap}
-                        </span>
-                      ))}
-                    </div>
-
-                    <div className="flex gap-4">
-                      {'dashboardUrl' in provider && (
-                        <a
-                          href={provider.dashboardUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
-                        >
-                          Dashboard <ExternalLink className="w-2.5 h-2.5" />
-                        </a>
-                      )}
-                      <a
-                        href={provider.docsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
-                      >
-                        Documentation <ExternalLink className="w-2.5 h-2.5" />
-                      </a>
-                    </div>
-                  </div>
-                )}
+                    )
+                  )}
+                  <span className="text-[10px] font-medium text-text-secondary px-1 py-0.5">
+                    +230 more
+                  </span>
+                </div>
+                <div className="flex gap-4">
+                  <a
+                    href={provider.modelsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
+                  >
+                    View all models <ExternalLink className="w-2.5 h-2.5" />
+                  </a>
+                  <a
+                    href={provider.usageUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
+                  >
+                    Check usage <ExternalLink className="w-2.5 h-2.5" />
+                  </a>
+                  <a
+                    href={provider.docsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-text-secondary hover:text-text-secondary transition-colors inline-flex items-center gap-1"
+                  >
+                    Docs <ExternalLink className="w-2.5 h-2.5" />
+                  </a>
+                </div>
               </div>
             </motion.div>
           )

--- a/xerus_web/app/settings/api-keys/page.tsx
+++ b/xerus_web/app/settings/api-keys/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { ExternalLink, Eye, EyeOff, RefreshCw, Network, Shield, ArrowUpRight } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { useRedirectIfNotAuth } from '@/utils/AuthContext'
 import { saveApiKey, checkApiKeyStatus, deleteApiKey, getAllApiKeys } from '@/lib/api/user'
 
@@ -65,7 +65,7 @@ export default function ApiKeysPage() {
       updateApiKeyStatus({ ...apiKeyStatus, [provider]: true })
       setApiKeys((prev) => ({ ...prev, [provider]: input }))
       setApiKeyInputs((prev) => ({ ...prev, [provider]: '' }))
-      toast.success(`${PROVIDERS.find((p) => p.id === provider)?.name} API key saved`)
+      toast.success(`${PROVIDERS.find((p) => p.id === provider)?.name} API key saved`, { description: 'Your key is securely stored and ready to use.' })
     } catch {
       toast.error("Couldn't save your API key", { description: 'Please check the key and try again.' })
     } finally {
@@ -80,7 +80,7 @@ export default function ApiKeysPage() {
       updateApiKeyStatus({ ...apiKeyStatus, [provider]: false })
       setApiKeys((prev) => ({ ...prev, [provider]: null }))
       setApiKeyInputs((prev) => ({ ...prev, [provider]: '' }))
-      toast.success('API key removed')
+      toast.success('API key removed', { description: 'This provider will no longer be used.' })
     } catch {
       toast.error("Couldn't remove your API key", { description: 'Please try again.' })
     } finally {

--- a/xerus_web/app/settings/billing/page.tsx
+++ b/xerus_web/app/settings/billing/page.tsx
@@ -6,7 +6,7 @@ import { getCreditBalance, type CreditBalance } from '@/lib/api/user'
 import { cn } from '@/lib/utils'
 import { motion } from 'framer-motion'
 import { Crown, MessageSquare, Clock, Database, Check, Sparkles } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 const PLAN_CREDITS: Record<string, number> = {
   free: 10,

--- a/xerus_web/app/settings/data/page.tsx
+++ b/xerus_web/app/settings/data/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef } from 'react'
 import { useRedirectIfNotAuth } from '@/utils/AuthContext'
 import {
   exportWorkspace,
@@ -14,7 +14,7 @@ import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 
 export default function DataPage() {
-  const user = useRedirectIfNotAuth()
+  useRedirectIfNotAuth()
   const [actionInProgress, setActionInProgress] = useState<string | null>(null)
   const [snapshots, setSnapshots] = useState<SnapshotFile[]>([])
   const [snapshotsOpen, setSnapshotsOpen] = useState(false)
@@ -71,7 +71,7 @@ export default function DataPage() {
     setActionInProgress('restore')
     try {
       await restoreFromSnapshot(snapshot.key)
-      toast.success('Workspace restored from snapshot')
+      toast.success('Workspace restored from backup')
       setSnapshots([])
     } catch {
       toast.error("Couldn't restore the workspace", { description: 'Please try again.' })
@@ -90,7 +90,7 @@ export default function DataPage() {
         const result = await listSnapshots()
         setSnapshots(result)
       } catch {
-        toast.error("Couldn't load snapshots", { description: 'Please try again.' })
+        toast.error("Couldn't load backups", { description: 'Please try again.' })
       } finally {
         setSnapshotsLoading(false)
       }
@@ -104,7 +104,7 @@ export default function DataPage() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
       >
-        <h1 className="font-serif text-[22px] text-text tracking-tight mb-1">Data</h1>
+        <h1 className="font-serif text-[22px] text-text tracking-tight mb-1">Data &amp; Backups</h1>
         <p className="text-sm text-text-secondary mb-8">
           Export, import, and restore your workspace
         </p>
@@ -193,7 +193,7 @@ export default function DataPage() {
               <History className="w-4 h-4 text-text-secondary" />
             </div>
             <div>
-              <p className="text-sm font-medium text-text">Snapshots</p>
+              <p className="text-sm font-medium text-text">Backups</p>
               <p className="text-xs text-text-secondary mt-0.5">
                 View and restore from previous backups
               </p>
@@ -215,7 +215,7 @@ export default function DataPage() {
                 ))}
               </div>
             ) : snapshots.length === 0 ? (
-              <p className="text-sm text-text-secondary py-2">No snapshots available</p>
+              <p className="text-sm text-text-secondary py-2">No backups available</p>
             ) : (
               <div className="space-y-2">
                 {snapshots.map((snapshot) => (
@@ -241,6 +241,9 @@ export default function DataPage() {
                 ))}
               </div>
             )}
+            <p className="text-[11px] text-text-muted mt-3">
+              Up to 7 backups retained automatically
+            </p>
           </div>
         )}
       </motion.div>

--- a/xerus_web/app/settings/data/page.tsx
+++ b/xerus_web/app/settings/data/page.tsx
@@ -11,7 +11,7 @@ import {
 import type { SnapshotFile } from '@/lib/api/workspace'
 import { Download, Upload, History, RotateCcw, ChevronDown, ChevronUp } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 export default function DataPage() {
   useRedirectIfNotAuth()
@@ -43,7 +43,7 @@ export default function DataPage() {
     setActionInProgress('export')
     try {
       await exportWorkspace()
-      toast.success('Workspace export downloaded')
+      toast.success('Workspace export downloaded', { description: 'Check your downloads folder for the export file.' })
     } catch {
       toast.error("Couldn't export your data", { description: 'Please try again.' })
     } finally {
@@ -58,7 +58,7 @@ export default function DataPage() {
     setActionInProgress('import')
     try {
       await importWorkspace(file)
-      toast.success('Workspace imported successfully')
+      toast.success('Workspace imported successfully', { description: 'Your workspace data has been restored.' })
     } catch {
       toast.error("Couldn't import the workspace", { description: 'Please check the file and try again.' })
     } finally {
@@ -71,7 +71,7 @@ export default function DataPage() {
     setActionInProgress('restore')
     try {
       await restoreFromSnapshot(snapshot.key)
-      toast.success('Workspace restored from backup')
+      toast.success('Workspace restored from backup', { description: 'Your workspace has been rolled back to this backup.' })
       setSnapshots([])
     } catch {
       toast.error("Couldn't restore the workspace", { description: 'Please try again.' })
@@ -177,7 +177,7 @@ export default function DataPage() {
         </div>
       </motion.div>
 
-      {/* Snapshots */}
+      {/* Backups */}
       <motion.div
         className="bg-surface/60 rounded-2xl border border-surface-active/60 overflow-hidden"
         initial={{ opacity: 0, y: 8 }}

--- a/xerus_web/app/settings/page.tsx
+++ b/xerus_web/app/settings/page.tsx
@@ -6,7 +6,7 @@ import { getUserProfile, updateUserProfile, deleteAccount } from '@/lib/api/user
 import { useRouter } from 'next/navigation'
 import { Mail, Crown, Trash2, AlertTriangle } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import Link from 'next/link'
 
 interface ProfileData {
@@ -48,7 +48,7 @@ export default function ProfilePage() {
         })
         setDisplayNameInput(data.display_name)
       } catch {
-        toast.error("Couldn't load your profile")
+        toast.error("Couldn't load your profile", { description: 'Please refresh the page and try again.' })
         setProfile({
           uid: user.uid,
           email: user.email,
@@ -68,7 +68,7 @@ export default function ProfilePage() {
     try {
       await updateUserProfile({ display_name: displayNameInput })
       setProfile((prev) => (prev ? { ...prev, display_name: displayNameInput } : null))
-      toast.success('Display name updated')
+      toast.success('Display name updated', { description: 'Your new name will appear across the platform.' })
     } catch {
       toast.error("Couldn't save your changes", { description: 'Please try again.' })
     } finally {
@@ -79,7 +79,7 @@ export default function ProfilePage() {
   const handleDeleteAccount = async () => {
     try {
       await deleteAccount()
-      toast.success('Account deleted')
+      toast.success('Account deleted', { description: 'Your account and all data have been removed.' })
       router.push('/login')
     } catch {
       toast.error("Couldn't delete your account", { description: 'Please contact support if this persists.' })

--- a/xerus_web/app/settings/workspace/page.tsx
+++ b/xerus_web/app/settings/workspace/page.tsx
@@ -31,12 +31,16 @@ const PLAN_LABELS: Record<string, string> = {
   prodigy: 'Prodigy',
 }
 
-// Pod resource defaults from xerus-pod config (Hetzner cx32)
-// These will come from a backend API endpoint in the future
-const POD_RESOURCES = {
-  vcpus: 4,
-  memoryGb: 8,
-  diskGb: 50,
+// Per-sandbox resource allocation by plan tier
+// Maps to Daytona sandbox resource limits (RESOURCE_LIMITS_DISABLED=false in prod)
+const PLAN_RESOURCES: Record<string, { vcpus: number; memoryGb: number; storageGb: number }> = {
+  free:     { vcpus: 1, memoryGb: 1, storageGb: 5 },
+  starter:  { vcpus: 1, memoryGb: 2, storageGb: 10 },
+  advanced: { vcpus: 2, memoryGb: 4, storageGb: 25 },
+  prodigy:  { vcpus: 4, memoryGb: 8, storageGb: 50 },
+}
+
+const POD_ENV = {
   os: 'Ubuntu 24.04',
   region: 'Nuremberg, EU',
 } as const
@@ -83,6 +87,8 @@ export default function WorkspaceOverviewPage() {
   }
 
   const isRunning = workspaceStatus?.sandbox_running
+  const planType = credits?.plan_type || 'free'
+  const podResources = PLAN_RESOURCES[planType] || PLAN_RESOURCES.free
   const totalCredits = credits ? PLAN_CREDITS[credits.plan_type] || 10 : 10
   const creditsPercent = credits ? Math.min(100, (credits.credits_available / totalCredits) * 100) : 0
 
@@ -157,33 +163,33 @@ export default function WorkspaceOverviewPage() {
             <div className="flex items-center justify-center gap-1.5 mb-1">
               <Cpu className="w-3.5 h-3.5 text-text-secondary" />
             </div>
-            <p className="text-lg font-semibold text-text">{POD_RESOURCES.vcpus}</p>
+            <p className="text-lg font-semibold text-text">{podResources.vcpus}</p>
             <p className="text-[11px] text-text-secondary">vCPUs</p>
           </div>
           <div className="bg-surface-hover/50 border border-surface-active/40 rounded-xl p-3.5 text-center">
             <div className="flex items-center justify-center gap-1.5 mb-1">
               <MemoryStick className="w-3.5 h-3.5 text-text-secondary" />
             </div>
-            <p className="text-lg font-semibold text-text">{POD_RESOURCES.memoryGb} <span className="text-sm font-normal text-text-secondary">GB</span></p>
+            <p className="text-lg font-semibold text-text">{podResources.memoryGb} <span className="text-sm font-normal text-text-secondary">GB</span></p>
             <p className="text-[11px] text-text-secondary">Memory</p>
           </div>
           <div className="bg-surface-hover/50 border border-surface-active/40 rounded-xl p-3.5 text-center">
             <div className="flex items-center justify-center gap-1.5 mb-1">
               <HardDrive className="w-3.5 h-3.5 text-text-secondary" />
             </div>
-            <p className="text-lg font-semibold text-text">{POD_RESOURCES.diskGb} <span className="text-sm font-normal text-text-secondary">GB</span></p>
-            <p className="text-[11px] text-text-secondary">Disk</p>
+            <p className="text-lg font-semibold text-text">{podResources.storageGb} <span className="text-sm font-normal text-text-secondary">GB</span></p>
+            <p className="text-[11px] text-text-secondary">Storage</p>
           </div>
         </div>
 
         {/* OS + Region info row */}
         <div className="flex items-center gap-3 text-[11px] text-text-secondary mb-4">
           <span className="inline-flex items-center gap-1.5 bg-surface-hover/50 border border-surface-active/40 rounded-lg px-2.5 py-1">
-            {POD_RESOURCES.os}
+            {POD_ENV.os}
           </span>
           <span className="inline-flex items-center gap-1.5 bg-surface-hover/50 border border-surface-active/40 rounded-lg px-2.5 py-1">
             <span className="text-[13px]">&#127466;&#127482;</span>
-            {POD_RESOURCES.region}
+            {POD_ENV.region}
           </span>
         </div>
 
@@ -272,7 +278,7 @@ export default function WorkspaceOverviewPage() {
             <p className="text-2xl font-semibold text-text mb-0.5">
               --
               <span className="text-sm font-normal text-text-secondary ml-1">
-                / {POD_RESOURCES.diskGb} GB
+                / {podResources.storageGb} GB
               </span>
             </p>
             <div className="w-full h-1.5 bg-surface-hover rounded-full mt-2 mb-2 overflow-hidden">

--- a/xerus_web/app/settings/workspace/page.tsx
+++ b/xerus_web/app/settings/workspace/page.tsx
@@ -13,7 +13,7 @@ import {
 import type { WorkspaceStatus } from '@/lib/api/workspace'
 import { Cpu, HardDrive, MemoryStick, Server, Sparkles, Play, Pause, Square, Archive, Bot, Puzzle, ChevronRight } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
@@ -31,8 +31,7 @@ const PLAN_LABELS: Record<string, string> = {
   prodigy: 'Prodigy',
 }
 
-// Per-sandbox resource allocation by plan tier
-// Maps to Daytona sandbox resource limits (RESOURCE_LIMITS_DISABLED=false in prod)
+// Per-pod resource allocation by plan tier
 const PLAN_RESOURCES: Record<string, { vcpus: number; memoryGb: number; storageGb: number }> = {
   free:     { vcpus: 1, memoryGb: 1, storageGb: 5 },
   starter:  { vcpus: 1, memoryGb: 2, storageGb: 10 },

--- a/xerus_web/app/settings/workspace/page.tsx
+++ b/xerus_web/app/settings/workspace/page.tsx
@@ -11,7 +11,7 @@ import {
   triggerBackup,
 } from '@/lib/api/workspace'
 import type { WorkspaceStatus } from '@/lib/api/workspace'
-import { Server, Sparkles, Play, Pause, Square, Archive, Bot, Puzzle, ChevronRight } from 'lucide-react'
+import { Cpu, HardDrive, MemoryStick, Server, Sparkles, Play, Pause, Square, Archive, Bot, Puzzle, ChevronRight } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 import Link from 'next/link'
@@ -30,6 +30,16 @@ const PLAN_LABELS: Record<string, string> = {
   advanced: 'Advanced',
   prodigy: 'Prodigy',
 }
+
+// Pod resource defaults from xerus-pod config (Hetzner cx32)
+// These will come from a backend API endpoint in the future
+const POD_RESOURCES = {
+  vcpus: 4,
+  memoryGb: 8,
+  diskGb: 50,
+  os: 'Ubuntu 24.04',
+  region: 'Nuremberg, EU',
+} as const
 
 export default function WorkspaceOverviewPage() {
   const user = useRedirectIfNotAuth()
@@ -94,11 +104,11 @@ export default function WorkspaceOverviewPage() {
       >
         <h1 className="font-serif text-[22px] text-text tracking-tight mb-1">Workspace</h1>
         <p className="text-sm text-text-secondary mb-8">
-          Manage your sandbox environment and resources
+          Your pod environment and resource usage
         </p>
       </motion.div>
 
-      {/* Sandbox Status */}
+      {/* Pod Status */}
       <motion.div
         className="bg-surface/60 rounded-2xl border border-surface-active/60 p-6 mb-6"
         initial={{ opacity: 0, y: 8 }}
@@ -111,7 +121,7 @@ export default function WorkspaceOverviewPage() {
               <Server className="w-4 h-4 text-text-secondary" />
             </div>
             <div>
-              <p className="text-sm font-medium text-text">Daytona Sandbox</p>
+              <p className="text-sm font-medium text-text">Pod</p>
               {workspaceStatus?.sandbox_id && (
                 <p className="text-[11px] text-text-secondary font-mono mt-0.5">
                   {workspaceStatus.sandbox_id}
@@ -141,10 +151,47 @@ export default function WorkspaceOverviewPage() {
           )}
         </div>
 
+        {/* Pod Resources */}
+        <div className="grid grid-cols-3 gap-3 mb-4">
+          <div className="bg-surface-hover/50 border border-surface-active/40 rounded-xl p-3.5 text-center">
+            <div className="flex items-center justify-center gap-1.5 mb-1">
+              <Cpu className="w-3.5 h-3.5 text-text-secondary" />
+            </div>
+            <p className="text-lg font-semibold text-text">{POD_RESOURCES.vcpus}</p>
+            <p className="text-[11px] text-text-secondary">vCPUs</p>
+          </div>
+          <div className="bg-surface-hover/50 border border-surface-active/40 rounded-xl p-3.5 text-center">
+            <div className="flex items-center justify-center gap-1.5 mb-1">
+              <MemoryStick className="w-3.5 h-3.5 text-text-secondary" />
+            </div>
+            <p className="text-lg font-semibold text-text">{POD_RESOURCES.memoryGb} <span className="text-sm font-normal text-text-secondary">GB</span></p>
+            <p className="text-[11px] text-text-secondary">Memory</p>
+          </div>
+          <div className="bg-surface-hover/50 border border-surface-active/40 rounded-xl p-3.5 text-center">
+            <div className="flex items-center justify-center gap-1.5 mb-1">
+              <HardDrive className="w-3.5 h-3.5 text-text-secondary" />
+            </div>
+            <p className="text-lg font-semibold text-text">{POD_RESOURCES.diskGb} <span className="text-sm font-normal text-text-secondary">GB</span></p>
+            <p className="text-[11px] text-text-secondary">Disk</p>
+          </div>
+        </div>
+
+        {/* OS + Region info row */}
+        <div className="flex items-center gap-3 text-[11px] text-text-secondary mb-4">
+          <span className="inline-flex items-center gap-1.5 bg-surface-hover/50 border border-surface-active/40 rounded-lg px-2.5 py-1">
+            {POD_RESOURCES.os}
+          </span>
+          <span className="inline-flex items-center gap-1.5 bg-surface-hover/50 border border-surface-active/40 rounded-lg px-2.5 py-1">
+            <span className="text-[13px]">&#127466;&#127482;</span>
+            {POD_RESOURCES.region}
+          </span>
+        </div>
+
+        {/* Actions */}
         <div className="flex gap-2">
           {!isRunning ? (
             <button
-              onClick={() => handleAction('start', startWorkspace, 'Workspace started')}
+              onClick={() => handleAction('start', startWorkspace, 'Pod started')}
               disabled={workspaceAction !== null}
               className="flex items-center gap-1.5 px-4 py-2 bg-[#FF6600] text-white text-xs font-medium rounded-lg hover:bg-[#E65C00] transition-colors disabled:opacity-40"
             >
@@ -154,7 +201,7 @@ export default function WorkspaceOverviewPage() {
           ) : (
             <>
               <button
-                onClick={() => handleAction('pause', pauseWorkspace, 'Workspace paused')}
+                onClick={() => handleAction('pause', pauseWorkspace, 'Pod paused')}
                 disabled={workspaceAction !== null}
                 className="flex items-center gap-1.5 px-4 py-2 bg-surface-hover text-text text-xs font-medium rounded-lg hover:bg-surface-pressed transition-colors disabled:opacity-40"
               >
@@ -162,7 +209,7 @@ export default function WorkspaceOverviewPage() {
                 {workspaceAction === 'pause' ? 'Pausing...' : 'Pause'}
               </button>
               <button
-                onClick={() => handleAction('stop', stopWorkspace, 'Workspace stopped')}
+                onClick={() => handleAction('stop', stopWorkspace, 'Pod stopped')}
                 disabled={workspaceAction !== null}
                 className="flex items-center gap-1.5 px-4 py-2 bg-surface-hover text-text text-xs font-medium rounded-lg hover:bg-surface-pressed transition-colors disabled:opacity-40"
               >
@@ -216,24 +263,27 @@ export default function WorkspaceOverviewPage() {
             )}
           </div>
 
-          {/* Plan */}
+          {/* Storage */}
           <div className="bg-surface/60 rounded-2xl border border-surface-active/60 p-5">
             <div className="flex items-center gap-2 mb-3">
-              <Server className="w-4 h-4 text-text-secondary" />
-              <p className="text-sm font-medium text-text">Current Plan</p>
+              <HardDrive className="w-4 h-4 text-text-secondary" />
+              <p className="text-sm font-medium text-text">Storage</p>
             </div>
             <p className="text-2xl font-semibold text-text mb-0.5">
-              {credits ? PLAN_LABELS[credits.plan_type] || 'Free' : '--'}
+              --
+              <span className="text-sm font-normal text-text-secondary ml-1">
+                / {POD_RESOURCES.diskGb} GB
+              </span>
             </p>
-            <p className="text-[11px] text-text-secondary mb-3">
-              {totalCredits.toLocaleString()} credits per month
+            <div className="w-full h-1.5 bg-surface-hover rounded-full mt-2 mb-2 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-[#FF6600]/70 transition-all duration-500"
+                style={{ width: '0%' }}
+              />
+            </div>
+            <p className="text-[11px] text-text-secondary">
+              Workspace files, knowledge base, memory
             </p>
-            <Link
-              href="/settings/billing"
-              className="text-xs font-medium text-[#FF6600] hover:text-[#E65C00] transition-colors"
-            >
-              {credits?.plan_type === 'free' ? 'Upgrade plan' : 'Manage plan'}
-            </Link>
           </div>
         </div>
       </motion.div>
@@ -248,9 +298,9 @@ export default function WorkspaceOverviewPage() {
           Quick Actions
         </p>
         <div className="bg-surface/60 rounded-2xl border border-surface-active/60 overflow-hidden">
-          {/* Sync Snapshot */}
+          {/* Create Backup */}
           <button
-            onClick={() => handleAction('backup', triggerBackup, 'Snapshot created')}
+            onClick={() => handleAction('backup', triggerBackup, 'Backup created')}
             disabled={workspaceAction !== null}
             className="flex items-center w-full px-5 py-4 hover:bg-surface-hover/40 transition-colors disabled:opacity-40 text-left group"
           >
@@ -259,10 +309,10 @@ export default function WorkspaceOverviewPage() {
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-text">
-                {workspaceAction === 'backup' ? 'Creating snapshot...' : 'Sync Snapshot'}
+                {workspaceAction === 'backup' ? 'Creating backup...' : 'Create Backup'}
               </p>
               <p className="text-xs text-text-secondary mt-0.5">
-                Take a backup snapshot of your workspace
+                Take a backup of your current workspace
               </p>
             </div>
             <ChevronRight className="w-4 h-4 text-text-secondary/50 group-hover:text-text-secondary transition-colors shrink-0" />

--- a/xerus_web/app/skills/[slug]/page.tsx
+++ b/xerus_web/app/skills/[slug]/page.tsx
@@ -19,7 +19,7 @@ import { FloatingPanel } from '@/components/common/FloatingPanel';
 import { FloatingPanelProvider } from '@/components/common/FloatingPanelContext';
 import { SkillSecretsCard } from '@/components/skills/SkillSecretsCard';
 import { parseSkillEnvKeys } from '@/lib/utils/parse-skill-env-keys';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 
 export default function SkillDetailPage() {
     const router = useRouter();
@@ -87,10 +87,10 @@ export default function SkillDetailPage() {
                     setDeleting(true);
                     try {
                         await deleteSkill(skill.slug);
-                        toast.success('Skill deleted');
+                        toast.success('Skill deleted', { description: 'This skill has been permanently removed.' });
                         router.push('/skills');
                     } catch (error) {
-                        toast.error("Couldn't remove this skill");
+                        toast.error("Couldn't remove this skill", { description: 'Please try again in a moment.' });
                     } finally {
                         setDeleting(false);
                     }

--- a/xerus_web/app/skills/[slug]/page.tsx
+++ b/xerus_web/app/skills/[slug]/page.tsx
@@ -103,7 +103,7 @@ export default function SkillDetailPage() {
 
     if (error || !skill) {
         return (
-            <div className="min-h-screen bg-surface-alt flex flex-col items-center justify-center gap-6 px-4">
+            <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
                 <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />
                 <div className="text-center">
                     <h1 className="text-lg font-serif text-text mb-1">Skill not found</h1>
@@ -123,7 +123,7 @@ export default function SkillDetailPage() {
     const requiredEnvKeys = skillMdContent ? parseSkillEnvKeys(skillMdContent) : [];
 
     return (
-        <div className="min-h-screen bg-surface-alt font-sans text-text">
+        <div className="min-h-screen font-sans text-text">
             <div className="max-w-5xl mx-auto px-6 py-12">
                 {/* Nav bar */}
                 <div className="flex items-center justify-between mb-8">

--- a/xerus_web/app/tools/[toolId]/page.tsx
+++ b/xerus_web/app/tools/[toolId]/page.tsx
@@ -93,7 +93,7 @@ export default function ToolDetailPage() {
 
     if (error || !tool) {
         return (
-            <div className="min-h-screen bg-surface-alt flex flex-col items-center justify-center gap-6 px-4">
+            <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
                 <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />
                 <div className="text-center">
                     <h1 className="text-lg font-serif text-text mb-1">{error ? 'Something went wrong' : 'Connector not found'}</h1>
@@ -110,7 +110,7 @@ export default function ToolDetailPage() {
     }
 
     return (
-        <div className="min-h-screen bg-surface-alt font-sans text-text">
+        <div className="min-h-screen font-sans text-text">
             <div className="max-w-5xl mx-auto px-6 py-12">
                 <Link href="/tools" className="inline-flex items-center gap-2 text-text-secondary hover:text-text mb-8 transition-colors">
                     <ArrowLeft className="w-4 h-4" />

--- a/xerus_web/app/workspace/page.tsx
+++ b/xerus_web/app/workspace/page.tsx
@@ -208,7 +208,7 @@ export default function WorkspacePage() {
   if (loading) return <XerusLoader message="Loading workspace..." />
   if (error) {
     return (
-      <div className="min-h-screen bg-surface-alt flex items-center justify-center p-8">
+      <div className="min-h-screen flex items-center justify-center p-8">
         <div className="text-center max-w-md">
           <div className="w-16 h-16 bg-surface-hover rounded-full flex items-center justify-center mx-auto mb-4">
             <FolderOpen className="w-8 h-8 text-text-secondary" />
@@ -225,10 +225,10 @@ export default function WorkspacePage() {
 
   return (
     <FloatingPanelProvider>
-      <div className="flex flex-col h-screen bg-surface-alt overflow-hidden">
+      <div className="flex flex-col h-screen overflow-hidden">
         <div className="flex-1 flex flex-col min-w-0 min-h-0">
           {/* Toolbar */}
-          <div className="flex items-center justify-between px-4 py-2 border-b border-surface-active/40 shrink-0 bg-surface-alt">
+          <div className="flex items-center justify-between px-4 py-2 border-b border-surface-active/40 shrink-0">
             <div className="flex items-center gap-3">
               <h3 className="text-sm font-medium text-text capitalize">
                 {activeSection === 'files' ? 'All Files'

--- a/xerus_web/components/GradientBackground.tsx
+++ b/xerus_web/components/GradientBackground.tsx
@@ -2,7 +2,7 @@
 
 export function GradientBackground() {
   return (
-    <div className="absolute inset-0 overflow-hidden">
+    <div className="absolute inset-0 overflow-hidden pointer-events-none">
       <div className="absolute -top-40 -right-40 w-96 h-96 bg-[#FF6600]/20 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob" />
       <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-[#FFB800]/20 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-2000" />
       <div className="absolute top-40 left-40 w-96 h-96 bg-[#FF8533]/20 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-4000" />

--- a/xerus_web/components/LoginOverlay.tsx
+++ b/xerus_web/components/LoginOverlay.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth'
 import { auth } from '@/utils/firebase'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { GradientBackground } from './GradientBackground'
 
 export function LoginOverlay() {

--- a/xerus_web/components/ScheduleConfigSection.tsx
+++ b/xerus_web/components/ScheduleConfigSection.tsx
@@ -12,7 +12,7 @@ import {
   Calendar,
   Check
 } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 
 export interface ScheduleConfig {
   time?: string; // "09:00"
@@ -104,17 +104,17 @@ export default function ScheduleConfigSection({
 
   const handleSave = async () => {
     if (!schedule.name) {
-      toast.error('Please enter a schedule name');
+      toast.error('Name required', { description: 'Give your schedule a name to continue.' });
       return;
     }
 
     if (!schedule.taskPrompt || schedule.taskPrompt.trim() === '') {
-      toast.error('Please enter a task prompt - what should the agent do?');
+      toast.error('Task prompt required', { description: 'Tell your agent what to do on each run.' });
       return;
     }
 
     if (schedule.taskPrompt.length > 2000) {
-      toast.error('Task prompt exceeds maximum length of 2000 characters');
+      toast.error('Prompt too long', { description: 'Keep your task prompt under 2,000 characters.' });
       return;
     }
 

--- a/xerus_web/components/SchedulesList.tsx
+++ b/xerus_web/components/SchedulesList.tsx
@@ -17,7 +17,7 @@ import {
   Loader2,
   MoreVertical
 } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import type { ScheduledExecution } from '@/lib/api/types';
 
 interface SchedulesListProps {
@@ -46,7 +46,7 @@ export default function SchedulesList({
       await onToggle(schedule.id, !schedule.enabled);
     } catch (error) {
       console.error('Failed to toggle schedule:', error);
-      toast.error("Couldn't update the schedule");
+      toast.error("Couldn't update the schedule", { description: 'Please try again in a moment.' });
     } finally {
       setTogglingId(null);
     }
@@ -60,10 +60,10 @@ export default function SchedulesList({
           setDeletingId(scheduleId);
           try {
             await onDelete(scheduleId);
-            toast.success('Schedule deleted');
+            toast.success('Schedule deleted', { description: 'This schedule has been removed.' });
           } catch (error) {
             console.error('Failed to delete schedule:', error);
-            toast.error("Couldn't remove the schedule");
+            toast.error("Couldn't remove the schedule", { description: 'Please try again in a moment.' });
           } finally {
             setDeletingId(null);
           }

--- a/xerus_web/components/UserMenu.tsx
+++ b/xerus_web/components/UserMenu.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { ChevronDown, User, Settings, LogOut, Users } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { useAuth } from '@/utils/AuthContext'
 import { logout, getCreditBalance, type CreditBalance } from '@/lib/api/user'
 import type { UserProfile } from '@/lib/api/types'

--- a/xerus_web/components/agents/AgentCard.tsx
+++ b/xerus_web/components/agents/AgentCard.tsx
@@ -3,6 +3,7 @@ import type { Assistant } from "@/lib/api/types"
 import { AgentAvatarWithModel, ModelIcon } from './AgentAvatar'
 import { Loader2, Lock, Users, Plus, Wrench, Settings, Copy, ArrowRight } from 'lucide-react'
 import { canCloneAgent, getAgentVisibilityClass } from "@/utils/agentLabels"
+import { formatModelName } from "@/utils/models"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
 interface AgentCardProps {
@@ -46,7 +47,7 @@ export function AgentCard({ agent, onClone, onChat, onClick, isCloning, isOwner 
                     {agent.model && (
                         <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 bg-white border border-surface-active rounded-md px-2 py-0.5 shadow-sm flex items-center gap-0.5 z-10 whitespace-nowrap">
                             <ModelIcon model={agent.model} size="sm" />
-                            <span className="text-[10px] font-bold text-text-secondary max-w-[60px] truncate">{agent.model}</span>
+                            <span className="text-[10px] font-bold text-text-secondary whitespace-nowrap">{formatModelName(agent.model)}</span>
                         </div>
                     )}
                 </div>

--- a/xerus_web/components/agents/ide/BehaviourTab.tsx
+++ b/xerus_web/components/agents/ide/BehaviourTab.tsx
@@ -20,7 +20,7 @@ import {
   updateHeartbeatConfig,
   deleteHeartbeatConfig,
 } from '@/lib/api/heartbeat'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 
 type BehaviourSection = 'heartbeat' | 'thinking' | 'autonomy' | 'proactivity'
@@ -136,7 +136,7 @@ export function BehaviourTab({
 
   const handleWriteWithAI = async () => {
     if (!editContent.trim()) {
-      toast.error('Add some text first')
+      toast.error('Missing content', { description: 'Add some text before saving.' })
       return
     }
     setIsFormatting(true)

--- a/xerus_web/components/agents/ide/IdentityTab.tsx
+++ b/xerus_web/components/agents/ide/IdentityTab.tsx
@@ -12,7 +12,7 @@ import { useAuth } from "@/utils/AuthContext"
 import { useSearchableTools, useToolLookup } from "@/hooks/useTools"
 import { useToolAuth } from "@/hooks/useToolAuth"
 import { Tool } from "@/types/tool"
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { isTemplateContent } from './FileCard'
 import { SchedulesCard } from './SchedulesCard'
 import { AgentChannelsCard } from './AgentChannelsCard'
@@ -230,7 +230,7 @@ export function IdentityTab({
   const handleWriteWithAI = async () => {
     const content = activeFile ? editContent : tempPrompt
     if (!content.trim()) {
-      toast.error('Add some text first')
+      toast.error('Missing content', { description: 'Add some text before using AI.' })
       return
     }
     setIsFormatting(true)

--- a/xerus_web/components/agents/ide/MemoryTab.tsx
+++ b/xerus_web/components/agents/ide/MemoryTab.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useEffect } from 'react'
 import { Brain } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { getAgentMemories, type MemoryEntry } from '@/lib/api/memory'
 
 type MemoryFilter = 'all' | 'working' | 'episodic' | 'semantic' | 'procedural'
@@ -47,7 +47,7 @@ export function MemoryTab({ agent }: MemoryTabProps) {
                 if (!cancelled) setMemories(data)
             } catch (err) {
                 if (!cancelled) {
-                    toast.error("Couldn't load agent memories")
+                    toast.error("Couldn't load agent memories", { description: 'Please refresh the page and try again.' })
                     setMemories([])
                 }
             } finally {

--- a/xerus_web/components/agents/ide/RunHistory.tsx
+++ b/xerus_web/components/agents/ide/RunHistory.tsx
@@ -5,7 +5,7 @@ import {
     History, Check, XCircle, Clock, Loader2,
     ChevronLeft, ChevronRight, Activity,
 } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { getAgentHistory, type RunEntry } from '@/lib/api/history'
 
 type RunStatus = 'all' | 'success' | 'failed'
@@ -31,7 +31,7 @@ export function RunHistory({ agent }: RunHistoryProps) {
                 if (!cancelled) setRuns(data)
             } catch (err) {
                 if (!cancelled) {
-                    toast.error("Couldn't load run history")
+                    toast.error("Couldn't load run history", { description: 'Please refresh the page and try again.' })
                     setRuns([])
                 }
             } finally {

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -267,11 +267,11 @@ export function ChatContainer({
   const agentSlug = state.currentAgent?.slug ?? null
 
   return (
-    <div className={cn('flex w-full bg-surface relative h-screen overflow-hidden', className)}>
+    <div className={cn('flex w-full relative h-screen overflow-hidden', className)}>
       <PanelGroup orientation="horizontal" className="flex-1 min-w-0">
         {/* Chat column */}
         <Panel defaultSize={isSandboxOpen ? 50 : 100} minSize={30}>
-          <div className="flex flex-col h-full bg-surface relative overflow-hidden">
+          <div className="flex flex-col h-full relative overflow-hidden">
             <MessageList
               messages={state.messages as ChatMessageExtended[]}
               currentAgent={state.currentAgent}

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -22,7 +22,7 @@ import type { ChatMessageExtended } from './chat-message.types'
 import { mapStreamEventsToExecution } from './mapStreamToExecutionEvents'
 
 const ExecutionDetail = dynamic(() => import('@/components/execution').then(m => ({ default: m.ExecutionDetail })))
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { XerusLoader } from '@/components/common/XerusLoader'
 import { startBrowser, startTerminal } from '@/lib/api/workspace'
 import { getSharedPipedreamClient } from '@/lib/pipedream-client'
@@ -116,7 +116,7 @@ export function ChatContainer({
         app: appSlug,
         onSuccess: () => {
           chat.handleDismissToolAuth()
-          toast.success('App connected')
+          toast.success('App connected', { description: 'Your agent can now use this app.' })
           document.querySelectorAll('iframe[id^="pipedream-connect-iframe-"]').forEach(el => el.remove())
         },
         onError: (err) => {

--- a/xerus_web/components/chat/ChatInput.tsx
+++ b/xerus_web/components/chat/ChatInput.tsx
@@ -197,7 +197,7 @@ export function ChatInput({
   }, [value])
 
   return (
-    <div className={cn('w-full max-w-3xl mx-auto px-4 pb-1.5 pt-2 shrink-0 bg-surface', className)}>
+    <div className={cn('w-full max-w-3xl mx-auto px-4 pb-1.5 pt-2 shrink-0', className)}>
       <div className="relative">
         {/* @mention Picker */}
         {showPicker && filteredAgents.length > 0 && (

--- a/xerus_web/components/chat/useChatExecution.ts
+++ b/xerus_web/components/chat/useChatExecution.ts
@@ -39,7 +39,7 @@ import {
   commitTurn,
 } from './streaming-turn-reducer'
 import { extractTextFromParts } from './streaming-turn.utils'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 type SetState = React.Dispatch<React.SetStateAction<ChatState>>
 

--- a/xerus_web/components/chat/useChatState.ts
+++ b/xerus_web/components/chat/useChatState.ts
@@ -18,7 +18,7 @@ import { getTree, type FileNode } from '@/lib/api/workspace'
 import { Agent, Conversation, ChatState, SelectedChannel, SessionEntry, ProjectGroup, SessionStatus } from './types'
 import { XERUS_MASTER_SLUG } from './AgentDropdown'
 import { useChatExecution } from './useChatExecution'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import type { ChatMessageExtended } from './chat-message.types'
 import type { WorkspaceFile } from './WorkspaceTree'
 
@@ -373,7 +373,7 @@ export function useChatState({ initialAgentId, conversationId, initialMessage }:
         conversationId: prev.conversationId === id ? null : prev.conversationId,
         messages: prev.conversationId === id ? [] : prev.messages,
       }))
-      toast.success('Conversation deleted')
+      toast.success('Conversation deleted', { description: 'This conversation has been permanently removed.' })
     } catch (error) {
       console.error('Failed to delete conversation:', error)
       toast.error("Couldn't delete this conversation", { description: 'Please try again.' })

--- a/xerus_web/components/layout/AppLayout.tsx
+++ b/xerus_web/components/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ import { AppSidebar } from '@/components/navigation/AppSidebar'
 import { MobileBottomBar } from '@/components/navigation/MobileBottomBar'
 import { MobileHeader } from '@/components/navigation/MobileHeader'
 import { MotionConfig } from 'framer-motion'
+import { GradientBackground } from '@/components/GradientBackground'
 
 import { InviteCodeGate } from '@/components/InviteCodeGate'
 
@@ -136,7 +137,8 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
   // Mobile layout: floating header + content + bottom bar
   if (isMobile) {
     return (
-      <div className="flex flex-col h-screen bg-surface-alt">
+      <div className="flex flex-col h-screen relative">
+        <GradientBackground />
         <a
           href="#main-content"
           className="absolute -top-full left-2 z-[100] px-4 py-2 bg-[#FF6600] text-white rounded-xl text-sm font-medium focus:top-2 focus:outline-none transition-[top]"
@@ -154,7 +156,8 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
 
   // Desktop and Tablet layout
   return (
-    <div className="flex h-screen overflow-hidden bg-surface-alt relative">
+    <div className="flex h-screen overflow-hidden relative">
+      <GradientBackground />
       <a
         href="#main-content"
         className="absolute -top-full left-2 z-[100] px-4 py-2 bg-[#FF6600] text-white rounded-xl text-sm font-medium focus:top-2 focus:outline-none transition-[top]"

--- a/xerus_web/components/layout/AppLayout.tsx
+++ b/xerus_web/components/layout/AppLayout.tsx
@@ -25,7 +25,7 @@ const LoginOverlay = dynamic(
 // Contextual loading screen — shows appropriate message per gate
 function LoadingScreen({ title, subtitle }: { title?: string; subtitle?: string }) {
   return (
-    <div className="flex h-screen items-center justify-center bg-surface-alt">
+    <div className="flex h-screen items-center justify-center">
       <div className="flex flex-col items-center gap-8 animate-tab-in">
         <img src="/logo/xerus.svg" alt="Xerus" className="w-20 h-20 animate-pulse" />
 
@@ -109,7 +109,7 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
   // Onboarding page: no sidebar, full-screen onboarding chat
   if (isOnboardingPage && user) {
     return (
-      <div className="flex h-screen overflow-hidden bg-surface-alt">
+      <div className="flex h-screen overflow-hidden">
         <main className="flex-1 relative h-screen overflow-y-auto">
           {children}
         </main>
@@ -120,7 +120,7 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
   // Login page: no sidebar, overlay
   if (isLoginPage) {
     return (
-      <div className="flex h-screen overflow-hidden bg-surface-alt relative">
+      <div className="flex h-screen overflow-hidden relative">
         <main className="flex-1 relative h-screen overflow-y-auto filter blur-sm">
           <div className="h-full flex items-center justify-center p-8">
             <div className="text-center text-text-secondary">
@@ -182,7 +182,7 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
         {/* Right Panel */}
         {isRightPanelOpen && rightPanelContent && (
           <aside
-            className="shrink-0 w-[var(--right-panel-width)] h-screen border-l border-surface-active bg-surface overflow-y-auto"
+            className="shrink-0 w-[var(--right-panel-width)] h-screen border-l border-surface-active overflow-y-auto"
             role="complementary"
             aria-label="Detail panel"
           >

--- a/xerus_web/components/office/OfficeDashboard.tsx
+++ b/xerus_web/components/office/OfficeDashboard.tsx
@@ -260,7 +260,7 @@ export function OfficeDashboard() {
   }
 
   return (
-    <div className="bg-surface-alt min-h-full font-sans text-text">
+    <div className="min-h-full font-sans text-text">
       <div className="max-w-[1140px] mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
         {/* Page header */}
         <header className="mb-8 flex items-center gap-3">

--- a/xerus_web/components/settings/SettingsSidebar.tsx
+++ b/xerus_web/components/settings/SettingsSidebar.tsx
@@ -19,7 +19,7 @@ const NAV_SECTIONS = [
     label: 'Workspace',
     items: [
       { href: '/settings/workspace', label: 'Overview', icon: Server },
-      { href: '/settings/data', label: 'Data', icon: HardDrive },
+      { href: '/settings/data', label: 'Data & Backups', icon: HardDrive },
       { href: '/settings/billing', label: 'Billing', icon: CreditCard },
     ],
   },

--- a/xerus_web/components/settings/SettingsSidebar.tsx
+++ b/xerus_web/components/settings/SettingsSidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import { User, Key, Server, HardDrive, CreditCard, LogOut, ExternalLink } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { logout } from '@/lib/api/user'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 const NAV_SECTIONS = [
   {
@@ -33,7 +33,7 @@ export function SettingsSidebar() {
   const handleLogout = async () => {
     try {
       await logout()
-      toast.success('Signed out')
+      toast.success('Signed out', { description: 'You have been securely signed out.' })
     } catch {
       toast.error("Couldn't sign you out", { description: 'Please try again.' })
     }

--- a/xerus_web/components/ui/NotificationBanner.tsx
+++ b/xerus_web/components/ui/NotificationBanner.tsx
@@ -26,25 +26,25 @@ const typeConfig = {
     icon: Info,
     iconColor: 'text-indigo-600',
     iconBg: 'bg-indigo-50',
-    accentColor: 'text-indigo-500',
+    ringColor: 'ring-indigo-100',
   },
   success: {
     icon: CheckCircle,
     iconColor: 'text-emerald-600',
     iconBg: 'bg-emerald-50',
-    accentColor: 'text-emerald-500',
+    ringColor: 'ring-emerald-100',
   },
   warning: {
     icon: AlertTriangle,
     iconColor: 'text-amber-600',
     iconBg: 'bg-amber-50',
-    accentColor: 'text-amber-500',
+    ringColor: 'ring-amber-100',
   },
   error: {
     icon: AlertCircle,
     iconColor: 'text-red-600',
     iconBg: 'bg-red-50',
-    accentColor: 'text-red-500',
+    ringColor: 'ring-red-100',
   },
 }
 
@@ -94,36 +94,32 @@ export function NotificationBanner({
   if (!isVisible) return null
 
   return (
-    <div className="fixed top-6 right-6 z-50 flex flex-col items-center w-full max-w-[26rem] font-sans">
+    <div className="fixed top-4 right-5 z-50 flex flex-col items-center w-full max-w-[23rem] font-sans">
       {/* Main Card */}
-      <div className="w-full bg-white/95 backdrop-blur-sm border border-surface-active/60 rounded-[18px] shadow-[0_8px_30px_rgb(0,0,0,0.12)] overflow-hidden transition-all duration-300 ease-out hover:shadow-[0_8px_30px_rgb(0,0,0,0.16)]">
-        <div className="flex items-center pl-3 pr-2 py-2.5 gap-3">
-          {/* Icon - Left */}
-          <div className={`shrink-0 w-7 h-7 rounded-full ${config.iconBg} flex items-center justify-center ring-4 ring-white`}>
-            <Icon className={`w-3.5 h-3.5 ${config.iconColor}`} strokeWidth={2.5} />
+      <div className="w-full bg-white border border-black/[0.06] rounded-[16px] shadow-[0_6px_24px_rgb(0,0,0,0.08)] overflow-hidden transition-all duration-300 ease-out">
+        <div className="flex items-center pl-3 pr-2.5 py-2.5 gap-2.5">
+          {/* Icon */}
+          <div className={`shrink-0 w-6 h-6 rounded-full ${config.iconBg} flex items-center justify-center ring-2 ${config.ringColor}`}>
+            <Icon className={`w-3 h-3 ${config.iconColor}`} strokeWidth={2.5} />
           </div>
 
-          {/* Content - Center */}
-          <div className="flex-1 min-w-0 flex flex-col justify-center gap-0.5">
-            <p className="text-sm font-semibold text-text leading-none">{title}</p>
+          {/* Content */}
+          <div className="flex-1 min-w-0 flex flex-col justify-center">
+            <p className="text-[12px] font-semibold text-[#1a1a1a] leading-tight">{title}</p>
             {message && (
-              <p className="text-xs text-text-muted font-medium leading-tight mt-0.5">{message}</p>
+              <p className="text-[10px] text-[#6e6e6e] font-normal leading-snug mt-px">{message}</p>
             )}
           </div>
 
-          {/* Actions & Close - Right */}
-          <div className="flex items-center gap-2 shrink-0 pl-1">
+          {/* Actions & Close */}
+          <div className="flex items-center gap-1.5 shrink-0">
             {actions && actions.length > 0 && (
               <div className="flex items-center gap-1.5">
                 {actions.map((action, idx) => (
                   <button
                     key={idx}
                     onClick={action.onClick}
-                    className={`text-[0.7rem] font-semibold px-2.5 py-1 rounded-md transition-all duration-200 border ${
-                      action.variant === 'primary'
-                        ? 'bg-[#1a1a1a] text-white border-transparent hover:bg-black' 
-                        : 'bg-white text-text border-surface-active hover:bg-surface-hover'
-                    }`}
+                    className="text-[10px] font-medium px-2 py-0.5 rounded-md bg-white text-[#1a1a1a] border border-black/[0.12] hover:bg-[#f5f5f5] transition-colors"
                   >
                     {action.label}
                   </button>
@@ -131,28 +127,23 @@ export function NotificationBanner({
               </div>
             )}
 
-            {/* Divider */}
-            {actions && actions.length > 0 && (
-              <div className="w-px h-5 bg-surface-active" /> 
-            )}
-
-            {/* Circle Close Button */}
+            {/* Close Button */}
             <button
               onClick={handleClose}
-              className="shrink-0 w-6 h-6 flex items-center justify-center rounded-full text-text-muted hover:text-text hover:bg-surface-hover/80 border border-transparent hover:border-surface-active transition-all"
+              className="shrink-0 w-5 h-5 flex items-center justify-center rounded-full text-[#999] hover:text-[#1a1a1a] transition-colors"
               aria-label="Close notification"
             >
-              <X className="w-3.5 h-3.5" />
+              <X className="w-3 h-3" />
             </button>
           </div>
         </div>
       </div>
 
-      {/* Countdown - Outside the card */}
+      {/* Countdown */}
       {autoCloseSeconds && countdown > 0 && (
         <div className="mt-1.5 text-center animate-in fade-in slide-in-from-top-1 duration-300">
-          <p className="text-[10px] text-text-secondary/70 font-medium tracking-wide">
-            This message will automatically close in <span className="text-[#5A24E0] font-bold">{countdown} sec</span>
+          <p className="text-[9px] text-[#999] font-medium tracking-wide">
+            This message will automatically close in <span className="text-[#FF6600] font-bold">{countdown} sec</span>
           </p>
         </div>
       )}

--- a/xerus_web/components/ui/NotificationProvider.tsx
+++ b/xerus_web/components/ui/NotificationProvider.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { toast, type NotificationData } from '@/lib/toast'
+import { NotificationBanner } from './NotificationBanner'
+
+export function NotificationProvider() {
+  const [notification, setNotification] = useState<NotificationData | null>(null)
+
+  useEffect(() => {
+    return toast.subscribe((n) => {
+      setNotification(n)
+    })
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setNotification(null)
+  }, [])
+
+  if (!notification) return null
+
+  return (
+    <NotificationBanner
+      key={notification.id}
+      type={notification.type}
+      title={notification.title}
+      message={notification.message}
+      actions={notification.actions}
+      autoCloseSeconds={notification.autoCloseSeconds}
+      onClose={handleClose}
+      show={true}
+    />
+  )
+}

--- a/xerus_web/components/upload/UploadPanel.tsx
+++ b/xerus_web/components/upload/UploadPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState, useRef, useEffect, useCallback } from 'react'
-import { Upload, X, Minus, Folder, Tag, Loader2, ChevronDown, Mic, Paperclip, RotateCcw } from 'lucide-react'
+import { Upload, X, Minus, Folder, Tag, Loader2, ChevronDown, Mic, Paperclip, RotateCcw, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { FloatingPanel } from '@/components/common/FloatingPanel'
 import { detectUploadContent, type UploadContentType } from '@/lib/utils/detect-upload-content'
@@ -30,11 +30,11 @@ interface FileItem {
 type UploadPanelProps = {
     isOpen: boolean
     onClose: () => void
+    folders?: FolderOption[]
+    currentFolderId?: string | null
 } & (
     | {
         context: 'workspace'
-        folders: FolderOption[]
-        currentFolderId: string | null
         uploadFile: (file: File, tags: string[], folderId: string | null) => Promise<void>
         onUploadComplete: () => void
         onImportAgent?: never
@@ -44,8 +44,6 @@ type UploadPanelProps = {
         context: 'import'
         onImportAgent?: (files: File[]) => Promise<void>
         onImportSkill?: (files: File[]) => Promise<void>
-        folders?: never
-        currentFolderId?: never
         uploadFile?: never
         onUploadComplete?: never
     }
@@ -144,14 +142,14 @@ export function UploadPanel(props: UploadPanelProps) {
     const [tags, setTags] = useState<string[]>([])
     const [tagInput, setTagInput] = useState('')
     const [selectedFolderId, setSelectedFolderId] = useState<string | null>(
-        context === 'workspace' ? props.currentFolderId : null
+        props.currentFolderId || null
     )
     const [isDragActive, setIsDragActive] = useState(false)
     const [isUploading, setIsUploading] = useState(false)
     const fileInputRef = useRef<HTMLInputElement>(null)
 
     // Update folder when prop changes
-    const currentFolderProp = context === 'workspace' ? props.currentFolderId : null
+    const currentFolderProp = props.currentFolderId || null
     useEffect(() => {
         if (currentFolderProp) {
             setSelectedFolderId(currentFolderProp)
@@ -512,77 +510,71 @@ export function UploadPanel(props: UploadPanelProps) {
                             </div>
                         )}
 
-                        {/* File list — always visible when files exist */}
-                        {fileItems.length > 0 && (
-                            <>
-                                {/* Attachments */}
-                                {attachmentFiles.length > 0 && (
-                                    <div className="mb-8">
-                                        <h4 className="text-sm font-medium text-text mb-3">Attachments:</h4>
-                                        <div className="space-y-2">
-                                            {attachmentFiles.map(file => (
-                                                <div key={file.id} className="group flex items-center gap-3 p-3 rounded-[16px] border border-surface-active bg-white hover:bg-[#F9F9F9] transition-colors">
-                                                    <div className="w-8 h-8 rounded-full bg-surface flex items-center justify-center shrink-0">
-                                                        {file.type === 'pdf' && <span className="text-sm font-serif italic text-text-secondary">@</span>}
-                                                        {file.type === 'audio' && <Mic className="w-4 h-4 text-text-secondary" />}
-                                                        {file.type === 'other' && <Paperclip className="w-4 h-4 text-text-secondary" />}
-                                                    </div>
-                                                    <div className="flex-1 min-w-0 flex items-center gap-3">
-                                                        <span className="text-sm text-text truncate font-medium">{file.file.name}</span>
-                                                        <span className="text-xs text-text-secondary shrink-0">
-                                                            {file.file.size < 1024 ? `${file.file.size} B` : file.file.size < 1048576 ? `${(file.file.size / 1024).toFixed(1)} KB` : `${(file.file.size / 1048576).toFixed(1)} MB`}
-                                                        </span>
-                                                    </div>
-                                                    <button
-                                                        onClick={() => removeFile(file.id)}
-                                                        className="p-2 text-text-secondary hover:text-red-500 transition-colors"
-                                                        aria-label="Remove file"
-                                                    >
-                                                        <X className="w-4 h-4" />
-                                                    </button>
-                                                </div>
-                                            ))}
-                                        </div>
-                                    </div>
-                                )}
-
-                                {/* Image Grid */}
-                                {imageFiles.length > 0 && (
-                                    <div className="mb-8">
-                                        <div className="grid grid-cols-3 gap-3">
-                                            {imageFiles.map(file => (
-                                                <div key={file.id} className="relative aspect-video rounded-[16px] overflow-hidden group border border-surface-active">
-                                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                                    <img
-                                                        src={file.blobUrl || ''}
-                                                        alt={file.file.name}
-                                                        className="w-full h-full object-cover"
-                                                    />
-                                                    <div className="absolute bottom-2 left-2 px-2 py-1 bg-black/50 backdrop-blur-sm rounded-full text-[10px] text-white font-medium">
-                                                        {file.file.size < 1024 ? `${file.file.size} B` : file.file.size < 1048576 ? `${(file.file.size / 1024).toFixed(1)} KB` : `${(file.file.size / 1048576).toFixed(1)} MB`}
-                                                    </div>
-                                                    <button
-                                                        onClick={() => removeFile(file.id)}
-                                                        className="absolute top-2 right-2 w-6 h-6 bg-white/80 hover:bg-white rounded-full flex items-center justify-center text-text-secondary hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
-                                                        aria-label="Remove image"
-                                                    >
-                                                        <X className="w-3 h-3" />
-                                                    </button>
-                                                </div>
-                                            ))}
+                        {/* Attachments — always visible */}
+                        <div className="mb-6">
+                            <h4 className="text-sm font-medium text-text mb-3">Attachments:</h4>
+                            {attachmentFiles.length > 0 ? (
+                                <div className="space-y-2">
+                                    {attachmentFiles.map(file => (
+                                        <div key={file.id} className="group flex items-center gap-3 p-3 rounded-[16px] border border-surface-active bg-white hover:bg-[#F9F9F9] transition-colors">
+                                            <div className="w-8 h-8 rounded-full bg-surface flex items-center justify-center shrink-0">
+                                                {file.type === 'pdf' && <span className="text-sm font-serif italic text-text-secondary">@</span>}
+                                                {file.type === 'audio' && <Mic className="w-4 h-4 text-text-secondary" />}
+                                                {file.type === 'other' && <Paperclip className="w-4 h-4 text-text-secondary" />}
+                                            </div>
+                                            <div className="flex-1 min-w-0 flex items-center gap-3">
+                                                <span className="text-sm text-text truncate font-medium">{file.file.name}</span>
+                                                <span className="text-xs text-text-secondary shrink-0">
+                                                    {file.file.size < 1024 ? `${file.file.size} B` : file.file.size < 1048576 ? `${(file.file.size / 1024).toFixed(1)} KB` : `${(file.file.size / 1048576).toFixed(1)} MB`}
+                                                </span>
+                                            </div>
                                             <button
-                                                onClick={() => fileInputRef.current?.click()}
-                                                className="aspect-video rounded-[16px] bg-surface border border-surface-active flex items-center justify-center hover:bg-surface-hover transition-colors"
-                                                aria-label="Add image"
+                                                onClick={() => removeFile(file.id)}
+                                                className="p-2 text-text-secondary hover:text-red-500 transition-colors"
+                                                aria-label="Remove file"
                                             >
-                                                <PlusIcon className="w-6 h-6 text-text-secondary" />
+                                                <X className="w-4 h-4" />
                                             </button>
                                         </div>
-                                    </div>
-                                )}
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-xs text-text-secondary py-2">No files added yet</p>
+                            )}
+                        </div>
 
-                            </>
-                        )}
+                        {/* Image Grid — always visible */}
+                        <div className="mb-6">
+                            <div className="grid grid-cols-3 gap-3">
+                                {imageFiles.map(file => (
+                                    <div key={file.id} className="relative aspect-video rounded-[16px] overflow-hidden group border border-surface-active">
+                                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                                        <img
+                                            src={file.blobUrl || ''}
+                                            alt={file.file.name}
+                                            className="w-full h-full object-cover"
+                                        />
+                                        <div className="absolute bottom-2 left-2 px-2 py-1 bg-black/50 backdrop-blur-sm rounded-full text-[10px] text-white font-medium">
+                                            {file.file.size < 1024 ? `${file.file.size} B` : file.file.size < 1048576 ? `${(file.file.size / 1024).toFixed(1)} KB` : `${(file.file.size / 1048576).toFixed(1)} MB`}
+                                        </div>
+                                        <button
+                                            onClick={() => removeFile(file.id)}
+                                            className="absolute top-2 right-2 w-6 h-6 bg-white/80 hover:bg-white rounded-full flex items-center justify-center text-text-secondary hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                                            aria-label="Remove image"
+                                        >
+                                            <X className="w-3 h-3" />
+                                        </button>
+                                    </div>
+                                ))}
+                                <button
+                                    onClick={() => fileInputRef.current?.click()}
+                                    className="aspect-video rounded-[16px] bg-surface border border-surface-active flex items-center justify-center hover:bg-surface-hover transition-colors"
+                                    aria-label="Add image"
+                                >
+                                    <PlusIcon className="w-6 h-6 text-text-secondary" />
+                                </button>
+                            </div>
+                        </div>
 
                         {/* Tags + Folder — always visible */}
                         <div className="space-y-4 pt-2 border-t border-surface-active">
@@ -624,76 +616,88 @@ export function UploadPanel(props: UploadPanelProps) {
                                 </div>
                             </div>
 
-                            {/* Folder Selection — only when folders are available */}
-                            {context === 'workspace' && (
-                                <div className="space-y-2">
-                                    <label className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-2">
-                                        <Folder className="w-3 h-3" /> Folder
-                                    </label>
-                                    <div className="relative">
-                                        <select
-                                            value={selectedFolderId || ''}
-                                            onChange={(e) => setSelectedFolderId(e.target.value || null)}
-                                            className="w-full appearance-none bg-white border border-surface-active text-text text-sm rounded-lg px-3 py-2.5 focus:outline-none focus:border-[#FF6600] transition-colors"
-                                        >
-                                            <option value="">No Folder (Root)</option>
-                                            {props.folders.map(folder => (
-                                                <option key={folder.id} value={folder.id}>
-                                                    {folder.name}
-                                                </option>
-                                            ))}
-                                        </select>
-                                        <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
-                                    </div>
+                            {/* Folder / Channel — always visible */}
+                            <div className="space-y-2">
+                                <label className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-2">
+                                    <Folder className="w-3 h-3" /> {context === 'workspace' ? 'Folder' : 'Channel'}
+                                </label>
+                                <div className="relative">
+                                    <select
+                                        value={selectedFolderId || ''}
+                                        onChange={(e) => setSelectedFolderId(e.target.value || null)}
+                                        className="w-full appearance-none bg-white border border-surface-active text-text text-sm rounded-lg px-3 py-2.5 focus:outline-none focus:border-[#FF6600] transition-colors"
+                                    >
+                                        <option value="">{context === 'workspace' ? 'No Folder (Root)' : 'No Channel'}</option>
+                                        {(props.folders || []).map(folder => (
+                                            <option key={folder.id} value={folder.id}>
+                                                {folder.name}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
                                 </div>
-                            )}
+                            </div>
                         </div>
                     </div>
 
-                    {/* Footer Actions — always visible */}
-                    <div className="pt-6 mt-auto flex justify-end gap-3 shrink-0 border-t border-surface-active">
+                    {/* Footer — always visible */}
+                    <div className="pt-4 mt-auto shrink-0 border-t border-surface-active">
+                        <div className="flex items-center justify-between">
+                            {/* Left: Write with AI */}
                             <button
-                                onClick={onClose}
-                                className="px-6 py-2.5 rounded-[12px] border border-surface-active text-text hover:bg-surface font-medium text-sm transition-colors"
+                                disabled
+                                className="h-9 px-3 rounded-[12px] flex items-center gap-2 text-text-secondary font-medium text-sm opacity-50 cursor-not-allowed"
                             >
-                                Cancel
+                                <Sparkles className="w-4 h-4" />
+                                Write with AI
                             </button>
 
-                            {/* Import button for agent/skill */}
-                            {isDetectedImport && (
+                            {/* Right: Cancel + action */}
+                            <div className="flex items-center gap-3">
                                 <button
-                                    onClick={() => handleImport(minimize)}
-                                    disabled={isImporting}
-                                    className="px-6 py-2.5 rounded-[12px] bg-text text-white text-sm font-medium hover:bg-[#1a1a1a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                                    onClick={onClose}
+                                    className="px-6 py-2.5 rounded-[12px] border border-surface-active text-text hover:bg-surface font-medium text-sm transition-colors"
                                 >
-                                    {isImporting ? (
-                                        <>
-                                            <Loader2 className="w-4 h-4 animate-spin" />
-                                            Importing...
-                                        </>
-                                    ) : (
-                                        detectedType === 'agent' ? 'Import Agent' : 'Import Skill'
-                                    )}
+                                    Cancel
                                 </button>
-                            )}
 
-                            {/* Upload button for workspace files */}
-                            {!isDetectedImport && context === 'workspace' && (
-                                <button
-                                    onClick={() => handleWorkspaceUpload(minimize)}
-                                    disabled={fileItems.length === 0 || isUploading}
-                                    className="px-6 py-2.5 rounded-[12px] bg-text text-white text-sm font-medium hover:bg-[#1a1a1a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                                >
-                                    {isUploading ? (
-                                        <>
-                                            <Loader2 className="w-4 h-4 animate-spin" />
-                                            Uploading...
-                                        </>
-                                    ) : (
-                                        `Upload ${fileItems.length > 0 ? `${fileItems.length} Files` : ''}`
-                                    )}
-                                </button>
-                            )}
+                                {/* Import button for agent/skill */}
+                                {isDetectedImport && (
+                                    <button
+                                        onClick={() => handleImport(minimize)}
+                                        disabled={isImporting}
+                                        className="px-6 py-2.5 rounded-[12px] bg-text text-white text-sm font-medium hover:bg-[#1a1a1a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                                    >
+                                        {isImporting ? (
+                                            <>
+                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                                Importing...
+                                            </>
+                                        ) : (
+                                            detectedType === 'agent' ? 'Import Agent' : 'Import Skill'
+                                        )}
+                                    </button>
+                                )}
+
+                                {/* Upload button for workspace files */}
+                                {!isDetectedImport && context === 'workspace' && (
+                                    <button
+                                        onClick={() => handleWorkspaceUpload(minimize)}
+                                        disabled={fileItems.length === 0 || isUploading}
+                                        className="px-6 py-2.5 rounded-[12px] bg-text text-white text-sm font-medium hover:bg-[#1a1a1a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                                    >
+                                        {isUploading ? (
+                                            <>
+                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                                Uploading...
+                                            </>
+                                        ) : (
+                                            `Upload ${fileItems.length > 0 ? `${fileItems.length} Files` : ''}`
+                                        )}
+                                    </button>
+                                )}
+                            </div>
+                        </div>
                     </div>
                 </div>
             )}

--- a/xerus_web/components/upload/UploadPanel.tsx
+++ b/xerus_web/components/upload/UploadPanel.tsx
@@ -188,6 +188,20 @@ export function UploadPanel(props: UploadPanelProps) {
         const type = detectUploadContent(files)
         setDetectedType(type)
 
+        // Always build the file list so attachments/images render for every context
+        const items: FileItem[] = files.map(file => {
+            const ft = getFileType(file)
+            return {
+                file,
+                id: Math.random().toString(36).substring(7),
+                status: 'pending' as const,
+                progress: 0,
+                type: ft,
+                blobUrl: ft === 'image' ? URL.createObjectURL(file) : undefined,
+            }
+        })
+        setFileItems(items)
+
         if (type === 'agent') {
             const agentMdFile = files.find(f => f.name === 'agent.md')
             if (agentMdFile) {
@@ -223,20 +237,6 @@ export function UploadPanel(props: UploadPanelProps) {
 
                 setSkillData({ frontmatter: data, xerushub, body })
             }
-        } else {
-            // Regular files — build FileItem list with blob URLs for images
-            const items: FileItem[] = files.map(file => {
-                const type = getFileType(file)
-                return {
-                    file,
-                    id: Math.random().toString(36).substring(7),
-                    status: 'pending' as const,
-                    progress: 0,
-                    type,
-                    blobUrl: type === 'image' ? URL.createObjectURL(file) : undefined,
-                }
-            })
-            setFileItems(items)
         }
     }, [])
 
@@ -437,39 +437,43 @@ export function UploadPanel(props: UploadPanelProps) {
                     {/* Body */}
                     <div className="flex-1 overflow-y-auto custom-scrollbar pr-2 -mr-2">
 
-                        {/* Drop zone — shown when no files yet */}
-                        {!hasContent && (
-                            <div
-                                className={cn(
-                                    "border-2 border-dashed rounded-[24px] h-48 flex flex-col items-center justify-center text-center transition-colors cursor-pointer",
-                                    isDragActive
-                                        ? "border-[#FF6600] bg-[#FF6600]/5"
-                                        : "border-surface-active hover:border-[#FF6600] hover:bg-surface"
-                                )}
-                                onDragEnter={handleDrag}
-                                onDragLeave={handleDrag}
-                                onDragOver={handleDrag}
-                                onDrop={handleDrop}
-                                onClick={() => fileInputRef.current?.click()}
-                            >
-                                <input
-                                    type="file"
-                                    ref={fileInputRef}
-                                    className="hidden"
-                                    multiple
-                                    onChange={handleFileSelect}
-                                />
-                                <div className="flex flex-col items-center gap-2">
+                        {/* Drop zone — always visible, compact when files already added */}
+                        <div
+                            className={cn(
+                                "border-2 border-dashed rounded-[24px] flex flex-col items-center justify-center text-center transition-colors cursor-pointer mb-8",
+                                hasContent ? "h-24" : "h-48",
+                                isDragActive
+                                    ? "border-[#FF6600] bg-[#FF6600]/5"
+                                    : "border-surface-active hover:border-[#FF6600] hover:bg-surface"
+                            )}
+                            onDragEnter={handleDrag}
+                            onDragLeave={handleDrag}
+                            onDragOver={handleDrag}
+                            onDrop={handleDrop}
+                            onClick={() => fileInputRef.current?.click()}
+                        >
+                            <input
+                                type="file"
+                                ref={fileInputRef}
+                                className="hidden"
+                                multiple
+                                onChange={handleFileSelect}
+                            />
+                            <div className="flex flex-col items-center gap-2">
+                                {!hasContent && (
                                     <div className="w-12 h-12 rounded-full bg-surface-hover flex items-center justify-center mb-2">
                                         <Upload className="w-5 h-5 text-text-secondary" />
                                     </div>
-                                    <span className="text-text font-medium">Drop files or folders here</span>
-                                    <p className="text-xs text-text-secondary">
-                                        or click to browse
-                                    </p>
+                                )}
+                                <div className="flex items-center gap-2 text-text font-medium">
+                                    {hasContent && <Upload className="w-4 h-4" />}
+                                    <span>{hasContent ? 'Drop more files or click to browse' : 'Drop files or folders here'}</span>
                                 </div>
+                                {!hasContent && (
+                                    <p className="text-xs text-text-secondary">or click to browse</p>
+                                )}
                             </div>
-                        )}
+                        </div>
 
                         {/* Agent Preview */}
                         {detectedType === 'agent' && agentData && (
@@ -508,8 +512,8 @@ export function UploadPanel(props: UploadPanelProps) {
                             </div>
                         )}
 
-                        {/* Workspace file list — same UI as old FileUploadPanel */}
-                        {detectedType === 'files' && fileItems.length > 0 && (
+                        {/* File list — always visible when files exist */}
+                        {fileItems.length > 0 && (
                             <>
                                 {/* Attachments */}
                                 {attachmentFiles.length > 0 && (
@@ -526,7 +530,7 @@ export function UploadPanel(props: UploadPanelProps) {
                                                     <div className="flex-1 min-w-0 flex items-center gap-3">
                                                         <span className="text-sm text-text truncate font-medium">{file.file.name}</span>
                                                         <span className="text-xs text-text-secondary shrink-0">
-                                                            {(file.file.size / (1024 * 1024)).toFixed(1)} MB
+                                                            {file.file.size < 1024 ? `${file.file.size} B` : file.file.size < 1048576 ? `${(file.file.size / 1024).toFixed(1)} KB` : `${(file.file.size / 1048576).toFixed(1)} MB`}
                                                         </span>
                                                     </div>
                                                     <button
@@ -555,7 +559,7 @@ export function UploadPanel(props: UploadPanelProps) {
                                                         className="w-full h-full object-cover"
                                                     />
                                                     <div className="absolute bottom-2 left-2 px-2 py-1 bg-black/50 backdrop-blur-sm rounded-full text-[10px] text-white font-medium">
-                                                        {(file.file.size / (1024 * 1024)).toFixed(1)} MB
+                                                        {file.file.size < 1024 ? `${file.file.size} B` : file.file.size < 1048576 ? `${(file.file.size / 1024).toFixed(1)} KB` : `${(file.file.size / 1048576).toFixed(1)} MB`}
                                                     </div>
                                                     <button
                                                         onClick={() => removeFile(file.id)}
@@ -577,77 +581,77 @@ export function UploadPanel(props: UploadPanelProps) {
                                     </div>
                                 )}
 
-                                {/* Tags + Folder (workspace only) */}
-                                {context === 'workspace' && (
-                                    <div className="space-y-4 pt-2 border-t border-surface-active">
-                                        {/* Tags */}
-                                        <div className="space-y-2">
-                                            <label className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-2">
-                                                <Tag className="w-3 h-3" /> Tags
-                                            </label>
-                                            <div className="flex flex-wrap gap-2 bg-white p-2 rounded-lg border border-surface-active focus-within:ring-1 focus-within:ring-[#FF6600] transition-shadow">
-                                                {tags.map(tag => (
-                                                    <span key={tag} className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-surface text-xs font-medium text-text">
-                                                        {tag}
-                                                        <button onClick={() => removeTag(tag)} className="hover:text-red-500" aria-label={`Remove tag ${tag}`}>
-                                                            <X className="w-3 h-3" />
-                                                        </button>
-                                                    </span>
-                                                ))}
-                                                <input
-                                                    type="text"
-                                                    value={tagInput}
-                                                    onChange={(e) => setTagInput(e.target.value)}
-                                                    onKeyDown={handleTagKeyDown}
-                                                    placeholder={tags.length === 0 ? "Add tags..." : ""}
-                                                    className="flex-1 min-w-[80px] text-sm bg-transparent focus:outline-none"
-                                                />
-                                            </div>
-                                            <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
-                                                {['Design', 'Blog', 'Research', 'Archive'].map(suggestion => (
-                                                    <button
-                                                        key={suggestion}
-                                                        onClick={() => {
-                                                            if (!tags.includes(suggestion)) setTags([...tags, suggestion])
-                                                        }}
-                                                        className="px-2 py-1 rounded-full bg-surface-hover text-xs text-text-secondary hover:bg-surface-pressed hover:text-text transition-colors whitespace-nowrap"
-                                                    >
-                                                        + {suggestion}
-                                                    </button>
-                                                ))}
-                                            </div>
-                                        </div>
-
-                                        {/* Folder Selection */}
-                                        <div className="space-y-2">
-                                            <label className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-2">
-                                                <Folder className="w-3 h-3" /> Folder
-                                            </label>
-                                            <div className="relative">
-                                                <select
-                                                    value={selectedFolderId || ''}
-                                                    onChange={(e) => setSelectedFolderId(e.target.value || null)}
-                                                    className="w-full appearance-none bg-white border border-surface-active text-text text-sm rounded-lg px-3 py-2.5 focus:outline-none focus:border-[#FF6600] transition-colors"
-                                                >
-                                                    <option value="">No Folder (Root)</option>
-                                                    {props.folders.map(folder => (
-                                                        <option key={folder.id} value={folder.id}>
-                                                            {folder.name}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
-                                            </div>
-                                        </div>
-                                    </div>
-                                )}
                             </>
                         )}
+
+                        {/* Tags + Folder — always visible */}
+                        <div className="space-y-4 pt-2 border-t border-surface-active">
+                            {/* Tags */}
+                            <div className="space-y-2">
+                                <label className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-2">
+                                    <Tag className="w-3 h-3" /> Tags
+                                </label>
+                                <div className="flex flex-wrap gap-2 bg-white p-2 rounded-lg border border-surface-active focus-within:ring-1 focus-within:ring-[#FF6600] transition-shadow">
+                                    {tags.map(tag => (
+                                        <span key={tag} className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-surface text-xs font-medium text-text">
+                                            {tag}
+                                            <button onClick={() => removeTag(tag)} className="hover:text-red-500" aria-label={`Remove tag ${tag}`}>
+                                                <X className="w-3 h-3" />
+                                            </button>
+                                        </span>
+                                    ))}
+                                    <input
+                                        type="text"
+                                        value={tagInput}
+                                        onChange={(e) => setTagInput(e.target.value)}
+                                        onKeyDown={handleTagKeyDown}
+                                        placeholder={tags.length === 0 ? "Add tags..." : ""}
+                                        className="flex-1 min-w-[80px] text-sm bg-transparent focus:outline-none"
+                                    />
+                                </div>
+                                <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+                                    {['Design', 'Blog', 'Research', 'Archive'].map(suggestion => (
+                                        <button
+                                            key={suggestion}
+                                            onClick={() => {
+                                                if (!tags.includes(suggestion)) setTags([...tags, suggestion])
+                                            }}
+                                            className="px-2 py-1 rounded-full bg-surface-hover text-xs text-text-secondary hover:bg-surface-pressed hover:text-text transition-colors whitespace-nowrap"
+                                        >
+                                            + {suggestion}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Folder Selection — only when folders are available */}
+                            {context === 'workspace' && (
+                                <div className="space-y-2">
+                                    <label className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-2">
+                                        <Folder className="w-3 h-3" /> Folder
+                                    </label>
+                                    <div className="relative">
+                                        <select
+                                            value={selectedFolderId || ''}
+                                            onChange={(e) => setSelectedFolderId(e.target.value || null)}
+                                            className="w-full appearance-none bg-white border border-surface-active text-text text-sm rounded-lg px-3 py-2.5 focus:outline-none focus:border-[#FF6600] transition-colors"
+                                        >
+                                            <option value="">No Folder (Root)</option>
+                                            {props.folders.map(folder => (
+                                                <option key={folder.id} value={folder.id}>
+                                                    {folder.name}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
                     </div>
 
-                    {/* Footer Actions */}
-                    {hasContent && (
-                        <div className="pt-6 mt-auto flex justify-end gap-3 shrink-0 border-t border-surface-active">
+                    {/* Footer Actions — always visible */}
+                    <div className="pt-6 mt-auto flex justify-end gap-3 shrink-0 border-t border-surface-active">
                             <button
                                 onClick={onClose}
                                 className="px-6 py-2.5 rounded-[12px] border border-surface-active text-text hover:bg-surface font-medium text-sm transition-colors"
@@ -660,7 +664,7 @@ export function UploadPanel(props: UploadPanelProps) {
                                 <button
                                     onClick={() => handleImport(minimize)}
                                     disabled={isImporting}
-                                    className="px-6 py-2.5 rounded-[12px] bg-[#FF6600] hover:bg-[#E65C00] text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                                    className="px-6 py-2.5 rounded-[12px] bg-text text-white text-sm font-medium hover:bg-[#1a1a1a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                                 >
                                     {isImporting ? (
                                         <>
@@ -674,7 +678,7 @@ export function UploadPanel(props: UploadPanelProps) {
                             )}
 
                             {/* Upload button for workspace files */}
-                            {detectedType === 'files' && context === 'workspace' && (
+                            {!isDetectedImport && context === 'workspace' && (
                                 <button
                                     onClick={() => handleWorkspaceUpload(minimize)}
                                     disabled={fileItems.length === 0 || isUploading}
@@ -690,8 +694,7 @@ export function UploadPanel(props: UploadPanelProps) {
                                     )}
                                 </button>
                             )}
-                        </div>
-                    )}
+                    </div>
                 </div>
             )}
         </FloatingPanel>

--- a/xerus_web/components/workspace/AgentDetailView.tsx
+++ b/xerus_web/components/workspace/AgentDetailView.tsx
@@ -134,7 +134,7 @@ export function AgentDetailView({ agentId, onBack }: AgentDetailViewProps) {
   }
 
   return (
-    <div className="h-full overflow-y-auto scrollbar-thin bg-surface-alt text-text font-sans">
+    <div className="h-full overflow-y-auto scrollbar-thin text-text font-sans">
       <div className="max-w-5xl mx-auto px-6 py-8">
         {/* Navigation */}
         <div className="flex items-center justify-between mb-8">

--- a/xerus_web/components/workspace/BrowseView.tsx
+++ b/xerus_web/components/workspace/BrowseView.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useCallback } from 'react'
 import { FolderOpen, Plus, Upload, Search, LayoutGrid, List, ArrowUpDown, FolderInput } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { FolderCard, FolderSvgDefinitions } from '@/components/FolderCard'
 import { FileCard } from './FileCard'
@@ -69,7 +69,7 @@ export function BrowseView({
         onOpen: () => onFileClick(file),
         onDownload: () => {
           workspaceApi.downloadFile(file.path, file.name)
-            .then(() => toast.success('File downloaded'))
+            .then(() => toast.success('File downloaded', { description: 'Check your downloads folder.' }))
             .catch(() => toast.error("Couldn't download this file", { description: 'Please try again.' }))
         },
         // Disabled until backend supports these operations

--- a/xerus_web/components/workspace/BrowseView.tsx
+++ b/xerus_web/components/workspace/BrowseView.tsx
@@ -134,7 +134,7 @@ export function BrowseView({
   return (
     <>
       {/* Search bar — Eden-style: dominant, full-width with scope chip */}
-      <div className="shrink-0 px-6 pt-6 pb-4 bg-surface-alt">
+      <div className="shrink-0 px-6 pt-6 pb-4">
         <div className="relative flex items-center bg-surface-hover rounded-[24px] overflow-hidden transition-all focus-within:ring-2 focus-within:ring-[#E5E5E5] px-1 py-1">
           <Search className="ml-3 w-4 h-4 text-text-muted shrink-0" />
           {currentDirPath && (

--- a/xerus_web/components/workspace/FileEditor.tsx
+++ b/xerus_web/components/workspace/FileEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react'
 import { Eye, Pencil, Loader2, Lock, Sparkles, ArrowUp } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { BinaryViewer } from './BinaryViewer'
 import { MarkdownPreview } from './MarkdownPreview'
@@ -75,7 +75,7 @@ export function FileEditor({ path, name, size, onDirtyChange, className }: FileE
     try {
       await workspaceApi.putFile(path, currentContent)
       setOriginalContent(currentContent)
-      toast.success('File saved')
+      toast.success('File saved', { description: 'Your changes have been written to disk.' })
     } catch (err) {
       toast.error("Couldn't save this file", { description: 'Please try again.' })
     } finally {

--- a/xerus_web/components/workspace/FileEditor.tsx
+++ b/xerus_web/components/workspace/FileEditor.tsx
@@ -138,7 +138,7 @@ export function FileEditor({ path, name, size, onDirtyChange, className }: FileE
   const showSyntaxViewer = mode === 'view' && !isMd
 
   return (
-    <div className={cn("flex flex-col h-full bg-white", className)}>
+    <div className={cn("flex flex-col h-full", className)}>
 
       {/* Read-only notice — matching agent IDE pattern */}
       {!isEditable && (

--- a/xerus_web/components/workspace/ItemDetailPane.tsx
+++ b/xerus_web/components/workspace/ItemDetailPane.tsx
@@ -27,7 +27,7 @@ function AgentDetail({ agent, onClose, router }: { agent: Assistant; onClose: ()
   const isMarketplace = agent.agentType === 'public' || agent.agentType === 'shared'
 
   return (
-    <div className="h-full flex flex-col bg-white overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-5 py-3 border-b border-surface-active/40 shrink-0">
         <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">Agent Details</span>
@@ -123,7 +123,7 @@ function AgentDetail({ agent, onClose, router }: { agent: Assistant; onClose: ()
 
 function SkillDetail({ skill, onClose, router }: { skill: Skill; onClose: () => void; router: ReturnType<typeof useRouter> }) {
   return (
-    <div className="h-full flex flex-col bg-white overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-5 py-3 border-b border-surface-active/40 shrink-0">
         <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">Skill Details</span>

--- a/xerus_web/components/workspace/SkillDetailView.tsx
+++ b/xerus_web/components/workspace/SkillDetailView.tsx
@@ -171,7 +171,7 @@ export function SkillDetailView({ skillSlug, onBack }: SkillDetailViewProps) {
   const requiredEnvKeys = skillMdContent ? parseSkillEnvKeys(skillMdContent) : []
 
   return (
-    <div className="h-full overflow-y-auto scrollbar-thin bg-surface-alt font-sans text-text">
+    <div className="h-full overflow-y-auto scrollbar-thin font-sans text-text">
       <div className="max-w-5xl mx-auto px-6 py-8">
         {/* Nav */}
         <div className="flex items-center justify-between mb-8">

--- a/xerus_web/components/workspace/SkillDetailView.tsx
+++ b/xerus_web/components/workspace/SkillDetailView.tsx
@@ -16,7 +16,7 @@ import { FloatingPanel } from '@/components/common/FloatingPanel'
 import { FloatingPanelProvider } from '@/components/common/FloatingPanelContext'
 import { SkillSecretsCard } from '@/components/skills/SkillSecretsCard'
 import { parseSkillEnvKeys } from '@/lib/utils/parse-skill-env-keys'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 function SkillFileViewer({ slug, filePath, onContentLoaded }: { slug: string; filePath: string; onContentLoaded?: (content: string) => void }) {
   const { data: content, isLoading: loading } = useSWR(
@@ -135,10 +135,10 @@ export function SkillDetailView({ skillSlug, onBack }: SkillDetailViewProps) {
           setDeleting(true)
           try {
             await deleteSkill(skill.slug)
-            toast.success('Skill deleted')
+            toast.success('Skill deleted', { description: 'This skill has been permanently removed.' })
             onBack()
           } catch {
-            toast.error("Couldn't remove this skill")
+            toast.error("Couldn't remove this skill", { description: 'Please try again in a moment.' })
           } finally {
             setDeleting(false)
           }

--- a/xerus_web/hooks/useAgentActions.ts
+++ b/xerus_web/hooks/useAgentActions.ts
@@ -9,7 +9,7 @@ import {
   deleteAssistant,
 } from '@/lib/api/agents'
 import { slugify } from '@/utils/slugify'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 interface UseAgentActionsArgs {
   agent: any
@@ -105,7 +105,7 @@ export function useAgentActions({ agent, setAgent }: UseAgentActionsArgs) {
           setIsDeleting(true)
           try {
             await deleteAssistant(parseInt(agent.id))
-            toast.success('Agent deleted')
+            toast.success('Agent deleted', { description: 'This agent has been permanently removed.' })
             router.push('/ai-agents')
           } catch (error) {
             console.error('Failed to delete agent:', error)

--- a/xerus_web/hooks/useAgentChannels.ts
+++ b/xerus_web/hooks/useAgentChannels.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { apiCall } from '@/lib/api/client'
 import { useAuth } from '@/utils/AuthContext'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 export interface AgentChannel {
   channel_id: string
@@ -49,7 +49,7 @@ export function useAgentChannels(agentId: number): UseAgentChannelsReturn {
       const response = await apiCall(`/agents/${agentId}/channels`, { method: 'GET' })
       setAssignedChannels(await parseChannelsResponse(response))
     } catch {
-      toast.error("Couldn't load channel assignments")
+      toast.error("Couldn't load channel assignments", { description: 'Please refresh the page and try again.' })
       setAssignedChannels([])
     } finally {
       setIsLoading(false)

--- a/xerus_web/hooks/useChannelData.ts
+++ b/xerus_web/hooks/useChannelData.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { apiGet, apiPost } from '@/lib/api/client'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import type { ChannelMessage } from '@/components/channels/ChannelActivity'
 import type { KanbanTask } from '@/components/common/TaskCard'
 
@@ -129,7 +129,7 @@ export function useChannelTasks(channelId: string): UseChannelTasksReturn {
     try {
       await apiPost(`/tasks/${taskId}/status`, { status: newStatus })
     } catch {
-      toast.error("Couldn't update that task — reverting")
+      toast.error("Couldn't update that task — reverting", { description: 'Your changes could not be saved. The task has been restored.' })
       fetchTasks()
     }
   }, [fetchTasks])

--- a/xerus_web/hooks/useOfficeData.ts
+++ b/xerus_web/hooks/useOfficeData.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo } from 'react'
 import useSWR from 'swr'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import { getAssistants, getUserAgents } from '@/lib/api/agents'
 import { apiPost, apiGet } from '@/lib/api/client'
 import type { Assistant } from '@/lib/api/types'
@@ -194,7 +194,7 @@ export function useCompanyTasks(): UseCompanyTasksReturn {
     try {
       await apiPost(`/tasks/${taskId}/status`, { status: newStatus })
     } catch {
-      toast.error("Couldn't move that task — reverting")
+      toast.error("Couldn't move that task — reverting", { description: 'The task has been moved back to its original position.' })
       fetchData()
     }
   }, [fetchData])

--- a/xerus_web/hooks/useScheduleHandlers.ts
+++ b/xerus_web/hooks/useScheduleHandlers.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, type Dispatch, type SetStateAction } from 'react'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 import {
   createSchedule,
   getSchedules,

--- a/xerus_web/hooks/useToolAuth.ts
+++ b/xerus_web/hooks/useToolAuth.ts
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Tool } from "@/types/tool"
 import { apiCall } from "@/lib/api/client"
 import { getSharedPipedreamClient } from '@/lib/pipedream-client'
-import { toast } from 'sonner'
+import { toast } from '@/lib/toast'
 
 export function useToolAuth(refetch: () => void) {
     const [configuringAuth, setConfiguringAuth] = useState<string | null>(null)
@@ -61,9 +61,9 @@ export function useToolAuth(refetch: () => void) {
                 setConfiguringAuth(null)
             }
         } else if (!tool.auth_type || tool.auth_type === 'none') {
-            toast.info('This tool does not require authentication')
+            toast.info('This tool does not require authentication', { description: 'You can use this tool right away.' })
         } else {
-            toast.error("This tool's login type isn't supported yet")
+            toast.error("This tool's login type isn't supported yet", { description: 'We are working on adding support for this.' })
         }
     }
 
@@ -71,7 +71,7 @@ export function useToolAuth(refetch: () => void) {
         const toolIdentifier = tool.mcp_server ? tool.mcp_server_id ?? tool.name : tool.tool_name || tool.name
 
         if (!tool.connected_account_ids || tool.connected_account_ids.length === 0) {
-            toast.error("This tool isn't connected yet")
+            toast.error("This tool isn't connected yet", { description: 'Connect this tool first to manage accounts.' })
             return
         }
 
@@ -96,7 +96,7 @@ export function useToolAuth(refetch: () => void) {
                 await new Promise(resolve => setTimeout(resolve, 500))
                 refetch()
             } else {
-                toast.success('App disconnected')
+                toast.success('App disconnected', { description: 'This app is no longer connected to your workspace.' })
                 await new Promise(resolve => setTimeout(resolve, 500))
                 refetch()
             }

--- a/xerus_web/lib/api/agent-kb.ts
+++ b/xerus_web/lib/api/agent-kb.ts
@@ -2,7 +2,7 @@
  * Agent Knowledge Base API Module
  * CRUD operations for agent-knowledge base associations
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { apiCall } from './client';
 
 /**
@@ -44,7 +44,7 @@ export const addAgentKnowledgeBase = async (
   });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Knowledge base added');
+  toast.success('Knowledge base added', { description: 'Your agent can now access this knowledge.' });
   return data.knowledge_base || data;
 };
 
@@ -56,5 +56,5 @@ export const removeAgentKnowledgeBase = async (
   knowledgeBaseId: string
 ): Promise<void> => {
   await apiCall(`/agents/${agentId}/knowledge-bases/${knowledgeBaseId}`, { method: 'DELETE' });
-  toast.success('Knowledge base removed');
+  toast.success('Knowledge base removed', { description: 'This knowledge source has been disconnected.' });
 };

--- a/xerus_web/lib/api/agents.ts
+++ b/xerus_web/lib/api/agents.ts
@@ -3,6 +3,10 @@
  * CRUD operations for AI agents/assistants
  */
 import { toast } from '@/lib/toast';
+import { apiCall, getApiHeaders } from './client';
+import { mapAgentToAssistant } from './mappers';
+import type {
+  Assistant,
   BackendAgent,
   AgentCreateInput,
   AgentUpdateInput,

--- a/xerus_web/lib/api/agents.ts
+++ b/xerus_web/lib/api/agents.ts
@@ -3,10 +3,6 @@
  * CRUD operations for AI agents/assistants
  */
 import { toast } from '@/lib/toast';
-import { apiCall, getApiHeaders } from './client';
-import { mapAgentToAssistant } from './mappers';
-import type {
-  Assistant,
   BackendAgent,
   AgentCreateInput,
   AgentUpdateInput,

--- a/xerus_web/lib/api/agents.ts
+++ b/xerus_web/lib/api/agents.ts
@@ -2,7 +2,7 @@
  * Agents API Module
  * CRUD operations for AI agents/assistants
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { apiCall, getApiHeaders } from './client';
 import { mapAgentToAssistant } from './mappers';
 import type {
@@ -200,7 +200,7 @@ export const createAgent = async (data: AgentCreateInput): Promise<Assistant> =>
   // Validate behaviour fields before sending to backend
   const validationError = validateBehaviourFields(data);
   if (validationError) {
-    toast.error(validationError);
+    toast.error(validationError, { description: 'Please review your input and try again.' });
     throw new Error(validationError);
   }
 
@@ -212,7 +212,7 @@ export const createAgent = async (data: AgentCreateInput): Promise<Assistant> =>
   const result = await response.json();
   const agentData = result.data || result;
   const agent: BackendAgent = agentData.agent || agentData;
-  toast.success('Agent created');
+  toast.success('Agent created', { description: 'Your new agent is ready to configure.' });
   return mapAgentToAssistant(agent);
 };
 
@@ -223,7 +223,7 @@ export const updateAgent = async (id: number, updates: AgentUpdateInput): Promis
   // Validate behaviour fields before sending to backend
   const validationError = validateBehaviourFields(updates);
   if (validationError) {
-    toast.error(validationError);
+    toast.error(validationError, { description: 'Please review your input and try again.' });
     throw new Error(validationError);
   }
 
@@ -250,7 +250,7 @@ export const updateAgent = async (id: number, updates: AgentUpdateInput): Promis
   const result = await response.json();
   const agentData = result.data || result;
   const agent: BackendAgent = agentData.agent || agentData;
-  toast.success('Changes saved');
+  toast.success('Changes saved', { description: 'Your agent has been updated.' });
 
   const assistant = mapAgentToAssistant(agent);
   return {
@@ -264,7 +264,7 @@ export const updateAgent = async (id: number, updates: AgentUpdateInput): Promis
  */
 export const deleteAssistant = async (id: number): Promise<void> => {
   await apiCall(`/agents/${id}`, { method: 'DELETE' });
-  toast.success('Agent deleted');
+  toast.success('Agent deleted', { description: 'This agent has been permanently removed.' });
 };
 
 /**
@@ -320,7 +320,7 @@ export const setDefaultAgent = async (agentId: number): Promise<Assistant> => {
   const response = await apiCall(`/agents/${agentId}/set-default`, { method: 'POST' });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Set as default agent');
+  toast.success('Default agent updated', { description: 'This agent will now handle new conversations.' });
   return mapAgentToAssistant(data.agent || data);
 };
 

--- a/xerus_web/lib/api/client.ts
+++ b/xerus_web/lib/api/client.ts
@@ -2,7 +2,7 @@
  * API Client with toast notifications
  * Base client for all API operations
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { auth as firebaseAuth } from '@/utils/firebase';
 import { getApiUrlAsync } from '@/utils/context-detection';
 

--- a/xerus_web/lib/api/heartbeat.ts
+++ b/xerus_web/lib/api/heartbeat.ts
@@ -2,7 +2,7 @@
  * Heartbeat API Module
  * CRUD operations for agent heartbeat configuration and execution history
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { apiCall } from './client';
 import {
   mapHeartbeatConfigToFrontend,
@@ -76,7 +76,7 @@ export const updateHeartbeatConfig = async (
   const result = await response.json();
   const data = result.data || result;
   const savedConfig: BackendHeartbeatConfig = data.heartbeat_config || data;
-  toast.success('Automation settings saved');
+  toast.success('Automation settings saved', { description: 'Your automation preferences have been updated.' });
   return mapHeartbeatConfigToFrontend(savedConfig);
 };
 
@@ -85,7 +85,7 @@ export const updateHeartbeatConfig = async (
  */
 export const deleteHeartbeatConfig = async (agentId: number): Promise<void> => {
   await apiCall(`/agents/${agentId}/heartbeat`, { method: 'DELETE' });
-  toast.success('Automation removed');
+  toast.success('Automation removed', { description: 'This automation has been disabled.' });
 };
 
 /**
@@ -99,7 +99,9 @@ export const toggleHeartbeat = async (agentId: number, enabled: boolean): Promis
   const result = await response.json();
   const data = result.data || result;
   const config: BackendHeartbeatConfig = data.heartbeat_config || data;
-  toast.success(enabled ? 'Automation turned on' : 'Automation paused');
+  toast.success(enabled ? 'Automation turned on' : 'Automation paused', {
+    description: enabled ? 'Your agent will now run automatically.' : 'Your agent will stop running until re-enabled.',
+  });
   return mapHeartbeatConfigToFrontend(config);
 };
 

--- a/xerus_web/lib/api/schedules.ts
+++ b/xerus_web/lib/api/schedules.ts
@@ -2,7 +2,7 @@
  * Schedules API Module
  * Operations for scheduled agent executions
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { apiCall } from './client';
 import { mapScheduleToFrontend, mapScheduleToBackend } from './mappers';
 import type { ScheduledExecution, ExecutionResult, ScheduleFilters } from './types';
@@ -20,7 +20,7 @@ export const createSchedule = async (
 
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Schedule created');
+  toast.success('Schedule created', { description: 'Your agent will run on the set schedule.' });
   return mapScheduleToFrontend(data.schedule || data);
 };
 
@@ -85,7 +85,7 @@ export const updateSchedule = async (
 
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Schedule updated');
+  toast.success('Schedule updated', { description: 'Your changes have been applied.' });
   return mapScheduleToFrontend(data.schedule || data);
 };
 
@@ -94,7 +94,7 @@ export const updateSchedule = async (
  */
 export const deleteSchedule = async (id: string): Promise<void> => {
   await apiCall(`/schedules/${id}`, { method: 'DELETE' });
-  toast.success('Schedule deleted');
+  toast.success('Schedule deleted', { description: 'This schedule has been removed.' });
 };
 
 /**
@@ -104,7 +104,7 @@ export const enableSchedule = async (id: string): Promise<ScheduledExecution> =>
   const response = await apiCall(`/schedules/${id}/enable`, { method: 'POST' });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Schedule enabled');
+  toast.success('Schedule enabled', { description: 'Your agent will resume running on schedule.' });
   return mapScheduleToFrontend(data.schedule || data);
 };
 
@@ -115,7 +115,7 @@ export const disableSchedule = async (id: string): Promise<ScheduledExecution> =
   const response = await apiCall(`/schedules/${id}/disable`, { method: 'POST' });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Schedule paused');
+  toast.success('Schedule paused', { description: 'Your agent will stop running until re-enabled.' });
   return mapScheduleToFrontend(data.schedule || data);
 };
 
@@ -126,7 +126,7 @@ export const triggerSchedule = async (id: string): Promise<ExecutionResult> => {
   const response = await apiCall(`/schedules/${id}/trigger`, { method: 'POST' });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Schedule triggered');
+  toast.success('Schedule triggered', { description: 'Your agent is starting a new run now.' });
   return data.execution || data;
 };
 

--- a/xerus_web/lib/api/skills.ts
+++ b/xerus_web/lib/api/skills.ts
@@ -3,10 +3,6 @@
  * CRUD operations for skills marketplace, install/uninstall, and file operations
  */
 import { toast } from '@/lib/toast';
-import { apiCall, getApiHeaders } from './client';
-import { mapSkillToFrontend, mapSkillDetailToFrontend } from './mappers';
-import type {
-  Skill,
   SkillDetail,
   SkillCreateInput,
   SkillUpdateInput,
@@ -182,6 +178,29 @@ export const setSkillSecret = async (skillSlug: string, envKey: string, value: s
 export const deleteSkillSecret = async (skillSlug: string, envKey: string): Promise<void> => {
   await apiCall(`/skills/${skillSlug}/secrets/${envKey}`, { method: 'DELETE' });
   toast.success('Secret removed', { description: 'This secret has been deleted.' });
+};
+
+/**
+ * Import a skill from uploaded files (SKILL.md + optional xerushub.json + supporting files)
+ */
+export const importSkill = async (files: File[]): Promise<Skill> => {
+  const formData = new FormData();
+  for (const file of files) {
+    formData.append('files', file);
+  }
+
+  const headers = await getApiHeaders(true); // Exclude Content-Type for FormData
+
+  const response = await apiCall('/skills/import', {
+    method: 'POST',
+    headers,
+    body: formData,
+  });
+
+  const result = await response.json();
+  const skillData = result.data || result;
+  const skill = skillData.skill || skillData;
+  return mapSkillToFrontend(skill);
 };
 
 /**

--- a/xerus_web/lib/api/skills.ts
+++ b/xerus_web/lib/api/skills.ts
@@ -3,6 +3,10 @@
  * CRUD operations for skills marketplace, install/uninstall, and file operations
  */
 import { toast } from '@/lib/toast';
+import { apiCall, getApiHeaders } from './client';
+import { mapSkillToFrontend, mapSkillDetailToFrontend } from './mappers';
+import type {
+  Skill,
   SkillDetail,
   SkillCreateInput,
   SkillUpdateInput,

--- a/xerus_web/lib/api/skills.ts
+++ b/xerus_web/lib/api/skills.ts
@@ -206,26 +206,3 @@ export const importSkill = async (files: File[]): Promise<Skill> => {
   const skill = skillData.skill || skillData;
   return mapSkillToFrontend(skill);
 };
-
-/**
- * Import a skill from uploaded files (SKILL.md + optional xerushub.json + supporting files)
- */
-export const importSkill = async (files: File[]): Promise<Skill> => {
-  const formData = new FormData();
-  for (const file of files) {
-    formData.append('files', file);
-  }
-
-  const headers = await getApiHeaders(true); // Exclude Content-Type for FormData
-
-  const response = await apiCall('/skills/import', {
-    method: 'POST',
-    headers,
-    body: formData,
-  });
-
-  const result = await response.json();
-  const skillData = result.data || result;
-  const skill = skillData.skill || skillData;
-  return mapSkillToFrontend(skill);
-};

--- a/xerus_web/lib/api/skills.ts
+++ b/xerus_web/lib/api/skills.ts
@@ -2,7 +2,7 @@
  * Skills API Module
  * CRUD operations for skills marketplace, install/uninstall, and file operations
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { apiCall, getApiHeaders } from './client';
 import { mapSkillToFrontend, mapSkillDetailToFrontend } from './mappers';
 import type {
@@ -83,7 +83,7 @@ export const createSkill = async (input: SkillCreateInput): Promise<Skill> => {
   });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Skill created');
+  toast.success('Skill created', { description: 'Your new skill is ready to use.' });
   return mapSkillToFrontend(data.skill || data);
 };
 
@@ -94,13 +94,13 @@ export const updateSkill = async (slug: string, updates: SkillUpdateInput): Prom
   });
   const result = await response.json();
   const data = result.data || result;
-  toast.success('Skill updated');
+  toast.success('Skill updated', { description: 'Your changes have been applied.' });
   return mapSkillToFrontend(data.skill || data);
 };
 
 export const deleteSkill = async (slug: string): Promise<void> => {
   await apiCall(`/skills/${slug}`, { method: 'DELETE' });
-  toast.success('Skill deleted');
+  toast.success('Skill deleted', { description: 'This skill has been permanently removed.' });
 };
 
 // ============================================================
@@ -112,7 +112,7 @@ export const installSkill = async (skillSlug: string, input: SkillInstallInput):
     method: 'POST',
     body: JSON.stringify(input),
   });
-  toast.success('Skill installed');
+  toast.success('Skill installed', { description: 'This skill is now available to your agents.' });
 };
 
 export const uninstallSkill = async (skillSlug: string, scope: 'channel' | 'global' = 'global', channelPath?: string): Promise<void> => {
@@ -120,7 +120,7 @@ export const uninstallSkill = async (skillSlug: string, scope: 'channel' | 'glob
     method: 'DELETE',
     body: JSON.stringify({ scope, channel_id: channelPath }),
   });
-  toast.success('Skill uninstalled');
+  toast.success('Skill uninstalled', { description: 'This skill has been removed from your workspace.' });
 };
 
 
@@ -147,12 +147,12 @@ export const writeSkillFile = async (idOrSlug: string, filePath: string, content
     method: 'PUT',
     body: JSON.stringify({ content }),
   });
-  toast.success('File saved');
+  toast.success('File saved', { description: 'Your changes have been written to disk.' });
 };
 
 export const deleteSkillFile = async (idOrSlug: string, filePath: string): Promise<void> => {
   await apiCall(`/skills/${idOrSlug}/files/${filePath}`, { method: 'DELETE' });
-  toast.success('File deleted');
+  toast.success('File deleted', { description: 'This file has been permanently removed.' });
 };
 
 // ============================================================
@@ -176,12 +176,12 @@ export const setSkillSecret = async (skillSlug: string, envKey: string, value: s
     method: 'PUT',
     body: JSON.stringify({ value }),
   });
-  toast.success('Secret saved');
+  toast.success('Secret saved', { description: 'Your secret is securely stored.' });
 };
 
 export const deleteSkillSecret = async (skillSlug: string, envKey: string): Promise<void> => {
   await apiCall(`/skills/${skillSlug}/secrets/${envKey}`, { method: 'DELETE' });
-  toast.success('Secret removed');
+  toast.success('Secret removed', { description: 'This secret has been deleted.' });
 };
 
 /**

--- a/xerus_web/lib/api/tools.ts
+++ b/xerus_web/lib/api/tools.ts
@@ -2,7 +2,7 @@
  * Tools API Module
  * Operations for connector catalog and agent tool assignments.
  */
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { apiCall } from './client';
 
 export interface ToolCatalogResponse {
@@ -82,7 +82,9 @@ export const assignToolsToAgent = async (
       body: JSON.stringify({ tool_name: name, tool_config: {} }),
     })
   ));
-  toast.success(toolNames.length === 1 ? 'Tool added' : 'Tools added');
+  toast.success(toolNames.length === 1 ? 'Tool added' : 'Tools added', {
+    description: toolNames.length === 1 ? 'Your agent can now use this tool.' : 'Your agent can now use these tools.',
+  });
 };
 
 /**
@@ -107,7 +109,9 @@ export const removeToolsFromAgent = async (
   await Promise.all(toolNames.map(name =>
     apiCall(`/agents/${agentId}/tools/${encodeURIComponent(name)}`, { method: 'DELETE' })
   ));
-  toast.success(toolNames.length === 1 ? 'Tool removed' : 'Tools removed');
+  toast.success(toolNames.length === 1 ? 'Tool removed' : 'Tools removed', {
+    description: toolNames.length === 1 ? 'This tool has been disconnected from your agent.' : 'These tools have been disconnected from your agent.',
+  });
 };
 
 /**

--- a/xerus_web/lib/api/workspace.ts
+++ b/xerus_web/lib/api/workspace.ts
@@ -307,7 +307,7 @@ export async function importWorkspace(file: File): Promise<{ imported: boolean; 
 }
 
 /**
- * List available S3 snapshots
+ * List available workspace backups
  */
 export async function listSnapshots(): Promise<SnapshotFile[]> {
   const response = await apiCall('/workspace/snapshots', { method: 'GET' });
@@ -316,7 +316,7 @@ export async function listSnapshots(): Promise<SnapshotFile[]> {
 }
 
 /**
- * Restore workspace from an S3 snapshot
+ * Restore workspace from a backup
  */
 export async function restoreFromSnapshot(snapshotKey: string): Promise<{ restored: boolean }> {
   const response = await apiCall('/workspace/restore', {

--- a/xerus_web/lib/toast.ts
+++ b/xerus_web/lib/toast.ts
@@ -1,0 +1,66 @@
+/**
+ * Custom notification system using NotificationBanner design.
+ * Drop-in replacement for Sonner's toast API.
+ */
+
+type NotificationType = 'info' | 'success' | 'warning' | 'error'
+
+interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
+interface ToastOptions {
+  description?: string
+  duration?: number
+  action?: ToastAction
+}
+
+export interface NotificationData {
+  id: string
+  type: NotificationType
+  title: string
+  message?: string
+  autoCloseSeconds: number
+  actions?: Array<{ label: string; onClick: () => void; variant?: 'primary' | 'secondary' }>
+}
+
+type Listener = (notification: NotificationData) => void
+
+const listeners = new Set<Listener>()
+
+let counter = 0
+
+function show(type: NotificationType, title: string, opts?: ToastOptions) {
+  const id = `notif-${++counter}-${Date.now()}`
+  const autoCloseSeconds = opts?.duration
+    ? Math.ceil(opts.duration / 1000)
+    : type === 'error' ? 12 : type === 'warning' ? 10 : 6
+  const actions = opts?.action
+    ? [{ label: opts.action.label, onClick: opts.action.onClick, variant: 'primary' as const }]
+    : undefined
+  const notification: NotificationData = {
+    id,
+    type,
+    title,
+    message: opts?.description,
+    autoCloseSeconds,
+    actions,
+  }
+  listeners.forEach(fn => fn(notification))
+}
+
+function toastFn(title: string, opts?: ToastOptions) {
+  show('warning', title, opts)
+}
+
+toastFn.info = (title: string, opts?: ToastOptions) => show('info', title, opts)
+toastFn.success = (title: string, opts?: ToastOptions) => show('success', title, opts)
+toastFn.warning = (title: string, opts?: ToastOptions) => show('warning', title, opts)
+toastFn.error = (title: string, opts?: ToastOptions) => show('error', title, opts)
+toastFn.subscribe = (fn: Listener) => {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}
+
+export const toast = toastFn


### PR DESCRIPTION
## Summary

- **Settings pod terminology**: Replace Daytona/S3/sandbox with user-facing "Pod" and "Backup" branding across settings pages. Add plan-based resource display (vCPUs, memory, storage) to workspace overview. Remove Daytona API key provider (now platform-managed).
- **Agent config normalization**: Fix missing model badge on agent cards by normalizing `model` → `ai_model` field in marketplace configs. Auto-generate mascot for configs missing one (self-healing on first read). Fix `AgentCard` to use `formatModelName()` instead of raw model string.
- **Unified upload panel**: Fix blank panel when opened from Agents/Skills pages. Attachments list, image grid, tags, folder/channel dropdown, and footer now always render regardless of context. Add "Write with AI" button (disabled, ready for wiring). Fix file size display (B/KB/MB). Black action buttons matching existing design.
- **Toast system**: Replace direct `sonner` imports with `@/lib/toast` wrapper across all settings and API modules.
- **Gradient background**: Add warm gradient blob background across all pages, remove solid bg from loading screens and layout wrappers.

## Test plan

- [x] Open Settings > API Keys — only OpenRouter provider shown
- [x] Open Settings > Workspace — Pod status, resource cards (vCPUs/Memory/Storage),
- [x] Open Settings > Data & Backups — title, sidebar label, toast messages all say "backup" not "snapshot"
- [x] Open AI Agents — model badge visible below mascot on all agent cards (marketplace + user)
- [x] Open AI Agents > any agent — model badge visible in profile card
- [x] Click Import on Agents page — upload panel shows drop zone, attachments, image grid (+), tags, channel dropdown, footer with Write with AI + Cancel
- [x] Click Upload on Workspace page — same panel with folder dropdown instead of channel
- [x] Drop agent.md file on import panel — preview card shows, file list shows below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)