### PR TITLE
fix(frontend): update orange button color to #FF6600

### DIFF
--- a/xerus_web/app/globals.css
+++ b/xerus_web/app/globals.css
@@ -87,8 +87,8 @@
 @layer base {
   :root {
     /* Core Brand Colors */
-    --primary: 25 100% 57%;
-    /* #FF6B00 */
+    --primary: 24 100% 50%;
+    /* #FF6600 */
     --primary-foreground: 0 0% 100%;
     --secondary: 40 100% 50%;
     /* #FFB200 */
@@ -115,7 +115,7 @@
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 25 100% 57%;
+    --ring: 24 100% 50%;
     /* Match primary */
 
     /* Chart Colors */
@@ -158,7 +158,7 @@
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 25 100% 57%;
+    --primary: 24 100% 50%;
     --primary-foreground: 0 0% 100%;
     --secondary: 40 100% 50%;
     --secondary-foreground: 0 0% 100%;


### PR DESCRIPTION
## Summary
- Updated primary color from HSL(25, 100%, 57%) (~#FF7A24, mild orange) to HSL(24, 100%, 50%) (#FF6600, vivid orange)
- Affects all `bg-primary` buttons: agent Clone, skill Install, Chat, error screen Retry, and focus ring
- Single CSS variable change in `globals.css` — both light and dark themes updated

## Test plan
- [ ] Verify agent marketplace Clone button is now #FF6600
- [ ] Verify skill marketplace Install button is now #FF6600
- [ ] Verify error screen Retry buttons are now #FF6600
- [ ] Verify Chat button on owned agents is now #FF6600
- [ ] Check dark mode still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)