### PR TITLE
feat(workspace): restructure shared/ → drive/, add connections + tags

### DIFF
--- a/xerus_backend/src/domains/conversations/workspace-db.helpers.ts
+++ b/xerus_backend/src/domains/conversations/workspace-db.helpers.ts
@@ -15,6 +15,10 @@ export const WORKSPACE_DB_PATH = `${SANDBOX_CONFIG.workspacePath}/data/workspace
 const ESCAPED_DB_PATH = shellEscapePath(WORKSPACE_DB_PATH);
 
 export function escapeSQL(value: string): string {
+    // Reject newlines to prevent heredoc termination injection
+    if (/[\n\r]/.test(value)) {
+        throw new Error('SQL value must not contain newlines');
+    }
     // Strip null bytes (prevents SQLite string literal termination), then escape single quotes
     return value.replace(/\0/g, '').replace(/'/g, "''");
 }

--- a/xerus_backend/src/domains/drive/connections.routes.ts
+++ b/xerus_backend/src/domains/drive/connections.routes.ts
@@ -1,0 +1,133 @@
+// Connections Routes
+// REST endpoints for file_connections table in workspace.db:
+// - GET    /connections?file_path=...  -> connections for a file
+// - GET    /connections?target_type=...&target_ref=...  -> files connected to a target
+// - POST   /connections               -> create connection
+// - DELETE /connections/:id            -> remove connection
+
+import { Router, Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../../types';
+import { sendResponse } from '../../utils/response';
+import { BadRequestError, UnauthorizedError } from '../../utils/errors';
+import { authenticateFirebaseToken } from '../../middleware/auth';
+import { requireRunningSandbox, getDaytonaProvider } from '../sandbox-infra/sandbox/sandbox-route-helpers';
+import type { SandboxService } from '../sandbox-infra/sandbox/sandbox.service';
+import { validateDrivePath } from './drive-path-validator';
+import {
+    getConnectionsForFile,
+    getConnectionsForTarget,
+    createConnection,
+    deleteConnection,
+} from './connections.service';
+
+// -----------------------------------------------------------------------------
+// Types for dependency injection
+// -----------------------------------------------------------------------------
+
+export interface ConnectionsRouteDeps {
+    sandboxService: SandboxService;
+}
+
+// -----------------------------------------------------------------------------
+// Factory: creates the connections sub-router
+// -----------------------------------------------------------------------------
+
+const VALID_TARGET_TYPES = ['agent', 'channel', 'file'];
+
+export function createConnectionsRouter(deps: ConnectionsRouteDeps): Router {
+    const router = Router();
+    const auth = authenticateFirebaseToken;
+
+    // GET /connections?file_path=... OR ?target_type=...&target_ref=...
+    router.get('/connections', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            const filePath = req.query.file_path as string | undefined;
+            const targetType = req.query.target_type as string | undefined;
+            const targetRef = req.query.target_ref as string | undefined;
+
+            if (filePath) {
+                const connections = await getConnectionsForFile(provider, sandboxId, filePath);
+                sendResponse(res, 200, { connections }, startTime);
+            } else if (targetType && targetRef) {
+                if (!VALID_TARGET_TYPES.includes(targetType)) {
+                    throw new BadRequestError(`target_type must be one of: ${VALID_TARGET_TYPES.join(', ')}`);
+                }
+                const connections = await getConnectionsForTarget(provider, sandboxId, targetType, targetRef);
+                sendResponse(res, 200, { connections }, startTime);
+            } else {
+                throw new BadRequestError('Either file_path or both target_type and target_ref query params are required');
+            }
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    // POST /connections { file_path, target_type, target_ref }
+    router.post('/connections', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const { file_path, target_type, target_ref } = req.body;
+
+            if (typeof file_path !== 'string' || !file_path) {
+                throw new BadRequestError('file_path is required');
+            }
+            if (file_path.length > 1024) {
+                throw new BadRequestError('file_path too long');
+            }
+            if (typeof target_type !== 'string' || !VALID_TARGET_TYPES.includes(target_type)) {
+                throw new BadRequestError(`target_type must be one of: ${VALID_TARGET_TYPES.join(', ')}`);
+            }
+            if (typeof target_ref !== 'string' || !target_ref) {
+                throw new BadRequestError('target_ref is required');
+            }
+            if (target_ref.length > 256) {
+                throw new BadRequestError('target_ref too long');
+            }
+
+            // Validate path to prevent traversal and injection
+            const validatedPath = validateDrivePath(file_path);
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            const connection = await createConnection(
+                provider, sandboxId, validatedPath, target_type, target_ref, req.user.uid,
+            );
+
+            sendResponse(res, 201, { connection }, startTime);
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    // DELETE /connections/:id
+    router.delete('/connections/:id', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const id = parseInt(req.params.id, 10);
+            if (isNaN(id)) {
+                throw new BadRequestError('id must be a number');
+            }
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            await deleteConnection(provider, sandboxId, id);
+            sendResponse(res, 200, { deleted: true, id }, startTime);
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    return router;
+}

--- a/xerus_backend/src/domains/drive/connections.service.ts
+++ b/xerus_backend/src/domains/drive/connections.service.ts
@@ -1,0 +1,113 @@
+// Connections Service
+// CRUD for file_connections table in workspace.db (SQLite on sandbox).
+// Links files in drive/ to agents, channels, or other files.
+// Reference: docs/planning/workspace-redesign.md Section 4
+
+import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona.provider';
+import { escapeSQL, executeWorkspaceQuery, executeWorkspaceJsonQuery } from '../conversations/workspace-db.helpers';
+
+// Auto-create table if missing (handles unmigrated sandboxes)
+const ENSURE_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS file_connections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT NOT NULL,
+    target_type TEXT NOT NULL CHECK(target_type IN ('agent','channel','file')),
+    target_ref TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    created_by TEXT,
+    UNIQUE(file_path, target_type, target_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_fc_target ON file_connections(target_type, target_ref);
+CREATE INDEX IF NOT EXISTS idx_fc_file ON file_connections(file_path);
+`;
+
+const ensured = new Set<string>();
+
+async function ensureTable(provider: DaytonaProvider, sandboxId: string): Promise<void> {
+    if (ensured.has(sandboxId)) return;
+    await executeWorkspaceQuery(provider, sandboxId, ENSURE_TABLE_SQL);
+    ensured.add(sandboxId);
+}
+
+// -----------------------------------------------------------------------------
+// Types (mirror workspace-schema.sql file_connections table)
+// -----------------------------------------------------------------------------
+
+export interface FileConnectionRow {
+    id: number;
+    file_path: string;
+    target_type: 'agent' | 'channel' | 'file';
+    target_ref: string;
+    created_at: string;
+    created_by: string | null;
+}
+
+// -----------------------------------------------------------------------------
+// Queries
+// -----------------------------------------------------------------------------
+
+export async function getConnectionsForFile(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    filePath: string,
+): Promise<FileConnectionRow[]> {
+    const sql = `
+        SELECT id, file_path, target_type, target_ref, created_at, created_by
+        FROM file_connections
+        WHERE file_path = '${escapeSQL(filePath)}'
+        ORDER BY created_at DESC
+    `;
+    await ensureTable(provider, sandboxId);
+    return executeWorkspaceJsonQuery<FileConnectionRow>(provider, sandboxId, sql);
+}
+
+export async function getConnectionsForTarget(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    targetType: string,
+    targetRef: string,
+): Promise<FileConnectionRow[]> {
+    const sql = `
+        SELECT id, file_path, target_type, target_ref, created_at, created_by
+        FROM file_connections
+        WHERE target_type = '${escapeSQL(targetType)}' AND target_ref = '${escapeSQL(targetRef)}'
+        ORDER BY created_at DESC
+    `;
+    await ensureTable(provider, sandboxId);
+    return executeWorkspaceJsonQuery<FileConnectionRow>(provider, sandboxId, sql);
+}
+
+export async function createConnection(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    filePath: string,
+    targetType: string,
+    targetRef: string,
+    createdBy: string,
+): Promise<FileConnectionRow> {
+    const sql = `
+        INSERT OR IGNORE INTO file_connections (file_path, target_type, target_ref, created_by)
+        VALUES ('${escapeSQL(filePath)}', '${escapeSQL(targetType)}', '${escapeSQL(targetRef)}', '${escapeSQL(createdBy)}');
+        SELECT id, file_path, target_type, target_ref, created_at, created_by
+        FROM file_connections
+        WHERE file_path = '${escapeSQL(filePath)}'
+          AND target_type = '${escapeSQL(targetType)}'
+          AND target_ref = '${escapeSQL(targetRef)}'
+    `;
+    await ensureTable(provider, sandboxId);
+    const rows = await executeWorkspaceJsonQuery<FileConnectionRow>(provider, sandboxId, sql);
+    if (!rows[0]) {
+        throw new Error(`Failed to create connection for ${filePath}`);
+    }
+    return rows[0];
+}
+
+export async function deleteConnection(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    id: number,
+): Promise<void> {
+    const sql = `DELETE FROM file_connections WHERE id = ${id}`;
+    await ensureTable(provider, sandboxId);
+    await executeWorkspaceQuery(provider, sandboxId, sql);
+}

