### PR TITLE
fix(backend): make env loader and Pipedream init boot-resilient

### DIFF
--- a/xerus_backend/src/config/env.ts
+++ b/xerus_backend/src/config/env.ts
@@ -1,8 +1,20 @@
 // Environment loader — must be imported before any module that reads process.env
-// Loads .env.local (default) or .env.production (when NODE_ENV=production)
+// Tries .env.production (NODE_ENV=production) or .env.local first; falls back
+// to .env so deployments that only ship a single canonical .env still load.
+// Existing process.env vars always win — dotenv does not override by default.
 
 import dotenv from 'dotenv';
+import fs from 'fs';
 import path from 'path';
 
-const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.local';
-dotenv.config({ path: path.resolve(__dirname, '..', '..', envFile) });
+const root = path.resolve(__dirname, '..', '..');
+const primary = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.local';
+const candidates = [primary, '.env'];
+
+for (const file of candidates) {
+    const fullPath = path.join(root, file);
+    if (fs.existsSync(fullPath)) {
+        dotenv.config({ path: fullPath });
+        break;
+    }
+}

--- a/xerus_backend/src/domains/tools/service.ts
+++ b/xerus_backend/src/domains/tools/service.ts
@@ -31,7 +31,12 @@ import type {
 } from './types';
 
 export class ToolsService {
-    private pipedream = getPipedreamClient();
+    // Lazy accessor — Pipedream is optional infrastructure, so we don't want
+    // a missing PIPEDREAM_* env var to prevent the entire API from booting.
+    // The error surfaces on first connector-tool call instead.
+    private get pipedream() {
+        return getPipedreamClient();
+    }
 
     async listApps(input?: ListAppsInput): Promise<ListAppsResponse> {
         const validated = input ? toolValidator.validateListApps(input) : {};


### PR DESCRIPTION
## Summary

Production crash-looped after PR #22 deploy. Two latent bugs combined to take the whole API down:

1. **Env loader had no fallback to `.env`.** `src/config/env.ts` only tried `.env.production` (in prod) or `.env.local` (else). The VPS had only `.env` (leftover from an older setup), so dotenv loaded zero vars. PM2 had been masking this for weeks by serving cached process env from a long-ago start; the GitHub Actions deploy at 21:34 forced a true fresh spawn and the latent bug surfaced.
2. **`ToolsService` constructed the Pipedream client eagerly** in a field initializer (`private pipedream = getPipedreamClient()`). With `PIPEDREAM_*` vars now missing, this threw at module load — killing the entire API before it could bind to a port — even though Pipedream is only needed for connector tools.

## Changes

**`xerus_backend/src/config/env.ts`**
- Resolve the env file by trying primary (`.env.production` in prod, `.env.local` else) first, then `.env` as fallback
- Load exactly one file (`break` after first hit) — no double-load precedence games
- Existing `process.env` still wins (dotenv default behavior, no `override: true`)

**`xerus_backend/src/domains/tools/service.ts`**
- Replace eager `private pipedream = getPipedreamClient()` with a lazy getter
- API now boots without `PIPEDREAM_*` env; missing config surfaces only on first connector-tool call (where it can be caught and reported per-request)
- All 8 existing `this.pipedream.*` call sites unchanged — getter returns same client (already memoised inside `getPipedreamClient`)

## Production status

Already restored on `91.98.207.51`:
- Symlinked `/opt/xerus/xerus_backend/.env.production -> .env`
- `pm2 delete xerus-backend && pm2 start ecosystem.config.js && pm2 save`
- `https://api.xerus.ai/health` → `{\"status\":\"healthy\"}`, 0 restarts

This PR hardens the code so the same scenario can't recur — even a fresh VPS with only a `.env` file will boot, and a missing optional `PIPEDREAM_*` won't take down the whole API.

## Type

- [x] Fix

## Testing

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/config/env.ts src/domains/tools/service.ts` clean
- [x] Production verified online with the symlink workaround (independent of these code changes)
- [x] Existing `tools/__tests__/caching.test.ts` continues to import `toolsService` without change — lazy getter is API-compatible
- [x] No secrets or credentials in code

## Beads Task

None — production incident response.

---
Generated with [Claude Code](https://claude.com/claude-code)