### PR TITLE
feat(execution): watchdog for stuck execution_sessions rows

### DIFF
--- a/xerus_backend/src/jobs/execution-watchdog.ts
+++ b/xerus_backend/src/jobs/execution-watchdog.ts
@@ -1,0 +1,74 @@
+// Background Job: Execution Watchdog
+// Finalises execution_sessions rows that are stuck in pending/running past a
+// safety threshold. The runner inside a sandbox is supposed to write a
+// terminal status (completed/failed/cancelled) when it finishes -- if it
+// crashes mid-execution (sandbox OOM, network blip, runtime missing, deploy
+// restart, Daytona losing the sandbox) the row remains "running" forever and
+// the UI shows a phantom in-flight execution. This job is the safety net.
+//
+// Treats any execution older than EXECUTION_TIMEOUT_MINUTES still in
+// pending/running as a failed timeout. Set the threshold longer than the
+// longest legitimate execution to avoid false positives. paused executions
+// are intentionally excluded -- those are user-initiated waits, not zombies.
+
+import cron from 'node-cron';
+import { query } from '../database/connection';
+import { logger } from '../utils/logger';
+
+const log = logger('Job:ExecutionWatchdog');
+
+// Every 5 minutes
+const CRON_SCHEDULE = '*/5 * * * *';
+
+// Anything older than this still in pending/running gets reaped
+const EXECUTION_TIMEOUT_MINUTES = 30;
+
+interface ReapedRow {
+    id: string;
+    agent_slug: string;
+    age_minutes: number;
+}
+
+async function reapStuckExecutions(): Promise<void> {
+    const result = await query<ReapedRow>(
+        `UPDATE execution_sessions
+         SET status = 'failed',
+             completed_at = NOW(),
+             message_metadata = COALESCE(message_metadata, '{}'::jsonb) || jsonb_build_object(
+                 'failure_reason', 'watchdog_timeout',
+                 'failure_note', 'Watchdog finalised after exceeding timeout without writing terminal status',
+                 'timeout_minutes', $1::int,
+                 'finalised_at', NOW()
+             )
+         WHERE status IN ('pending', 'running')
+           AND created_at < NOW() - make_interval(mins => $1::int)
+         RETURNING id, agent_slug,
+                   EXTRACT(EPOCH FROM (NOW() - created_at))::int / 60 AS age_minutes`,
+        [EXECUTION_TIMEOUT_MINUTES],
+    );
+
+    if (result.rows.length === 0) {
+        log.debug('No stuck executions');
+        return;
+    }
+
+    log.warn('Reaped stuck executions', {
+        count: result.rows.length,
+        timeout_minutes: EXECUTION_TIMEOUT_MINUTES,
+        rows: result.rows.map(r => ({ id: r.id, agent_slug: r.agent_slug, age_minutes: r.age_minutes })),
+    });
+}
+
+export function startExecutionWatchdogJob(): void {
+    log.info('Scheduling job', { cron: CRON_SCHEDULE, timeout_minutes: EXECUTION_TIMEOUT_MINUTES });
+
+    cron.schedule(CRON_SCHEDULE, async () => {
+        try {
+            await reapStuckExecutions();
+        } catch (error) {
+            log.error('Watchdog tick failed', error instanceof Error ? error : new Error(String(error)));
+        }
+    });
+
+    log.info('Job scheduled successfully');
+}

--- a/xerus_backend/src/jobs/index.ts
+++ b/xerus_backend/src/jobs/index.ts
@@ -6,6 +6,7 @@ import { startSandboxSchedulerJob, startSandboxCleanupJob } from './sandbox-life
 import { startDigestSchedulerJob } from './digest-scheduler';
 import { startBackupSchedulerJob } from './s3-backup-job';
 import { startSnapshotWarmKeepJob } from './snapshot-warm-keep';
+import { startExecutionWatchdogJob } from './execution-watchdog';
 import type { SandboxProvider } from '../domains/sandbox-infra/sandbox/providers';
 import type { SandboxService } from '../domains/sandbox-infra/sandbox/sandbox.service';
 import type { S3BackupService } from '../domains/sandbox-infra/storage/s3-backup.service';
@@ -36,6 +37,7 @@ export function startAllJobs(deps: JobDependencies = {}): void {
         startSandboxSchedulerJob(deps.provider, deps.sandboxService);
         startSandboxCleanupJob(deps.provider, deps.sandboxService);
         startSnapshotWarmKeepJob(deps.provider);
+        startExecutionWatchdogJob();
         startDigestSchedulerJob(deps.db);
 
         if (deps.sandboxService && deps.backupService) {


### PR DESCRIPTION
## Why

Today's incident left a chat run for `Hcard360` stuck at `status='running'` for 3+ hours because the runner crashed (missing Bun) before writing a terminal status. The UI showed it as "Running" indefinitely. We finalised that one row by hand.

PR #25 fixes the Bun-specific cause, but the same class of zombie can be caused by *anything* that kills the runner before it can write back: sandbox OOM, network blips between backend ↔ sandbox, deploy restarts, code bugs. We need a safety net that catches the *class* of bug, not just one cause.

## What this does

`xerus_backend/src/jobs/execution-watchdog.ts` — node-cron job that ticks every 5 minutes and reaps any execution_sessions stuck in `pending`/`running` past a 30-minute threshold.

```sql
UPDATE execution_sessions
SET status = 'failed',
    completed_at = NOW(),
    message_metadata = COALESCE(message_metadata, '{}'::jsonb) || jsonb_build_object(
      'failure_reason', 'watchdog_timeout',
      'timeout_minutes', 30,
      'finalised_at', NOW()
    )
WHERE status IN ('pending', 'running')
  AND created_at < NOW() - make_interval(mins => 30::int)
RETURNING id, agent_slug, age_minutes;
```

Wired into `startAllJobs` alongside the existing lifecycle jobs.

## Design notes

| Concern | Decision |
|---|---|
| Threshold | `30 minutes` — set conservatively, longer than any expected legitimate execution. Easy to tune later. |
| Cadence | `*/5 * * * *` — every 5min. Stuck rows visible to UI within ~5min instead of forever. |
| `paused` excluded | `paused` is a user-initiated wait, not a zombie. Watchdog only catches `pending`/`running`. |
| Race: runner finishes at minute 31 | Runner UPDATEs use `WHERE id = $1` without status guards, so a late finish can move `failed → completed`. The runner UPDATEs don't touch `message_metadata`, so the watchdog audit trail (`failure_reason: watchdog_timeout`) survives either way. End state correctly reflects what happened. |
| Idempotency | UPDATE WHERE filters on `status IN ('pending', 'running')` — already-terminal rows don't re-match. Repeat ticks are no-ops. |
| Cron tick failure | Try/catch around `reapStuckExecutions` — DB errors get logged, don't kill the cron process. |

## Why "feat" not "fix"

There's no broken code being patched here — runner-side terminal writes are correct when the runner is alive. The watchdog is *new* infrastructure: defense-in-depth for runner death. PR #25 is the "fix"; this is the safety net.

## Type

- [x] Feature (reliability infrastructure)
- [x] Defense-in-depth complement to PR #25

## Testing

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/jobs/execution-watchdog.ts src/jobs/index.ts` clean
- [x] SQL syntax + `make_interval` validated against production Neon (read-only SELECT version of the WHERE returns 0 current matches — DB syntax verified, no false-positive risk after deploy)
- [x] No secrets or credentials in code

## Beads Task

None — direct continuation of today's incident response.

---
Generated with [Claude Code](https://claude.com/claude-code)