### PR TITLE
fix: auto-inject platform MCP server for master orchestrator

### DIFF
--- a/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
+++ b/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
@@ -113,13 +113,21 @@ export class AgentConfigLoader {
                 system_prompt = { type: 'preset' as const, preset: 'claude_code' as const, append };
             }
 
+            // Auto-inject platform MCP server for master orchestrator.
+            // The 'stdio' marker is resolved to an in-process SDK MCP server
+            // by ProcessManager.resolveMcpServers() at execution time.
+            const baseMcpServers = parsed.mcp_servers as Record<string, unknown> | undefined;
+            const mcp_servers = isMaster
+                ? { ...baseMcpServers, 'xerus-platform': { type: 'stdio' } }
+                : baseMcpServers;
+
             return {
                 agent_slug: agentSlug,
                 system_prompt,
                 model: String(parsed.model || DEFAULT_SDK_MODEL),
                 tools,
                 max_turns: Number(parsed.max_turns) || 50,
-                mcp_servers: parsed.mcp_servers as Record<string, unknown> | undefined,
+                mcp_servers,
                 cwd,
                 name: parsed.name as string | undefined,
                 description: parsed.description as string | undefined,


### PR DESCRIPTION
## Summary

- **Root cause**: Xerus Master's `config.json` has `platform_tools` (tool name list) but no `mcp_servers` field. `AgentConfigLoader` reads `parsed.mcp_servers` (undefined), so `ProcessManager` never creates the platform MCP server. The 32 platform tools described in the system prompt were never actually available.
- **Symptom**: Master agent runs 40+ aimless filesystem exploration calls (`find`, `ls`, `grep` via Bash) instead of using `platform.list_agents`, `platform.get_status`, etc.
- **Fix**: Auto-inject `{ 'xerus-platform': { type: 'stdio' } }` in `AgentConfigLoader.loadConfig()` when agent is master. `ProcessManager.resolveMcpServers()` already handles the `stdio` marker by replacing it with `createPlatformMcpServer()`. No config.json change needed.

## Test plan

- [ ] Verify `AgentConfigLoader.loadConfig('xerus-master')` returns config with `mcp_servers: { 'xerus-platform': { type: 'stdio' } }`
- [ ] Verify non-master agents still get `undefined` for `mcp_servers` (unless they have their own)
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] End-to-end: send "list my agents" to Xerus Master, verify it uses `platform.list_agents` instead of filesystem exploration

🤖 Generated with [Claude Code](https://claude.com/claude-code)