### PR TITLE
fix(frontend): add /skill/[slug] redirect to /skills/[slug]

### DIFF
--- a/xerus_web/app/skill/[slug]/page.tsx
+++ b/xerus_web/app/skill/[slug]/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default async function SkillSingularRedirect({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  redirect(`/skills/${slug}`)
+}


### PR DESCRIPTION
## Summary

- Adds a server-side redirect from `/skill/{slug}` (singular) to `/skills/{slug}` (plural) to fix 404s when users type the singular URL

## Type

- [x] Fix

## Changes

- `xerus_web/app/skill/[slug]/page.tsx` — new redirect page

## Testing

- [x] Server-side redirect, no runtime logic to test
- [x] No secrets or credentials in code

---
Generated with [Claude Code](https://claude.com/claude-code)