### PR TITLE
fix(sandbox): install Bun in workspace setup

### DIFF
--- a/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
@@ -135,6 +135,8 @@ export interface SetupReport {
     databases_initialized: boolean;
     node_verified: boolean;
     node_version: string;
+    bun_verified: boolean;
+    bun_version: string;
     duration_ms: number;
 }
 
@@ -153,6 +155,8 @@ export async function runFullWorkspaceSetup(
         databases_initialized: false,
         node_verified: false,
         node_version: '',
+        bun_verified: false,
+        bun_version: '',
         duration_ms: 0,
     };
 
@@ -267,6 +271,40 @@ export async function runFullWorkspaceSetup(
         report.node_version = versionMatch ? versionMatch[0] : 'unknown';
         report.node_verified = true;
         log.info('Node.js verified', { node_version: report.node_version, sandbox_id: sandboxId });
+    }
+
+    // 5b. Verify Bun is available (required by scheduler daemon at step 8).
+    // Mirrors the Node.js fallback above — base devcontainer image (Microsoft
+    // python:3.14) ships with neither runtime, and the scheduler daemon hard-fails
+    // if Bun is missing, so install it at runtime when absent.
+    const bunCheck = await provider.executeCommand(
+        sandboxId,
+        `which bun 2>/dev/null && bun --version && echo FOUND || echo MISSING`,
+    );
+    const bunOutput = (bunCheck.result || '').trim();
+    if (bunOutput.endsWith('MISSING')) {
+        log.warn('Bun not found, installing via bun.sh', { sandbox_id: sandboxId });
+        // Install to /usr/local so 'which bun' resolves without PATH munging
+        const installResult = await provider.executeCommand(
+            sandboxId,
+            `curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash 2>&1 | tail -5`,
+        );
+        const verifyResult = await provider.executeCommand(sandboxId, 'bun --version 2>/dev/null');
+        const verifyOutput = (verifyResult.result || '').trim();
+        if (verifyResult.exitCode !== 0 || !/^\d/.test(verifyOutput)) {
+            throw new Error(
+                `Bun installation failed in sandbox ${sandboxId}. `
+                + `Install output: ${(installResult.result || '').slice(-200)}`,
+            );
+        }
+        report.bun_version = verifyOutput;
+        report.bun_verified = true;
+        log.info('Installed Bun', { bun_version: report.bun_version, sandbox_id: sandboxId });
+    } else {
+        const versionMatch = bunOutput.match(/[\d.]+/);
+        report.bun_version = versionMatch ? versionMatch[0] : 'unknown';
+        report.bun_verified = true;
+        log.info('Bun verified', { bun_version: report.bun_version, sandbox_id: sandboxId });
     }
 
     // 6. Sync DB agents into workspace (scaffold missing ones + update index.json)


### PR DESCRIPTION
## Why

User reports `Failed to ensure sandbox` / inability to load `/workspace/overview` for `Hcard360@gmail.com`. Backend logs show the snapshot is fine (`active`), Daytona create succeeds, but **every** new sandbox dies during post-create setup with:

\`\`\`
Error: Bun runtime not found in sandbox <id>. Scheduler cannot start.
  at startSchedulerDaemon (sandbox-setup.ts:325:15)
  at runFullWorkspaceSetup (sandbox-setup.ts:279:5)
  at SandboxService.createSandbox (sandbox.service.ts:143:29)
\`\`\`

This isn't user-specific — every fresh sandbox is broken. It just hadn't been hit until Hcard360 came along because existing sandboxes from before the regression keep working.

## Root cause

`runFullWorkspaceSetup` installs Node.js at runtime when missing (sandbox-setup.ts:246-263) because the base devcontainer image (`mcr.microsoft.com/devcontainers/python:3.14`) ships with neither Node nor Bun. Step 8 then calls `startSchedulerDaemon` which hard-checks for Bun (sandbox-setup.ts:322-325) and throws if absent — but **no Bun fallback installer exists**, only a Node one.

Either Bun was supposed to be baked into the snapshot image and got dropped, or it was always meant to be runtime-installed and the install step was never written. Either way, the safest fix is the runtime fallback so the setup self-heals regardless of what the snapshot ships with.

## Changes

**`xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts`**
- Extended `SetupReport` with `bun_verified` / `bun_version`
- Added a step 5b mirroring the Node block: `which bun` probe, install via `curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash` when missing (puts the binary at `/usr/local/bin/bun` so `which bun` resolves without PATH munging), verify with `bun --version`, throw with install output on failure

## Production impact

Blocked **all new sandbox creation** since the regression. Pre-existing sandboxes (auto-archived/idle but resumeable) were unaffected, so partial functionality remained for existing users. Anyone hitting `/workspace/ensure` or `/workspace/overview` for the first time on a fresh sandbox could not get past setup.

## Type

- [x] Fix
- [x] Critical (production blocker)

## Testing

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Pattern matches existing Node fallback (lines 246-263) which is known to work in production
- [x] Bun install command verified: `BUN_INSTALL=/usr/local` is the documented bun.sh override
- [x] No secrets or credentials in code

After merge + deploy, the next sandbox-create attempt will install Bun, the scheduler will start, and `/workspace/overview` will succeed. Existing broken sandboxes from this incident will be cleaned up by the lifecycle job (`autoArchiveInterval=1440min`).

## Beads Task

None — production incident response.

---
Generated with [Claude Code](https://claude.com/claude-code)