--- a/xerus_backend/src/domains/drive/drive-upload.routes.ts
+++ b/xerus_backend/src/domains/drive/drive-upload.routes.ts
@@ -71,7 +71,7 @@ export function createUploadRouter(deps: UploadRouteDeps): Router {
     const router = Router();
     const auth = authenticateFirebaseToken;
 
-    // POST /upload?path=shared/knowledge/
+    // POST /upload?path=drive/
     router.post(
         '/upload',
         auth,
@@ -89,20 +89,20 @@ export function createUploadRouter(deps: UploadRouteDeps): Router {
 
                 const targetPath = String(req.query.path || '');
                 if (!targetPath) {
-                    throw new BadRequestError('path query parameter is required (e.g., shared/knowledge/)');
+                    throw new BadRequestError('path query parameter is required (e.g., drive/)');
                 }
 
                 const normalized = validateDrivePath(targetPath.endsWith('/') ? `${targetPath}placeholder` : targetPath);
                 const targetDir = normalized.replace(/\/placeholder$/, '').replace(/[^/]+$/, '');
 
-                const isKnowledgePath =
-                    targetDir.startsWith('shared/knowledge') ||
+                const isUploadablePath =
+                    targetDir.startsWith('drive') ||
                     /^agents\/[^/]+\/knowledge/.test(targetDir) ||
                     /^projects\/[^/]+\/knowledge/.test(targetDir);
 
-                if (!isKnowledgePath) {
+                if (!isUploadablePath) {
                     throw new BadRequestError(
-                        'Uploads are only allowed to knowledge directories (shared/knowledge/, agents/*/knowledge/, projects/*/knowledge/)',
+                        'Uploads are only allowed to drive/ or knowledge directories (drive/, agents/*/knowledge/, projects/*/knowledge/)',
                     );
                 }
 

--- a/xerus_backend/src/domains/drive/drive.routes.ts
+++ b/xerus_backend/src/domains/drive/drive.routes.ts
@@ -24,6 +24,9 @@ import { InMemoryWorkspaceSSEBroadcaster } from './workspace-sse.broadcaster';
 import type { FileChangeAction } from './workspace-sse.broadcaster';
 import { createUploadRouter } from './drive-upload.routes';
 import { createLifecycleRouter } from './drive-lifecycle.routes';
+import { createConnectionsRouter } from './connections.routes';
+import { createTagsRouter } from './tags.routes';
+import type { SandboxService } from '../sandbox-infra/sandbox/sandbox.service';
 
 function getContentType(filePath: string): string {
     const ext = path.extname(filePath).toLowerCase();
@@ -86,8 +89,10 @@ function getContentType(filePath: string): string {
 
 let driveServiceInstance: DriveService | null = null;
 
-export function setDriveDeps(service: DriveService): void {
+export function setDriveDeps(service: DriveService, sandboxService: SandboxService): void {
     driveServiceInstance = service;
+    router.use(createConnectionsRouter({ sandboxService }));
+    router.use(createTagsRouter({ sandboxService }));
 }
 
 function getDriveService(): DriveService {

--- a/xerus_backend/src/domains/drive/editability.ts
+++ b/xerus_backend/src/domains/drive/editability.ts
@@ -29,7 +29,7 @@ const EDITABLE_PATTERNS: RegExp[] = [
     /^agents\/[^/]+\/config\.json$/,
     /^agents\/[^/]+\/HEARTBEAT\.md$/,
     /^agents\/[^/]+\/knowledge\/.+/,
-    /^shared\/knowledge\/.+/,
+    /^drive\/.+/,
     /^projects\/[^/]+\/knowledge\/.+/,
 ];
 

--- a/xerus_backend/src/domains/drive/index.ts
+++ b/xerus_backend/src/domains/drive/index.ts
@@ -1,5 +1,5 @@
 // Drive - Barrel Export
-// Workspace Drive feature: file browser, editor, upload, status
+// Workspace Drive feature: file browser, editor, upload, status, connections, tags
 
 export { DriveService } from './drive.service';
 export { setDriveDeps, workspaceSSEBroadcaster } from './drive.routes';
@@ -19,3 +19,5 @@ export type {
     ChannelOverview,
     DocumentOverview,
 } from './types';
+export type { FileConnectionRow } from './connections.service';
+export type { FileTagRow, TagCount } from './tags.service';

--- a/xerus_backend/src/domains/drive/tags.routes.ts
+++ b/xerus_backend/src/domains/drive/tags.routes.ts
@@ -1,0 +1,140 @@
+// Tags Routes
+// REST endpoints for file_tags table in workspace.db:
+// - GET    /tags?file_path=...  -> tags for a file
+// - GET    /tags?tag=...        -> files with a tag
+// - POST   /tags                -> add tag to a file
+// - DELETE /tags/:id            -> remove tag
+// - GET    /tags/list           -> list all unique tags with counts
+
+import { Router, Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../../types';
+import { sendResponse } from '../../utils/response';
+import { BadRequestError, UnauthorizedError } from '../../utils/errors';
+import { authenticateFirebaseToken } from '../../middleware/auth';
+import { requireRunningSandbox, getDaytonaProvider } from '../sandbox-infra/sandbox/sandbox-route-helpers';
+import type { SandboxService } from '../sandbox-infra/sandbox/sandbox.service';
+import { validateDrivePath } from './drive-path-validator';
+import {
+    getTagsForFile,
+    getFilesByTag,
+    createTag,
+    deleteTag,
+    listTags,
+} from './tags.service';
+
+// -----------------------------------------------------------------------------
+// Types for dependency injection
+// -----------------------------------------------------------------------------
+
+export interface TagsRouteDeps {
+    sandboxService: SandboxService;
+}
+
+// -----------------------------------------------------------------------------
+// Factory: creates the tags sub-router
+// -----------------------------------------------------------------------------
+
+export function createTagsRouter(deps: TagsRouteDeps): Router {
+    const router = Router();
+    const auth = authenticateFirebaseToken;
+
+    // GET /tags/list — list all unique tags with file counts
+    // Defined before /tags to avoid matching /tags/:id pattern conflicts
+    router.get('/tags/list', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            const tags = await listTags(provider, sandboxId);
+            sendResponse(res, 200, { tags }, startTime);
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    // GET /tags?file_path=... OR ?tag=...
+    router.get('/tags', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            const filePath = req.query.file_path as string | undefined;
+            const tag = req.query.tag as string | undefined;
+
+            if (filePath) {
+                const tags = await getTagsForFile(provider, sandboxId, filePath);
+                sendResponse(res, 200, { tags }, startTime);
+            } else if (tag) {
+                const files = await getFilesByTag(provider, sandboxId, tag);
+                sendResponse(res, 200, { files }, startTime);
+            } else {
+                throw new BadRequestError('Either file_path or tag query param is required');
+            }
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    // POST /tags { file_path, tag }
+    router.post('/tags', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const { file_path, tag } = req.body;
+
+            if (typeof file_path !== 'string' || !file_path) {
+                throw new BadRequestError('file_path is required');
+            }
+            if (file_path.length > 1024) {
+                throw new BadRequestError('file_path too long');
+            }
+            if (typeof tag !== 'string' || !tag) {
+                throw new BadRequestError('tag is required');
+            }
+            if (tag.length > 128) {
+                throw new BadRequestError('tag too long');
+            }
+
+            // Validate path to prevent traversal and injection
+            const validatedPath = validateDrivePath(file_path);
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            const created = await createTag(provider, sandboxId, validatedPath, tag);
+            sendResponse(res, 201, { tag: created }, startTime);
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    // DELETE /tags/:id
+    router.delete('/tags/:id', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const startTime = res.locals.startTime || Date.now();
+        try {
+            if (!req.user) throw new UnauthorizedError();
+
+            const id = parseInt(req.params.id, 10);
+            if (isNaN(id)) {
+                throw new BadRequestError('id must be a number');
+            }
+
+            const sandboxId = await requireRunningSandbox(deps.sandboxService, req.user.uid);
+            const provider = getDaytonaProvider(deps.sandboxService);
+
+            await deleteTag(provider, sandboxId, id);
+            sendResponse(res, 200, { deleted: true, id }, startTime);
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    return router;
+}

--- a/xerus_backend/src/domains/drive/tags.service.ts
+++ b/xerus_backend/src/domains/drive/tags.service.ts
@@ -1,0 +1,122 @@
+// Tags Service
+// CRUD for file_tags table in workspace.db (SQLite on sandbox).
+// User-defined labels on files in drive/.
+// Reference: docs/planning/workspace-redesign.md Section 4
+
+import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona.provider';
+import { escapeSQL, executeWorkspaceQuery, executeWorkspaceJsonQuery } from '../conversations/workspace-db.helpers';
+
+const ENSURE_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS file_tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    UNIQUE(file_path, tag)
+);
+CREATE INDEX IF NOT EXISTS idx_ft_tag ON file_tags(tag);
+CREATE INDEX IF NOT EXISTS idx_ft_file ON file_tags(file_path);
+`;
+
+const ensured = new Set<string>();
+
+async function ensureTable(provider: DaytonaProvider, sandboxId: string): Promise<void> {
+    if (ensured.has(sandboxId)) return;
+    await executeWorkspaceQuery(provider, sandboxId, ENSURE_TABLE_SQL);
+    ensured.add(sandboxId);
+}
+
+// -----------------------------------------------------------------------------
+// Types (mirror workspace-schema.sql file_tags table)
+// -----------------------------------------------------------------------------
+
+export interface FileTagRow {
+    id: number;
+    file_path: string;
+    tag: string;
+    created_at: string;
+}
+
+export interface TagCount {
+    tag: string;
+    count: number;
+}
+
+// -----------------------------------------------------------------------------
+// Queries
+// -----------------------------------------------------------------------------
+
+export async function getTagsForFile(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    filePath: string,
+): Promise<FileTagRow[]> {
+    const sql = `
+        SELECT id, file_path, tag, created_at
+        FROM file_tags
+        WHERE file_path = '${escapeSQL(filePath)}'
+        ORDER BY tag
+    `;
+    await ensureTable(provider, sandboxId);
+    return executeWorkspaceJsonQuery<FileTagRow>(provider, sandboxId, sql);
+}
+
+export async function getFilesByTag(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    tag: string,
+): Promise<FileTagRow[]> {
+    const sql = `
+        SELECT id, file_path, tag, created_at
+        FROM file_tags
+        WHERE tag = '${escapeSQL(tag)}'
+        ORDER BY file_path
+    `;
+    await ensureTable(provider, sandboxId);
+    return executeWorkspaceJsonQuery<FileTagRow>(provider, sandboxId, sql);
+}
+
+export async function createTag(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    filePath: string,
+    tag: string,
+): Promise<FileTagRow> {
+    const sql = `
+        INSERT OR IGNORE INTO file_tags (file_path, tag)
+        VALUES ('${escapeSQL(filePath)}', '${escapeSQL(tag)}');
+        SELECT id, file_path, tag, created_at
+        FROM file_tags
+        WHERE file_path = '${escapeSQL(filePath)}' AND tag = '${escapeSQL(tag)}'
+    `;
+    await ensureTable(provider, sandboxId);
+    const rows = await executeWorkspaceJsonQuery<FileTagRow>(provider, sandboxId, sql);
+    if (!rows[0]) {
+        throw new Error(`Failed to create tag for ${filePath}`);
+    }
+    return rows[0];
+}
+
+export async function deleteTag(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    id: number,
+): Promise<void> {
+    const sql = `DELETE FROM file_tags WHERE id = ${id}`;
+    await ensureTable(provider, sandboxId);
+    await executeWorkspaceQuery(provider, sandboxId, sql);
+}
+
+export async function listTags(
+    provider: DaytonaProvider,
+    sandboxId: string,
+): Promise<TagCount[]> {
+    const sql = `
+        SELECT tag, COUNT(*) as count
+        FROM file_tags
+        GROUP BY tag
+        ORDER BY count DESC, tag
+    `;
+    await ensureTable(provider, sandboxId);
+    return executeWorkspaceJsonQuery<TagCount>(provider, sandboxId, sql);
+}

--- a/xerus_backend/src/domains/drive/workspace-overview.ts
+++ b/xerus_backend/src/domains/drive/workspace-overview.ts
@@ -74,11 +74,10 @@ async function extractAgentsFromChannel(channel: FileNode, readFile?: FileReader
 }
 
 function extractDocuments(root: FileNode): DocumentOverview[] {
-    const sharedDir = root.children?.find(c => c.name === 'shared' && c.type === 'directory');
-    const knowledgeDir = sharedDir?.children?.find(c => c.name === 'knowledge' && c.type === 'directory');
-    if (!knowledgeDir?.children) return [];
+    const driveDir = root.children?.find(c => c.name === 'drive' && c.type === 'directory');
+    if (!driveDir?.children) return [];
 
-    return knowledgeDir.children
+    return driveDir.children
         .filter(c => c.type === 'file' && c.name !== '.gitkeep')
         .map(f => ({ name: f.name, path: f.path }));
 }

--- a/xerus_backend/src/domains/execution/__tests__/agent-behavior.test.ts
+++ b/xerus_backend/src/domains/execution/__tests__/agent-behavior.test.ts
@@ -54,9 +54,7 @@ async function createTestWorkspace(): Promise<AgentWorkspace> {
         'agents',
         '.memory/agents/xerus-master',
         '.memory/agents/xerus-cto',
-        'shared/knowledge',
-        'shared/office',
-        'shared/standup',
+        'drive',
         'data',
         'projects',
     ];
@@ -85,11 +83,11 @@ async function createTestWorkspace(): Promise<AgentWorkspace> {
     // Copy company.md template
     try {
         await fs.copyFile(
-            path.join(WORKSPACE_TEMPLATE, 'shared', 'knowledge', 'company.md'),
-            path.join(root, 'shared', 'knowledge', 'company.md'),
+            path.join(WORKSPACE_TEMPLATE, 'drive', 'company.md'),
+            path.join(root, 'drive', 'company.md'),
         );
     } catch {
-        await fs.writeFile(path.join(root, 'shared', 'knowledge', 'company.md'), '# Company\n\n## Vision\n{TODO}\n');
+        await fs.writeFile(path.join(root, 'drive', 'company.md'), '# Company\n\n## Vision\n{TODO}\n');
     }
 
     // Initialize memory
@@ -99,7 +97,7 @@ async function createTestWorkspace(): Promise<AgentWorkspace> {
     );
 
     // Initialize activity log
-    await fs.writeFile(path.join(root, 'shared', 'activity.jsonl'), '');
+    await fs.writeFile(path.join(root, 'data', 'activity.jsonl'), '');
 
     // Copy hook scripts so tests can execute them
     const hookScripts = ['scaffold-sync-hook.sh', '_lib.sh'];
@@ -209,7 +207,7 @@ describe('Agent Behavior Specifications', () => {
 
             // Expected outputs after bootstrap completes:
             const expectedOutputs = {
-                'company.md populated': 'shared/knowledge/company.md should NOT contain {TODO}',
+                'company.md populated': 'drive/company.md should NOT contain {TODO}',
                 'project created': 'at least one directory under projects/',
                 'channel created': 'at least one CLAUDE.md under projects/*/channels/*/',
                 'STATUS.md updated': '.claude/agents/xerus-master/STATUS.md should not contain "Bootstrap"',
@@ -268,7 +266,7 @@ Generated: 2026-04-07T10:00:00Z
 ## Current Task
 - **ID**: task-001
 - **Title**: Write a company overview document
-- **Description**: Create shared/knowledge/company-overview.md with a brief description of the workspace
+- **Description**: Create drive/company-overview.md with a brief description of the workspace
 - **Priority**: 1 (high)
 - **Channel**: projects/default/channels/general
 `);
@@ -281,7 +279,7 @@ Generated: 2026-04-07T10:00:00Z
             // 5. Updates working.md
 
             const expectedOutputs = {
-                'task_output_created': 'shared/knowledge/company-overview.md should exist',
+                'task_output_created': 'drive/company-overview.md should exist',
                 'task_closed': '.beads/issues.jsonl should have a closed entry',
                 'completion_posted': 'output/posts.jsonl should have a post from xerus-master',
                 'working_updated': '.memory/agents/xerus-master/working.md should reflect task completion',

--- a/xerus_backend/src/domains/execution/hooks/__tests__/scaffold-sync-hook.test.ts
+++ b/xerus_backend/src/domains/execution/hooks/__tests__/scaffold-sync-hook.test.ts
@@ -51,7 +51,6 @@ async function createWorkspaceStructure(root: string): Promise<void> {
     await fs.mkdir(path.join(root, 'agents'), { recursive: true });
     await fs.mkdir(path.join(root, '.memory', 'agents'), { recursive: true });
     await fs.mkdir(path.join(root, '.xerus'), { recursive: true });
-    await fs.mkdir(path.join(root, 'shared'), { recursive: true });
     await fs.mkdir(path.join(root, 'data'), { recursive: true });
     await fs.mkdir(path.join(root, 'projects'), { recursive: true });
 
@@ -76,8 +75,8 @@ async function createWorkspaceStructure(root: string): Promise<void> {
         execSync(`sqlite3 "${dbPath}" < "${SCHEMA_FILE}"`, { stdio: 'pipe' });
     }
 
-    // Initialize shared/activity.jsonl
-    await fs.writeFile(path.join(root, 'shared', 'activity.jsonl'), '');
+    // Initialize data/activity.jsonl
+    await fs.writeFile(path.join(root, 'data', 'activity.jsonl'), '');
 }
 
 function runHook(root: string, toolName: string, filePath: string): { stdout: string; stderr: string; exitCode: number } {
@@ -350,7 +349,7 @@ describeIfBash('scaffold-sync-hook.sh', () => {
 
     describe('non-matching paths', () => {
         it('does nothing for unrelated file writes', async () => {
-            const result = runHook(tmpDir, 'Write', path.join(tmpDir, 'shared', 'knowledge', 'company.md'));
+            const result = runHook(tmpDir, 'Write', path.join(tmpDir, 'drive', 'company.md'));
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe('');
         });

--- a/xerus_backend/src/domains/execution/hooks/session-end.hook.ts
+++ b/xerus_backend/src/domains/execution/hooks/session-end.hook.ts
@@ -33,7 +33,7 @@ import type {
  * 6. Emit SSE session_ended - Notify frontend
  * 7. Sandbox Lifecycle Decision - Pause sandbox if appropriate
  * 8. Check Skill Creation - Suggest skill if novel problem solved
- * 9. Append Activity Log - Write to shared/activity.jsonl (last, least critical)
+ * 9. Append Activity Log - Write to data/activity.jsonl (last, least critical)
  *
  * ARCHITECTURE (Feb 2025): Git-based memory
  * - .memory/ Git repo is source of truth
@@ -83,7 +83,7 @@ export class SessionEndHandler {
             result.channel_notified = true;
         }
 
-        // 9. Append to shared/activity.jsonl (agent-visible execution trace)
+        // 9. Append to data/activity.jsonl (agent-visible execution trace)
         // Runs last: all critical work above is already complete.
         await this.appendActivityEntry(input);
 
@@ -193,7 +193,7 @@ export class SessionEndHandler {
     }
 
     /**
-     * Append execution summary to shared/activity.jsonl.
+     * Append execution summary to data/activity.jsonl.
      * Gives Xerus master and other agents visibility into what ran.
      * ~150-200 bytes per entry. Runs after all critical steps in handle().
      */

--- a/xerus_backend/src/domains/execution/hooks/session-end.types.ts
+++ b/xerus_backend/src/domains/execution/hooks/session-end.types.ts
@@ -199,7 +199,7 @@ export interface DRMCompressor {
 }
 
 /**
- * Interface for appending execution traces to shared/activity.jsonl.
+ * Interface for appending execution traces to data/activity.jsonl.
  * Gives agents (especially Xerus master) visibility into what ran.
  */
 export interface ActivityWriter {
@@ -207,7 +207,7 @@ export interface ActivityWriter {
 }
 
 /**
- * Single entry in shared/activity.jsonl.
+ * Single entry in data/activity.jsonl.
  * ~150-200 bytes per line. Rolling 7-day window (trimmed by daily digest).
  */
 export interface ActivityEntry {

--- a/xerus_backend/src/domains/execution/runner/session-hook-builders.ts
+++ b/xerus_backend/src/domains/execution/runner/session-hook-builders.ts
@@ -197,7 +197,7 @@ export function buildSessionEndHandlers(
             drmCompressor: createSandboxDRMCompressor(gitRepo, executor, emitter, ctx.agentSlug),
             activityWriter: {
                 appendEntry: async (entry) => {
-                    const activityPath = path.join(ctx.workspacePath, 'shared', 'activity.jsonl');
+                    const activityPath = path.join(ctx.workspacePath, 'data', 'activity.jsonl');
                     const dir = path.dirname(activityPath);
                     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
                     fs.appendFileSync(activityPath, JSON.stringify(entry) + '\n', 'utf-8');

--- a/xerus_backend/src/domains/inbox/messaging/__tests__/messaging.service.test.ts
+++ b/xerus_backend/src/domains/inbox/messaging/__tests__/messaging.service.test.ts
@@ -309,7 +309,7 @@ describe('MessageRouter', () => {
 
             await router.routeMessage(message);
 
-            const inboxPath = `/workspace/shared/inbox/${RESEARCHER}/inbox.md`;
+            const inboxPath = `/workspace/agents/${RESEARCHER}/inbox/inbox.md`;
             const content = workspaceWriter.getContent(inboxPath);
 
             expect(content).toContain(`**From**: ${ANALYST}`);
@@ -336,7 +336,7 @@ describe('MessageRouter', () => {
             await router.routeMessage(message1);
             await router.routeMessage(message2);
 
-            const inboxPath = `/workspace/shared/inbox/${RESEARCHER}/inbox.md`;
+            const inboxPath = `/workspace/agents/${RESEARCHER}/inbox/inbox.md`;
             const content = workspaceWriter.getContent(inboxPath);
 
             expect(content).toContain('First message');
@@ -384,7 +384,7 @@ describe('MessageRouter', () => {
 
             const result = await router.routeMessage(message);
 
-            expect(result.inbox_path).toBe(`/my/workspace/shared/inbox/${RESEARCHER}/inbox.md`);
+            expect(result.inbox_path).toBe(`/my/workspace/agents/${RESEARCHER}/inbox/inbox.md`);
         });
     });
 });

--- a/xerus_backend/src/domains/inbox/messaging/messaging.service.ts
+++ b/xerus_backend/src/domains/inbox/messaging/messaging.service.ts
@@ -156,11 +156,11 @@ export class MessageRouter {
     // -------------------------------------------------------------------------
 
     private generateInboxPath(workspacePath: string, targetSlug: string): string {
-        return `${workspacePath}/shared/inbox/${targetSlug}/inbox.md`;
+        return `${workspacePath}/agents/${targetSlug}/inbox/inbox.md`;
     }
 
     private getInboxDirectory(workspacePath: string, targetSlug: string): string {
-        return `${workspacePath}/shared/inbox/${targetSlug}`;
+        return `${workspacePath}/agents/${targetSlug}/inbox`;
     }
 
     private formatInboxMessage(message: InboxMessage): string {

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/__tests__/hook-health.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/__tests__/hook-health.test.ts
@@ -30,7 +30,7 @@ describe('hook-health', () => {
             expect(cmd).toContain("echo '---HOOKS---'");
             expect(cmd).toContain('.xerus/hook-audit.jsonl');
             expect(cmd).toContain("echo '---ACTIVITY---'");
-            expect(cmd).toContain('shared/activity.jsonl');
+            expect(cmd).toContain('data/activity.jsonl');
             expect(cmd).toContain("echo '---DBTABLES---'");
             expect(cmd).toContain('data/company.db');
             // shellEscape wraps path in single quotes

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/hook-health.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/hook-health.ts
@@ -1,6 +1,6 @@
 // Hook Health Check
 // Post-execution verification of shell hook side effects.
-// Reads .xerus/hook-audit.jsonl, shared/activity.jsonl, and company.db status
+// Reads .xerus/hook-audit.jsonl, data/activity.jsonl, and company.db status
 // from the sandbox via a single compound shell command.
 // See: docs/planning/execution/ (Shell Hook Observability)
 
@@ -31,7 +31,7 @@ const SENTINEL_DBTABLES = '---DBTABLES---';
 export function buildHealthCheckCommand(workspacePath: string): string {
     const base = shellEscape(workspacePath);
     const auditFile = `${base}/.xerus/hook-audit.jsonl`;
-    const activityFile = `${base}/shared/activity.jsonl`;
+    const activityFile = `${base}/data/activity.jsonl`;
     const dbFile = `${base}/data/company.db`;
 
     return [

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox.config.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox.config.ts
@@ -85,7 +85,7 @@ export const BACKUP_TAR_EXCLUDES = [
     '.xerus/manifest.yaml',
     'data/schema.sql',
     'data/workspace-schema.sql',
-    'shared/knowledge/TOOL_GUIDE.md',
+    '.claude/rules/TOOL_GUIDE.md',
 ] as const;
 
 // Pre-built tar exclude flags for shell commands

--- a/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/channel-claude-md.template.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/channel-claude-md.template.test.ts
@@ -52,14 +52,14 @@ describe('generateChannelClaudeMd', () => {
         const params: ChannelClaudeMdParams = {
             ...DEFAULT_PARAMS,
             sharedResources: [
-                'shared/knowledge/brand-guide.md',
-                'shared/knowledge/seo-playbook.md',
+                'drive/brand-guide.md',
+                'drive/seo-playbook.md',
             ],
         };
         const result = generateChannelClaudeMd(params);
         expect(result).toContain('## Resources');
-        expect(result).toContain('shared/knowledge/brand-guide.md');
-        expect(result).toContain('shared/knowledge/seo-playbook.md');
+        expect(result).toContain('drive/brand-guide.md');
+        expect(result).toContain('drive/seo-playbook.md');
     });
 
     it('should omit resources section when no shared resources', () => {

--- a/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/workspace.manager.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/workspace.manager.test.ts
@@ -433,16 +433,8 @@ describe('WorkspaceManager', () => {
             expect(manager.getMemoryPath()).toBe(`${basePath}/.memory`);
         });
 
-        it('getSharedPath returns shared directory', () => {
-            expect(manager.getSharedPath()).toBe(`${basePath}/shared`);
-        });
-
-        it('getSharedKnowledgePath returns shared/knowledge', () => {
-            expect(manager.getSharedKnowledgePath()).toBe(`${basePath}/shared/knowledge`);
-        });
-
-        it('getSharedInboxPath returns shared/inbox', () => {
-            expect(manager.getSharedInboxPath()).toBe(`${basePath}/shared/inbox`);
+        it('getDrivePath returns drive directory', () => {
+            expect(manager.getDrivePath()).toBe(`${basePath}/drive`);
         });
 
         it('getMarketplacePath returns marketplace directory', () => {
@@ -537,7 +529,7 @@ describe('WorkspaceManager', () => {
             expect(info.paths.agents).toBe(`${basePath}/agents`);
             expect(info.paths.projects).toBe(`${basePath}/projects`);
             expect(info.paths.memory).toBe(`${basePath}/.memory`);
-            expect(info.paths.shared).toBe(`${basePath}/shared`);
+            expect(info.paths.drive).toBe(`${basePath}/drive`);
             expect(info.paths.marketplace).toBe(`${basePath}/marketplace`);
             expect(info.paths.data).toBe(`${basePath}/data`);
             expect(info.paths.claude).toBe(`${basePath}/.claude`);
@@ -605,9 +597,9 @@ describe('Workspace Types', () => {
             expect(WORKSPACE_DIRECTORIES.memory).toBe('.memory');
             expect(WORKSPACE_DIRECTORIES.marketplace).toBe('marketplace');
             expect(WORKSPACE_DIRECTORIES.data).toBe('data');
-            expect(WORKSPACE_DIRECTORIES.shared).toBe('shared');
-            expect(WORKSPACE_DIRECTORIES.sharedKnowledge).toBe('shared/knowledge');
-            expect(WORKSPACE_DIRECTORIES.sharedInbox).toBe('shared/inbox');
+            expect(WORKSPACE_DIRECTORIES.drive).toBe('drive');
+            expect(WORKSPACE_DIRECTORIES.dataActivity).toBe('data/activity.jsonl');
+            expect(WORKSPACE_DIRECTORIES.claudeRules).toBe('.claude/rules');
         });
 
         it('should have claude subdirectory constants', () => {

--- a/xerus_backend/src/domains/sandbox-infra/workspace/workspace.manager.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/workspace.manager.ts
@@ -192,7 +192,7 @@ export class WorkspaceManager extends WorkspacePaths {
                 agents: agentsPath,
                 projects: this.getProjectsPath(),
                 memory: this.getMemoryPath(),
-                shared: this.getSharedPath(),
+                drive: this.getDrivePath(),
                 marketplace: this.getMarketplacePath(),
                 data: this.getDataPath(),
                 claude: this.getClaudePath(),

--- a/xerus_backend/src/domains/sandbox-infra/workspace/workspace.paths.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/workspace.paths.ts
@@ -38,24 +38,20 @@ export class WorkspacePaths {
         return this.resolve(WORKSPACE_DIRECTORIES.memory);
     }
 
-    getSharedPath(): string {
-        return this.resolve(WORKSPACE_DIRECTORIES.shared);
+    getDrivePath(): string {
+        return this.resolve(WORKSPACE_DIRECTORIES.drive);
     }
 
-    getSharedKnowledgePath(): string {
-        return this.resolve(WORKSPACE_DIRECTORIES.sharedKnowledge);
+    getDataActivityPath(): string {
+        return this.resolve(WORKSPACE_DIRECTORIES.dataActivity);
     }
 
-    getSharedInboxPath(): string {
-        return this.resolve(WORKSPACE_DIRECTORIES.sharedInbox);
+    getDataDashboardPath(): string {
+        return this.resolve(WORKSPACE_DIRECTORIES.dataDashboard);
     }
 
-    getSharedOfficePath(): string {
-        return this.resolve(WORKSPACE_DIRECTORIES.sharedOffice);
-    }
-
-    getSharedStandupPath(): string {
-        return this.resolve(WORKSPACE_DIRECTORIES.sharedStandup);
+    getClaudeRulesPath(): string {
+        return this.resolve(WORKSPACE_DIRECTORIES.claudeRules);
     }
 
     getMarketplacePath(): string {

--- a/xerus_backend/src/domains/sandbox-infra/workspace/workspace.types.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/workspace.types.ts
@@ -45,13 +45,15 @@ export const WORKSPACE_DIRECTORIES = {
     beads: '.beads',
     beadsIssues: '.beads/issues.jsonl',
 
-    // Shared resources
-    shared: 'shared',
-    sharedKnowledge: 'shared/knowledge',
-    sharedInbox: 'shared/inbox',
-    sharedOffice: 'shared/office',
-    sharedStandup: 'shared/standup',
-    sharedActivity: 'shared/activity.jsonl',
+    // User content
+    drive: 'drive',
+
+    // Operational data
+    dataActivity: 'data/activity.jsonl',
+    dataDashboard: 'data/dashboard',
+
+    // Agent governance rules
+    claudeRules: '.claude/rules',
 } as const;
 
 // Agent subdirectory structure (under agents/{slug}/)
@@ -129,7 +131,7 @@ export interface WorkspaceInfo {
         agents: string;
         projects: string;
         memory: string;
-        shared: string;
+        drive: string;
         marketplace: string;
         data: string;
         claude: string;

--- a/xerus_backend/src/index.ts
+++ b/xerus_backend/src/index.ts
@@ -268,7 +268,7 @@ async function startServer(): Promise<void> {
         setOnboardingDeps({ sandboxService });
         setUserRoutesDeps({ sandboxService });
 
-        setDriveDeps(new DriveService(sandboxService, backupService));
+        setDriveDeps(new DriveService(sandboxService, backupService), sandboxService);
 
         setSkillRoutesDeps({ sandboxService });
 

--- a/xerus_web/app/workspace/page.tsx
+++ b/xerus_web/app/workspace/page.tsx
@@ -26,8 +26,8 @@ import { cn } from '@/lib/utils'
 const SECTION_PATHS: Partial<Record<WorkspaceSection, string>> = {
   agents: 'agents',
   skills: 'marketplace',
-  connectors: 'shared',
-  knowledge: 'shared/knowledge',
+  connectors: 'connectors',
+  knowledge: 'drive',
   memory: '.memory',
   projects: 'projects',
 }
@@ -43,7 +43,7 @@ export default function WorkspacePage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
-  const [currentDirPath, setCurrentDirPath] = useState<string | null>(null)
+  const [currentDirPath, setCurrentDirPath] = useState<string | null>('drive')
   const [searchQuery, setSearchQuery] = useState('')
   const [activeFilter, setActiveFilter] = useState<FileFilter>('all')
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
@@ -128,7 +128,7 @@ export default function WorkspacePage() {
 
   const handleTreeSelect = useCallback((node: FileNode) => {
     if (node.type === 'directory') { setCurrentDirPath(node.path); setSelectedPath(node.path) }
-    else { openFileInEditor(node); setCurrentDirPath(node.path.includes('/') ? node.path.split('/').slice(0, -1).join('/') : null) }
+    else { openFileInEditor(node); setCurrentDirPath(node.path.includes('/') ? node.path.split('/').slice(0, -1).join('/') : 'drive') }
   }, [openFileInEditor])
 
   const handleDirClick = useCallback((node: FileNode) => { setCurrentDirPath(node.path); setSelectedPath(node.path) }, [])
@@ -153,7 +153,7 @@ export default function WorkspacePage() {
       prevSectionRef.current = activeSection
       setDetailView(null)
       if (activeSection === 'files' || activeSection === 'browse') {
-        if (activeSection === 'files') setCurrentDirPath(null)
+        if (activeSection === 'files') setCurrentDirPath('drive')
         setContentViewMode('browse')
       } else {
         const sectionPath = SECTION_PATHS[activeSection]
@@ -176,7 +176,7 @@ export default function WorkspacePage() {
           const fileName = parts[parts.length - 1]
           setOpenTabs(prev => prev.find(t => t.path === path) ? prev : [...prev, { path, name: fileName, isDirty: false }])
           setActiveTab(path)
-          setCurrentDirPath(parts.slice(0, -1).join('/') || null)
+          setCurrentDirPath(parts.slice(0, -1).join('/') || 'drive')
         } else {
           setCurrentDirPath(path)
         }
@@ -191,7 +191,7 @@ export default function WorkspacePage() {
     setContentViewMode(mode)
     setDetailView(null)
     if (mode === 'browse') {
-      setCurrentDirPath(SECTION_PATHS[activeSectionRef.current] || null)
+      setCurrentDirPath(SECTION_PATHS[activeSectionRef.current] || 'drive')
     }
   }, [])
 
@@ -263,7 +263,7 @@ export default function WorkspacePage() {
             </div>
             {showFileBrowser && (
               <button
-                onClick={() => { setUploadTargetPath('shared/knowledge'); setUploadPanelOpen(true) }}
+                onClick={() => { setUploadTargetPath('drive'); setUploadPanelOpen(true) }}
                 className="p-1.5 rounded-lg hover:bg-surface-hover text-text-secondary hover:text-text transition-colors"
                 title="Upload file"
               >
@@ -326,9 +326,15 @@ export default function WorkspacePage() {
                         onSortChange={setSortMode}
                         onDirClick={handleDirClick}
                         onFileClick={openFileInEditor}
-                        onNavigateBack={(path) => { setCurrentDirPath(path); setSelectedPath(path) }}
+                        onNavigateBack={(path) => {
+                          // Never navigate above drive/ — that's the user's root
+                          const safePath = (!path || path === '') ? 'drive' : path
+                          setCurrentDirPath(safePath)
+                          setSelectedPath(safePath)
+                        }}
                         onUploadClick={(path) => { setUploadTargetPath(path); setUploadPanelOpen(true) }}
                         onNewFolder={confirmNewFolder}
+                        showPropertyBar={isBrowseMode && currentDirPath?.startsWith('drive')}
                       />
                     </div>
                   </Panel>

--- a/xerus_web/components/layout/WorkspaceSectionContext.tsx
+++ b/xerus_web/components/layout/WorkspaceSectionContext.tsx
@@ -12,14 +12,14 @@ interface WorkspaceSectionContextType {
 }
 
 const Context = createContext<WorkspaceSectionContextType>({
-  activeSection: 'agents',
+  activeSection: 'browse',
   setActiveSection: () => {},
   navigateToPath: () => {},
   consumePendingPath: () => null,
 })
 
 export function WorkspaceSectionProvider({ children }: { children: ReactNode }) {
-  const [activeSection, setActiveSection] = useState<WorkspaceSection>('agents')
+  const [activeSection, setActiveSection] = useState<WorkspaceSection>('browse')
   // Ref, not state — transient signal data, consumed once (rule: rerender-use-ref-transient-values)
   const pendingPathRef = useRef<string | null>(null)
 

--- a/xerus_web/components/navigation/AppSidebar.tsx
+++ b/xerus_web/components/navigation/AppSidebar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { usePathname, useRouter } from 'next/navigation'
@@ -9,7 +9,7 @@ import {
   MessageSquare, Inbox, Home,
   Bot, Puzzle, Unplug, FileText, Files, Settings,
   PanelLeftClose, PanelLeftOpen,
-  Plus, Hash, ChevronDown, ChevronRight, FolderOpen, Folder,
+  Plus,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { apiCall } from '@/lib/api/client'
@@ -17,8 +17,6 @@ import { UserMenu } from '@/components/UserMenu'
 import { useUnreadCounts } from '@/hooks/useUnreadCounts'
 import { useWorkspaceSection, type WorkspaceSection } from '@/components/layout/WorkspaceSectionContext'
 import { useSidebarSlotContent } from '@/components/layout/SidebarSlotContext'
-import { useDomains } from '@/hooks/useDomains'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { InboxSidebarBody } from './InboxSidebarBody'
 import { getWorkspaceOverview, type WorkspaceOverview } from '@/lib/api/workspace'
@@ -200,66 +198,14 @@ function HomeSidebarBody({ activeSection, isOnWorkspace, onSectionClick, onPathC
     dedupingInterval: 30000,
   })
 
-  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set())
-
-  // Auto-expand all projects on first load
-  useEffect(() => {
-    if (overview?.projects && expandedProjects.size === 0) {
-      setExpandedProjects(new Set(overview.projects.map(p => p.slug)))
-    }
-  }, [overview?.projects, expandedProjects.size])
-
-  const toggleProject = (slug: string) => {
-    setExpandedProjects(prev => {
-      const next = new Set(prev)
-      next.has(slug) ? next.delete(slug) : next.add(slug)
-      return next
-    })
-  }
-
   return (
     <nav className="px-4 py-2 space-y-5">
-      {/* Projects — dynamic from overview */}
-      {overview?.projects && overview.projects.length > 0 ? overview.projects.map(project => {
-        const isExpanded = expandedProjects.has(project.slug)
-        return (
-          <div key={project.slug}>
-            <button
-              onClick={() => toggleProject(project.slug)}
-              className="flex items-center gap-2 w-full px-3 py-2 rounded-xl text-[15px] font-medium text-text hover:bg-surface-hover transition-colors group"
-            >
-              {isExpanded ? <ChevronDown className="w-4 h-4 text-text-secondary shrink-0" /> : <ChevronRight className="w-4 h-4 text-text-secondary shrink-0" />}
-              {isExpanded ? <FolderOpen className="w-5 h-5 text-primary shrink-0" /> : <Folder className="w-5 h-5 text-text-secondary shrink-0" />}
-              <span className="flex-1 text-left truncate">{project.name}</span>
-              <span className="text-[11px] font-medium text-text-secondary bg-surface-hover rounded-full px-2 py-0.5">{project.channels.length}</span>
-            </button>
-            {isExpanded && (
-              <div className="pl-7 pr-2 py-0.5 space-y-0.5">
-                {project.channels.map(channel => (
-                  <button
-                    key={channel.name}
-                    onClick={() => onPathClick(channel.path)}
-                    className="flex items-center gap-2 w-full px-3 py-1.5 rounded-xl text-[14px] text-text-secondary hover:bg-surface-hover/60 hover:text-text transition-colors"
-                  >
-                    <Hash className="w-4 h-4 shrink-0" />
-                    <span className="flex-1 text-left truncate">{channel.name}</span>
-                    {channel.deliverables.length > 0 ? (
-                      <span className="text-[10px] font-medium text-text-secondary">{channel.deliverables.length}</span>
-                    ) : null}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )
-      }) : null}
-
-      {/* Workspace — documents from shared/knowledge */}
-      {overview?.documents && overview.documents.length > 0 ? (
-        <div>
-          <p className="text-xs font-semibold text-text-secondary/60 mb-1.5 px-3 tracking-wide">Workspace</p>
-          <div className="space-y-0.5">
-            {overview.documents.map(doc => (
+      {/* Workspace — drive content */}
+      <div>
+        <p className="text-xs font-semibold text-text-secondary/60 mb-1.5 px-3 tracking-wide">Workspace</p>
+        <div className="space-y-0.5">
+          {overview?.documents && overview.documents.length > 0 ? (
+            overview.documents.map(doc => (
               <button
                 key={doc.path}
                 onClick={() => onPathClick(doc.path)}
@@ -268,10 +214,12 @@ function HomeSidebarBody({ activeSection, isOnWorkspace, onSectionClick, onPathC
                 <FileText className="w-4 h-4 shrink-0" />
                 <span className="flex-1 text-left truncate">{doc.name.replace(/\.md$/, '')}</span>
               </button>
-            ))}
-          </div>
+            ))
+          ) : (
+            <p className="px-3 py-2 text-[13px] text-text-muted">No files yet</p>
+          )}
         </div>
-      ) : null}
+      </div>
 
       {/* Marketplace */}
       <div>

--- a/xerus_web/components/workspace/BrowseView.tsx
+++ b/xerus_web/components/workspace/BrowseView.tsx
@@ -13,6 +13,7 @@ import type { FileNode } from '@/lib/api/workspace'
 import * as workspaceApi from '@/lib/api/workspace'
 import { countFiles } from './file-utils'
 import type { FileFilter, SortMode } from './file-utils'
+import { PropertyBar } from './PropertyBar'
 
 export type ViewMode = 'grid' | 'list'
 
@@ -35,6 +36,7 @@ interface BrowseViewProps {
   onUploadClick: (targetPath: string) => void
   onNewFolder: (name: string) => Promise<void>
   previews?: Record<string, string>
+  showPropertyBar?: boolean
 }
 
 export function BrowseView({
@@ -56,6 +58,7 @@ export function BrowseView({
   onUploadClick,
   onNewFolder,
   previews,
+  showPropertyBar = false,
 }: BrowseViewProps) {
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null)
@@ -209,10 +212,10 @@ export function BrowseView({
         {/* Section header: current folder title + actions */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
-            {currentDirPath && (
+            {currentDirPath && currentDirPath !== 'drive' && (
               <button
                 onClick={() => onNavigateBack(
-                  currentDirPath.includes('/') ? currentDirPath.split('/').slice(0, -1).join('/') : null
+                  currentDirPath.includes('/') ? currentDirPath.split('/').slice(0, -1).join('/') : 'drive'
                 )}
                 className="p-1.5 rounded-lg hover:bg-surface-hover text-text-secondary hover:text-text transition-colors"
               >
@@ -220,7 +223,7 @@ export function BrowseView({
               </button>
             )}
             <h2 className="font-serif text-2xl text-text">
-              {currentDirPath ? currentDirPath.split('/').pop() : 'Workspace'}
+              {!currentDirPath || currentDirPath === 'drive' ? 'Workspace' : currentDirPath.split('/').pop()}
             </h2>
             <button
               onClick={startNewFolder}
@@ -243,7 +246,7 @@ export function BrowseView({
               <ArrowUpDown className="w-3.5 h-3.5" />
             </button>
             <button
-              onClick={() => onUploadClick(currentDirPath || 'shared/knowledge')}
+              onClick={() => onUploadClick(currentDirPath || 'drive')}
               className="px-5 py-2 rounded-full bg-text text-white hover:bg-[#1a1a1a] transition-colors text-sm font-medium flex items-center gap-2 shadow-sm"
             >
               <Upload className="w-4 h-4" />
@@ -251,6 +254,13 @@ export function BrowseView({
             </button>
           </div>
         </div>
+
+        {/* Property bar — connections + tags (Eden-style, workspace only) */}
+        {showPropertyBar && currentDirPath && (
+          <div className="mb-5">
+            <PropertyBar filePath={currentDirPath} />
+          </div>
+        )}
 
         {/* Folders — responsive grid with FolderCard */}
         {(visibleDirs.length > 0 || isCreatingFolder) && (
@@ -373,7 +383,7 @@ export function BrowseView({
                 New Folder
               </button>
               <button
-                onClick={() => onUploadClick(currentDirPath || 'shared/knowledge')}
+                onClick={() => onUploadClick(currentDirPath || 'drive')}
                 className="px-6 py-2.5 rounded-full bg-text text-white hover:bg-[#1a1a1a] transition-colors text-sm font-medium inline-flex items-center gap-2"
               >
                 <Upload className="w-4 h-4" />

--- a/xerus_web/components/workspace/ConnectionDialog.tsx
+++ b/xerus_web/components/workspace/ConnectionDialog.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { Search, X } from 'lucide-react'
+import useSWR from 'swr'
+import { apiCall } from '@/lib/api/client'
+import { getUserAgents } from '@/lib/api/agents'
+import { getWorkspaceOverview } from '@/lib/api/workspace'
+
+interface ConnectionResult {
+  type: 'agent' | 'channel' | 'file'
+  ref: string
+  label: string
+  sublabel: string
+}
+
+interface ConnectionDialogProps {
+  filePath: string
+  open: boolean
+  onClose: () => void
+  onCreated: () => void
+}
+
+async function createConnection(filePath: string, targetType: string, targetRef: string) {
+  const response = await apiCall('/workspace/connections', {
+    method: 'POST',
+    body: JSON.stringify({ file_path: filePath, target_type: targetType, target_ref: targetRef }),
+  })
+  return response.json()
+}
+
+export function ConnectionDialog({ filePath, open, onClose, onCreated }: ConnectionDialogProps) {
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  const { data: agents = [] } = useSWR(open ? 'agents/mine' : null, getUserAgents)
+  const { data: overview } = useSWR(open ? 'workspace/overview' : null, getWorkspaceOverview, {
+    revalidateOnFocus: false,
+    dedupingInterval: 30000,
+  })
+
+  // Build searchable results
+  const allResults = useMemo<ConnectionResult[]>(() => {
+    const results: ConnectionResult[] = []
+
+    // Agents
+    for (const agent of agents) {
+      results.push({
+        type: 'agent',
+        ref: agent.slug || String(agent.id),
+        label: agent.name || agent.slug || String(agent.id),
+        sublabel: 'Agent',
+      })
+    }
+
+    // Channels from projects
+    if (overview?.projects) {
+      for (const project of overview.projects) {
+        for (const channel of project.channels) {
+          results.push({
+            type: 'channel',
+            ref: `${project.slug}/${channel.name}`,
+            label: `#${channel.name}`,
+            sublabel: project.name,
+          })
+        }
+      }
+    }
+
+    return results
+  }, [agents, overview])
+
+  const filteredResults = useMemo(() => {
+    if (!query.trim()) return allResults
+    const q = query.toLowerCase()
+    return allResults.filter(
+      (r) => r.label.toLowerCase().includes(q) || r.sublabel.toLowerCase().includes(q),
+    )
+  }, [allResults, query])
+
+  const grouped = useMemo(() => {
+    const groups: Record<string, ConnectionResult[]> = {}
+    for (const result of filteredResults) {
+      const key = result.type === 'agent' ? 'AGENTS' : result.type === 'channel' ? 'CHANNELS' : 'FILES'
+      if (!groups[key]) groups[key] = []
+      groups[key].push(result)
+    }
+    return groups
+  }, [filteredResults])
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setTimeout(() => inputRef.current?.focus(), 50)
+    }
+  }, [open])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open, onClose])
+
+  const handleSelect = useCallback(async (result: ConnectionResult) => {
+    await createConnection(filePath, result.type, result.ref)
+    onCreated()
+    onClose()
+  }, [filePath, onCreated, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      ref={dialogRef}
+      className="absolute z-50 mt-1 w-72 bg-white rounded-2xl shadow-lg border border-surface-active overflow-hidden"
+    >
+      {/* Search input */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-surface-active/40">
+        <Search className="w-4 h-4 text-text-muted shrink-0" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search agents, channels, files..."
+          className="flex-1 text-sm bg-transparent focus:outline-none text-text placeholder:text-text-muted"
+        />
+        <button onClick={onClose} className="p-0.5 rounded hover:bg-surface-hover text-text-muted">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Results */}
+      <div className="max-h-80 overflow-y-auto py-1">
+        {Object.keys(grouped).length === 0 ? (
+          <p className="text-sm text-text-muted text-center py-6">No results found</p>
+        ) : (
+          Object.entries(grouped).map(([groupName, items]) => (
+            <div key={groupName}>
+              <p className="text-[10px] font-semibold text-text-muted uppercase tracking-wider px-3 pt-2 pb-1">
+                {groupName}
+              </p>
+              {items.map((item) => (
+                <button
+                  key={`${item.type}-${item.ref}`}
+                  onClick={() => handleSelect(item)}
+                  className="w-full flex items-center justify-between px-3 py-2 hover:bg-surface-hover/60 transition-colors text-left"
+                >
+                  <span className="text-sm text-text truncate">{item.label}</span>
+                  <span className="text-xs text-text-muted shrink-0 ml-2">{item.sublabel}</span>
+                </button>
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/xerus_web/components/workspace/FileTree.tsx
+++ b/xerus_web/components/workspace/FileTree.tsx
@@ -17,7 +17,7 @@ import type { FileNode } from '@/lib/api/workspace'
 const READ_ONLY_DIRS = ['.memory', '.claude', 'marketplace', '.beads', 'context']
 
 // Directories that support uploading (shown with + button)
-const UPLOAD_DIRS = ['shared/knowledge', /^agents\/[^/]+\/knowledge$/, /^projects\/[^/]+\/knowledge$/]
+const UPLOAD_DIRS = ['drive', /^agents\/[^/]+\/knowledge$/, /^projects\/[^/]+\/knowledge$/]
 
 function isUploadableDir(path: string): boolean {
   return UPLOAD_DIRS.some((pattern) =>
@@ -179,7 +179,7 @@ export function FileTree({
   className,
 }: FileTreeProps) {
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
-    () => new Set(['agents', 'projects', 'shared']),
+    () => new Set(['agents', 'projects', 'drive']),
   )
 
   const handleToggle = useCallback((path: string) => {

--- a/xerus_web/components/workspace/PropertyBar.tsx
+++ b/xerus_web/components/workspace/PropertyBar.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useState, useCallback, useRef } from 'react'
+import { Plus, X } from 'lucide-react'
+import useSWR, { mutate } from 'swr'
+import { cn } from '@/lib/utils'
+import { apiCall } from '@/lib/api/client'
+import { ConnectionDialog } from './ConnectionDialog'
+import { TagDialog } from './TagDialog'
+
+interface Tag {
+  id: number
+  tag: string
+}
+
+interface Connection {
+  id: number
+  target_type: string
+  target_ref: string
+}
+
+interface PropertyBarProps {
+  filePath: string
+}
+
+async function fetchFileTags(filePath: string): Promise<Tag[]> {
+  const response = await apiCall(`/workspace/tags?file_path=${encodeURIComponent(filePath)}`, { method: 'GET' })
+  const data = await response.json()
+  const unwrapped = data.data ?? data
+  return unwrapped.tags ?? []
+}
+
+async function fetchFileConnections(filePath: string): Promise<Connection[]> {
+  const response = await apiCall(`/workspace/connections?file_path=${encodeURIComponent(filePath)}`, { method: 'GET' })
+  const data = await response.json()
+  const unwrapped = data.data ?? data
+  return unwrapped.connections ?? []
+}
+
+async function deleteTag(id: number) {
+  await apiCall(`/workspace/tags/${id}`, { method: 'DELETE' })
+}
+
+async function deleteConnection(id: number) {
+  await apiCall(`/workspace/connections/${id}`, { method: 'DELETE' })
+}
+
+export function PropertyBar({ filePath }: PropertyBarProps) {
+  const [showDropdown, setShowDropdown] = useState(false)
+  const [tagDialogOpen, setTagDialogOpen] = useState(false)
+  const [connectionDialogOpen, setConnectionDialogOpen] = useState(false)
+  const addBtnRef = useRef<HTMLButtonElement>(null)
+
+  const tagKey = filePath ? `workspace/tags?file=${filePath}` : null
+  const connKey = filePath ? `workspace/connections?file=${filePath}` : null
+
+  const { data: tags = [] } = useSWR<Tag[]>(tagKey, () => fetchFileTags(filePath), {
+    revalidateOnFocus: false,
+  })
+
+  const { data: connections = [] } = useSWR<Connection[]>(connKey, () => fetchFileConnections(filePath), {
+    revalidateOnFocus: false,
+  })
+
+  const refreshAll = useCallback(() => {
+    if (tagKey) mutate(tagKey)
+    if (connKey) mutate(connKey)
+  }, [tagKey, connKey])
+
+  const handleRemoveTag = useCallback(async (id: number) => {
+    await deleteTag(id)
+    refreshAll()
+  }, [refreshAll])
+
+  const handleRemoveConnection = useCallback(async (id: number) => {
+    await deleteConnection(id)
+    refreshAll()
+  }, [refreshAll])
+
+  const handleDropdownSelect = useCallback((type: 'tag' | 'connection') => {
+    setShowDropdown(false)
+    if (type === 'tag') setTagDialogOpen(true)
+    else setConnectionDialogOpen(true)
+  }, [])
+
+  return (
+    <div className="relative flex items-center gap-2 flex-wrap min-h-[32px]">
+      {/* Tag chips */}
+      {tags.map((tag) => (
+        <span
+          key={tag.id}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-surface-hover text-xs font-medium text-text"
+        >
+          #{tag.tag}
+          <button
+            onClick={() => handleRemoveTag(tag.id)}
+            className="p-0.5 rounded-full hover:bg-surface-active text-text-muted hover:text-text transition-colors"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </span>
+      ))}
+
+      {/* Connection chips */}
+      {connections.map((conn) => (
+        <span
+          key={conn.id}
+          className={cn(
+            'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium',
+            'bg-primary/10 text-primary',
+          )}
+        >
+          &rarr; {conn.target_ref}
+          <button
+            onClick={() => handleRemoveConnection(conn.id)}
+            className="p-0.5 rounded-full hover:bg-primary/20 text-primary/60 hover:text-primary transition-colors"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </span>
+      ))}
+
+      {/* "+ Add property" button */}
+      <div className="relative">
+        <button
+          ref={addBtnRef}
+          onClick={() => setShowDropdown(!showDropdown)}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium text-text-secondary hover:text-text hover:bg-surface-hover transition-colors border border-dashed border-surface-active"
+        >
+          <Plus className="w-3 h-3" />
+          Add property
+        </button>
+
+        {/* Dropdown */}
+        {showDropdown && (
+          <div className="absolute z-50 top-full left-0 mt-1 w-40 bg-white rounded-xl shadow-lg border border-surface-active overflow-hidden">
+            <button
+              onClick={() => handleDropdownSelect('tag')}
+              className="w-full flex items-center gap-2 px-3 py-2 hover:bg-surface-hover/60 text-sm text-text text-left transition-colors"
+            >
+              # Tag
+            </button>
+            <button
+              onClick={() => handleDropdownSelect('connection')}
+              className="w-full flex items-center gap-2 px-3 py-2 hover:bg-surface-hover/60 text-sm text-text text-left transition-colors"
+            >
+              &rarr; Connection
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Dialogs */}
+      <TagDialog
+        filePath={filePath}
+        open={tagDialogOpen}
+        onClose={() => setTagDialogOpen(false)}
+        onCreated={refreshAll}
+      />
+      <ConnectionDialog
+        filePath={filePath}
+        open={connectionDialogOpen}
+        onClose={() => setConnectionDialogOpen(false)}
+        onCreated={refreshAll}
+      />
+    </div>
+  )
+}

--- a/xerus_web/components/workspace/TagDialog.tsx
+++ b/xerus_web/components/workspace/TagDialog.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { Search, X } from 'lucide-react'
+import useSWR from 'swr'
+import { apiCall } from '@/lib/api/client'
+
+interface TagInfo {
+  tag: string
+  count: number
+}
+
+interface TagDialogProps {
+  filePath: string
+  open: boolean
+  onClose: () => void
+  onCreated: () => void
+}
+
+async function fetchTagList(): Promise<TagInfo[]> {
+  const response = await apiCall('/workspace/tags/list', { method: 'GET' })
+  const data = await response.json()
+  const unwrapped = data.data ?? data
+  return unwrapped.tags ?? []
+}
+
+async function createTag(filePath: string, tag: string) {
+  const response = await apiCall('/workspace/tags', {
+    method: 'POST',
+    body: JSON.stringify({ file_path: filePath, tag }),
+  })
+  return response.json()
+}
+
+export function TagDialog({ filePath, open, onClose, onCreated }: TagDialogProps) {
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  const { data: tags = [] } = useSWR<TagInfo[]>(open ? 'workspace/tags/list' : null, fetchTagList, {
+    revalidateOnFocus: false,
+    dedupingInterval: 15000,
+  })
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return tags
+    const q = query.toLowerCase()
+    return tags.filter((t) => t.tag.toLowerCase().includes(q))
+  }, [tags, query])
+
+  const showCreateOption = useMemo(() => {
+    if (!query.trim()) return false
+    const q = query.trim().toLowerCase()
+    return !tags.some((t) => t.tag.toLowerCase() === q)
+  }, [tags, query])
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setTimeout(() => inputRef.current?.focus(), 50)
+    }
+  }, [open])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open, onClose])
+
+  const handleSelect = useCallback(async (tag: string) => {
+    await createTag(filePath, tag)
+    onCreated()
+    onClose()
+  }, [filePath, onCreated, onClose])
+
+  const handleCreateNew = useCallback(async () => {
+    const tag = query.trim().toLowerCase().replace(/\s+/g, '-')
+    if (!tag) return
+    await createTag(filePath, tag)
+    onCreated()
+    onClose()
+  }, [filePath, query, onCreated, onClose])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && showCreateOption) {
+      e.preventDefault()
+      handleCreateNew()
+    }
+    if (e.key === 'Escape') {
+      onClose()
+    }
+  }, [showCreateOption, handleCreateNew, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      ref={dialogRef}
+      className="absolute z-50 mt-1 w-64 bg-white rounded-2xl shadow-lg border border-surface-active overflow-hidden"
+    >
+      {/* Search / create input */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-surface-active/40">
+        <Search className="w-4 h-4 text-text-muted shrink-0" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search or create tag..."
+          className="flex-1 text-sm bg-transparent focus:outline-none text-text placeholder:text-text-muted"
+        />
+        <button onClick={onClose} className="p-0.5 rounded hover:bg-surface-hover text-text-muted">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Results */}
+      <div className="max-h-80 overflow-y-auto py-1">
+        {showCreateOption && (
+          <button
+            onClick={handleCreateNew}
+            className="w-full flex items-center gap-2 px-3 py-2 hover:bg-surface-hover/60 transition-colors text-left"
+          >
+            <span className="text-sm text-primary font-medium">
+              Create &ldquo;{query.trim().toLowerCase().replace(/\s+/g, '-')}&rdquo;
+            </span>
+          </button>
+        )}
+
+        {filtered.length > 0 && (
+          <>
+            <p className="text-[10px] font-semibold text-text-muted uppercase tracking-wider px-3 pt-2 pb-1">
+              EXISTING TAGS
+            </p>
+            {filtered.map((t) => (
+              <button
+                key={t.tag}
+                onClick={() => handleSelect(t.tag)}
+                className="w-full flex items-center justify-between px-3 py-2 hover:bg-surface-hover/60 transition-colors text-left"
+              >
+                <span className="text-sm text-text">#{t.tag}</span>
+                <span className="text-xs text-text-muted">{t.count} files</span>
+              </button>
+            ))}
+          </>
+        )}
+
+        {filtered.length === 0 && !showCreateOption && (
+          <p className="text-sm text-text-muted text-center py-6">No tags yet</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/xerus_web/components/workspace/WorkspaceSidebar.tsx
+++ b/xerus_web/components/workspace/WorkspaceSidebar.tsx
@@ -3,7 +3,7 @@
 import { cn } from '@/lib/utils'
 import { Bot, Puzzle, BookOpen, Brain, FolderKanban, Files } from 'lucide-react'
 
-export type WorkspaceSection = 'agents' | 'skills' | 'knowledge' | 'memory' | 'projects' | 'files'
+import type { WorkspaceSection } from '@/components/layout/WorkspaceSectionContext'
 
 const SECTIONS: { id: WorkspaceSection; label: string; icon: React.ElementType; dividerAfter?: boolean }[] = [
   { id: 'agents', label: 'Agents', icon: Bot },

--- a/xerus_web/components/workspace/file-utils.ts
+++ b/xerus_web/components/workspace/file-utils.ts
@@ -157,7 +157,7 @@ const EDITABLE_PATTERNS: RegExp[] = [
   /^agents\/[^/]+\/config\.json$/,
   /^agents\/[^/]+\/HEARTBEAT\.md$/,
   /^agents\/[^/]+\/knowledge\/.+/,
-  /^shared\/knowledge\/.+/,
+  /^drive\/.+/,
   /^projects\/[^/]+\/knowledge\/.+/,
 ]
 


### PR DESCRIPTION
## Summary
- Eliminate `shared/` directory from workspace template, replace with `drive/` for user content
- Add `file_connections` and `file_tags` tables for Eden-style file metadata (tags + connections to agents/channels)
- Update all backend path references, create new connections/tags API endpoints
- Update frontend to browse `drive/` by default, add PropertyBar/ConnectionDialog/TagDialog components
- Security: add path validation, length limits, and escapeSQL newline rejection

## Changes

### Backend (22 files)
- **Path infrastructure**: workspace.types.ts, workspace.paths.ts, workspace.manager.ts — remove shared*, add drive
- **Inbox routing**: messaging.service.ts — shared/inbox/{slug} → agents/{slug}/inbox
- **Upload validation**: drive-upload.routes.ts — accept drive/ paths
- **New API**: connections.service.ts + routes, tags.service.ts + routes — CRUD with auto-table-creation
- **Security**: escapeSQL rejects newlines, validateDrivePath on new routes, input length limits

### Frontend (11 files)
- **Browse**: defaults to drive/, back button clamped, PropertyBar for tags/connections
- **Sidebar**: shows Workspace docs from drive/, Projects moved to /inbox only
- **New components**: ConnectionDialog, TagDialog, PropertyBar (Eden-style)

### Workspace Template (pushed separately to xerus-workspace master)
- `shared/` eliminated, `drive/` created, `.claude/rules/` for policies
- `workspace-schema.sql` has file_connections + file_tags tables
- All hooks/agents/skills/commands updated

## Test plan
- [x] Backend typecheck passes (0 errors)
- [x] Frontend typecheck passes (0 errors)
- [x] xerus-workspace tests pass (36/36)
- [x] 7-agent code review completed, all critical/high findings resolved
- [ ] Manual test: login → workspace shows drive/ contents
- [ ] Manual test: create tag on file, create connection to agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)