### PR TITLE
fix(frontend): resolve login spinner stuck forever and remove dashboard flash

### DIFF
--- a/xerus_web/components/LoginOverlay.tsx
+++ b/xerus_web/components/LoginOverlay.tsx
@@ -23,6 +23,7 @@ export function LoginOverlay() {
       if (firebaseError.code !== 'auth/popup-closed-by-user') {
         toast.error("Couldn't sign you in", { description: 'Please try again.' })
       }
+    } finally {
       setIsSigningIn(false)
     }
   }

--- a/xerus_web/components/layout/AppLayout.tsx
+++ b/xerus_web/components/layout/AppLayout.tsx
@@ -125,21 +125,9 @@ function LayoutShell({ children }: { children: React.ReactNode }) {
     )
   }
 
-  // Login page: no sidebar, overlay
+  // Login page: full-screen overlay handles everything (bg, branding, form)
   if (isLoginPage) {
-    return (
-      <div className="flex h-screen overflow-hidden relative">
-        <main className="flex-1 relative h-screen overflow-y-auto filter blur-sm">
-          <div className="h-full flex items-center justify-center p-8">
-            <div className="text-center text-text-secondary">
-              <h2 className="text-xl font-semibold mb-2">AI Agents Dashboard</h2>
-              <p>Sign in to access your personalized AI assistants</p>
-            </div>
-          </div>
-        </main>
-        <LoginOverlay />
-      </div>
-    )
+    return <LoginOverlay />
   }
 
   // Mobile layout: floating header + content + bottom bar

--- a/xerus_web/utils/AuthContext.tsx
+++ b/xerus_web/utils/AuthContext.tsx
@@ -49,6 +49,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (processingRef.current || !isMountedRef.current) return
       processingRef.current = true
 
+      // Show loading screen while auth state is being resolved
+      if (isMountedRef.current) {
+        setIsLoading(true)
+        setIsAuthReady(false)
+      }
+
       try {
         if (firebaseUser) {
           if (isMountedRef.current) {


### PR DESCRIPTION
## Summary
- **LoginOverlay**: `setIsSigningIn(false)` was only in `catch` — on successful sign-in the spinner never stopped. Moved to `finally`.
- **AuthContext**: `isAuthReady` stayed `true` from initial null-user check while `findOrCreateUser` ran. No loading screen shown. Now resets `isAuthReady=false` at start of each auth state change.
- **AppLayout**: Login page rendered blurred "AI Agents Dashboard" text behind overlay — flashed during hydration. Removed wrapper; `LoginOverlay` handles its own full-screen background.

## Test plan
- [ ] Sign in with Google — spinner should stop immediately after popup closes
- [ ] Loading screen should appear while profile resolves (Xerus logo + progress bar)
- [ ] Redirect to home after profile loads — no stuck spinner
- [ ] No "AI AGENT DASHBOARD" flash on first load
- [ ] Sign out and back in — smooth flow, no reload needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)