### PR TITLE
fix: stop swallowing skill API errors and fix installed skill access

### DIFF
--- a/xerus_backend/src/domains/skills/service.ts
+++ b/xerus_backend/src/domains/skills/service.ts
@@ -49,12 +49,14 @@ export class SkillService {
             throw new SkillNotFoundError(slug);
         }
 
-        if (!canUserViewSkill(skill, userId)) {
+        // Check install status first — installed skills are always viewable by the user
+        const isInstalled = await this.repository.isInstalled(userId, slug);
+
+        if (!isInstalled && !canUserViewSkill(skill, userId)) {
             throw new SkillAccessDeniedError(slug);
         }
 
         const files = await this.getSkillFiles(skill, userId);
-        const isInstalled = await this.repository.isInstalled(userId, slug);
 
         return {
             ...skill,
@@ -185,7 +187,8 @@ export class SkillService {
         if (!skill) {
             throw new SkillNotFoundError(slug);
         }
-        if (!canUserViewSkill(skill, userId)) {
+        const isInstalled = await this.repository.isInstalled(userId, slug);
+        if (!isInstalled && !canUserViewSkill(skill, userId)) {
             throw new SkillAccessDeniedError(slug);
         }
         return this.getSkillFiles(skill, userId);
@@ -194,7 +197,8 @@ export class SkillService {
     async readFile(slug: string, filePath: string, userId: string): Promise<string> {
         const skill = await this.repository.findBySlug(userId, slug);
         if (!skill) throw new SkillNotFoundError(slug);
-        if (!canUserViewSkill(skill, userId)) throw new SkillAccessDeniedError(slug);
+        const isInstalled = await this.repository.isInstalled(userId, slug);
+        if (!isInstalled && !canUserViewSkill(skill, userId)) throw new SkillAccessDeniedError(slug);
         const ws = this.requireWorkspace();
         return ws.readSkillFile(userId, skill.slug, filePath, skill.is_global);
     }

--- a/xerus_web/app/skills/[slug]/page.tsx
+++ b/xerus_web/app/skills/[slug]/page.tsx
@@ -101,7 +101,27 @@ export default function SkillDetailPage() {
 
     if (isLoading) return <XerusLoader />;
 
-    if (error || !skill) {
+    if (error) {
+        return (
+            <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
+                <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />
+                <div className="text-center">
+                    <h1 className="text-lg font-serif text-text mb-1">Could not load skill</h1>
+                    <p className="text-sm text-text-secondary">Something went wrong. Please try again.</p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <button onClick={() => mutateSkill()} className="px-5 py-2.5 bg-[#FF6600] hover:bg-[#E65C00] text-white font-medium rounded-xl text-sm transition-colors">
+                        Retry
+                    </button>
+                    <button onClick={() => router.push('/workspace')} className="px-5 py-2.5 bg-surface-hover hover:bg-surface-active text-text font-medium rounded-xl text-sm transition-colors">
+                        Back to Skills
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    if (!skill) {
         return (
             <div className="min-h-screen flex flex-col items-center justify-center gap-6 px-4">
                 <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />
@@ -109,7 +129,7 @@ export default function SkillDetailPage() {
                     <h1 className="text-lg font-serif text-text mb-1">Skill not found</h1>
                     <p className="text-sm text-text-secondary">The skill you are looking for does not exist or was removed.</p>
                 </div>
-                <button onClick={() => router.push('/skills')} className="px-5 py-2.5 bg-[#FF6600] hover:bg-[#E65C00] text-white font-medium rounded-xl text-sm transition-colors">
+                <button onClick={() => router.push('/workspace')} className="px-5 py-2.5 bg-[#FF6600] hover:bg-[#E65C00] text-white font-medium rounded-xl text-sm transition-colors">
                     Back to Skills
                 </button>
             </div>

--- a/xerus_web/components/workspace/SkillDetailView.tsx
+++ b/xerus_web/components/workspace/SkillDetailView.tsx
@@ -149,7 +149,27 @@ export function SkillDetailView({ skillSlug, onBack }: SkillDetailViewProps) {
 
   if (isLoading) return <XerusLoader />
 
-  if (error || !skill) {
+  if (error) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-6 px-4">
+        <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />
+        <div className="text-center">
+          <h1 className="text-lg font-serif text-text mb-1">Could not load skill</h1>
+          <p className="text-sm text-text-secondary">Something went wrong. Please try again.</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button onClick={() => mutateSkill()} className="px-5 py-2.5 bg-[#FF6600] hover:bg-[#E65C00] text-white font-medium rounded-xl text-sm transition-colors">
+            Retry
+          </button>
+          <button onClick={onBack} className="px-5 py-2.5 bg-surface-hover hover:bg-surface-active text-text font-medium rounded-xl text-sm transition-colors">
+            Back to Skills
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!skill) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-6 px-4">
         <Image src="/logo/xerus.svg" alt="" width={40} height={40} className="opacity-30" />

--- a/xerus_web/lib/api/skills.ts
+++ b/xerus_web/lib/api/skills.ts
@@ -57,19 +57,14 @@ export const getSkills = async (options?: {
 // ============================================================
 
 export const getSkill = async (idOrSlug: string): Promise<SkillDetail | null> => {
-  try {
-    const response = await apiCall(`/skills/${idOrSlug}`, { method: 'GET' }, false);
-    if (!response.ok) {
-      if (response.status === 404) return null;
-      throw new Error('Failed to fetch skill');
-    }
-    const result = await response.json();
-    const data = result.data || result;
-    return mapSkillDetailToFrontend(data.skill || data);
-  } catch (err) {
-    console.error('Error fetching skill:', err);
-    return null;
+  const response = await apiCall(`/skills/${idOrSlug}`, { method: 'GET' }, false);
+  if (!response.ok) {
+    if (response.status === 404) return null;
+    throw new Error(`Failed to fetch skill: ${response.status}`);
   }
+  const result = await response.json();
+  const data = result.data || result;
+  return mapSkillDetailToFrontend(data.skill || data);
 };
 
 // ============================================================


### PR DESCRIPTION
## Summary
- **Frontend `getSkill()`**: Removed catch-all that returned `null` for ALL errors (network, auth, 500s). Only 404 returns `null`; other errors throw so SWR properly populates `error` state.
- **Frontend `SkillDetailView` + `/skills/[slug]`**: Separated error vs not-found UI. Errors show "Could not load skill" + Retry button. Only actual 404s show "Skill not found".
- **Backend `service.ts`**: Installed skills were blocked by `canUserViewSkill` because `readInstalledSkill` sets `is_global=false`, failing all 3 access conditions. Fixed by checking `isInstalled` before the access gate — if the user installed the skill, they can view it. Applied to `getBySlug`, `listFiles`, and `readFile`.

## Test plan
- [ ] Click a marketplace skill in Skills panel — detail view loads
- [ ] Click an installed skill in Skills panel — detail view loads (was broken before)
- [ ] Click a user-created (imported) skill — detail view loads
- [ ] With backend down, click any skill — shows "Could not load skill" with Retry button (not "Skill not found")
- [ ] Visit `/skills/nonexistent-slug` — shows "Skill not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)