### PR TITLE
fix(frontend): resolve double-login race condition

### DIFF
--- a/xerus_web/components/LoginOverlay.tsx
+++ b/xerus_web/components/LoginOverlay.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth'
 import { auth } from '@/utils/firebase'
 import { toast } from '@/lib/toast'
@@ -9,24 +8,21 @@ import { GradientBackground } from './GradientBackground'
 
 export function LoginOverlay() {
   const [isSigningIn, setIsSigningIn] = useState(false)
-  const router = useRouter()
 
   const handleGoogleSignIn = async () => {
     const provider = new GoogleAuthProvider()
     setIsSigningIn(true)
 
     try {
-      const result = await signInWithPopup(auth, provider)
-      if (result.user) {
-        router.push('/')
-      }
+      await signInWithPopup(auth, provider)
+      // Don't navigate here — AuthContext detects the Firebase state change,
+      // resolves the user profile, then LayoutShell redirects to /
     } catch (error) {
       console.error('Google login failed:', (error as { code?: string }).code)
       const firebaseError = error as { code?: string }
       if (firebaseError.code !== 'auth/popup-closed-by-user') {
         toast.error("Couldn't sign you in", { description: 'Please try again.' })
       }
-    } finally {
       setIsSigningIn(false)
     }
   }

--- a/xerus_web/components/layout/AppLayout.tsx
+++ b/xerus_web/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import { AuthProvider, useAuth } from '@/utils/AuthContext'
@@ -25,8 +25,9 @@ const LoginOverlay = dynamic(
 // Contextual loading screen — shows appropriate message per gate
 function LoadingScreen({ title, subtitle }: { title?: string; subtitle?: string }) {
   return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="flex flex-col items-center gap-8 animate-tab-in">
+    <div className="flex h-screen items-center justify-center relative">
+      <GradientBackground />
+      <div className="flex flex-col items-center gap-8 animate-tab-in relative z-10">
         <img src="/logo/xerus.svg" alt="Xerus" className="w-20 h-20 animate-pulse" />
 
         {title ? (
@@ -76,6 +77,13 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
       router.push('/onboarding')
     }
   }, [isAuthReady, user, hasWorkspace, isOnboardingPage, isLoginPage, router])
+
+  // Redirect authenticated users away from /login
+  useEffect(() => {
+    if (isAuthReady && user && isLoginPage) {
+      router.push('/')
+    }
+  }, [isAuthReady, user, isLoginPage, router])
 
   // Redirect onboarded users away from /onboarding (prevent re-entry)
   useEffect(() => {
@@ -195,14 +203,6 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
 }
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const [isMounted, setIsMounted] = useState(false)
-
-  useEffect(() => { setIsMounted(true) }, [])
-
-  if (!isMounted) {
-    return <LoadingScreen />
-  }
-
   return (
     <AuthProvider>
       <SWRProvider>


### PR DESCRIPTION
## Summary
- **Fixed login race condition**: `LoginOverlay` was calling `router.push('/')` before `AuthContext` finished resolving the user via `findOrCreateUser`, causing `LayoutShell` to bounce back to `/login` (user still null). Users had to sign in twice.
- **Added missing redirect**: `LayoutShell` now redirects authenticated users away from `/login`. Previously only `LoginPage` had this logic, but it was dead code — `LayoutShell` never renders `{children}` on the login route.
- **Removed double loading screen**: Eliminated the redundant `isMounted` hydration gate in `AppLayout` that caused a minimal loading flash before the real auth loading screen.
- **Added gradient background to loading screens**: Loading screens now show the same gradient blobs as the rest of the app.

## Root Cause
Two bugs compounding:
1. `LoginOverlay.router.push('/')` fired before `AuthContext.findOrCreateUser` resolved → `LayoutShell` saw `user=null` on `/` and bounced back to `/login`
2. `LoginPage`'s redirect-if-authenticated effect was dead code — `LayoutShell` replaces `{children}` with hardcoded content on `/login`, so `LoginPage` never mounted

## Test plan
- [x] Sign in with Google — should redirect to `/` in one click, no double popup
- [x] Loading screen shows gradient background (not plain white)
- [x] No flash between two different loading screens
- [x] Sign out → redirected to `/login`
- [x] Direct navigation to `/login` while authenticated → redirected to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)