### PR TITLE
Chat page UI/UX overhaul — tool display, streaming events, bug fixes

### DIFF
--- a/xerus_backend/src/domains/agents/agent-filesystem.repository.ts
+++ b/xerus_backend/src/domains/agents/agent-filesystem.repository.ts
@@ -86,6 +86,10 @@ function normalizeConfig(raw: Record<string, unknown>): { config: AgentConfigFil
         raw.ai_model = raw.model;
         dirty = true;
     }
+    if (raw.model && raw.ai_model) {
+        delete raw.model;
+        dirty = true;
+    }
     if (!raw.mascot) {
         raw.mascot = generateMascotConfig();
         dirty = true;
@@ -139,8 +143,15 @@ export class AgentFilesystemRepository {
             const result = await this.driveService.readFile(userId, `agents/${slug}/config.json`);
             raw = result.content;
         } catch (err) {
-            if (isFileNotFoundError(err)) return null;
-            throw err;
+            if (!isFileNotFoundError(err)) throw err;
+            // System agents may live at .claude/agents/{slug}/config.json
+            try {
+                const fallback = await this.driveService.readFile(userId, `.claude/agents/${slug}/config.json`);
+                raw = fallback.content;
+            } catch (err2) {
+                if (isFileNotFoundError(err2)) return null;
+                throw err2;
+            }
         }
         const { config, dirty } = normalizeConfig(JSON.parse(raw));
         if (dirty) {
@@ -177,7 +188,26 @@ export class AgentFilesystemRepository {
 
     async putAgentConfig(userId: string, slug: string, config: AgentConfigFile): Promise<void> {
         const content = JSON.stringify(config, null, 2);
-        await this.driveService.writeFile(userId, `agents/${slug}/config.json`, content);
+        const path = await this.resolveConfigWritePath(userId, slug);
+        await this.driveService.writeFile(userId, path, content);
+    }
+
+    private async resolveConfigWritePath(userId: string, slug: string): Promise<string> {
+        const primary = `agents/${slug}/config.json`;
+        try {
+            await this.driveService.readFile(userId, primary);
+            return primary;
+        } catch (err) {
+            if (!isFileNotFoundError(err)) throw err;
+        }
+        const fallback = `.claude/agents/${slug}/config.json`;
+        try {
+            await this.driveService.readFile(userId, fallback);
+            return fallback;
+        } catch (err) {
+            if (!isFileNotFoundError(err)) throw err;
+        }
+        return primary;
     }
 
     async getAgentIndex(userId: string): Promise<AgentIndexEntry[]> {

--- a/xerus_backend/src/domains/agents/agent-helpers.ts
+++ b/xerus_backend/src/domains/agents/agent-helpers.ts
@@ -42,6 +42,7 @@ export function configToAgent(
 
 export function canUserView(agent: Agent, userId: string): boolean {
     if (agent.agent_type === 'internal') return false;
+    if (agent.agent_type === 'system') return true;
     if (agent.agent_type === 'public') return true;
     return agent.user_id === userId;
 }
@@ -49,6 +50,7 @@ export function canUserView(agent: Agent, userId: string): boolean {
 export function canUserModify(agent: Agent, userId: string): boolean {
     if (agent.agent_type === 'public' && agent.user_id === null) return false;
     if (agent.agent_type === 'internal') return false;
+    if (agent.agent_type === 'system') return true;
     return agent.user_id === userId;
 }
 

--- a/xerus_backend/src/domains/agents/agent-registry.repository.ts
+++ b/xerus_backend/src/domains/agents/agent-registry.repository.ts
@@ -29,7 +29,7 @@ export class AgentRegistryRepository {
 
     async findBySlug(slug: string, userId: string | null): Promise<AgentRegistryEntry | null> {
         const result = await query<AgentRegistryEntry>(
-            `SELECT * FROM agent_registry WHERE slug = $1 AND user_id = $2 LIMIT 1`,
+            `SELECT * FROM agent_registry WHERE slug = $1 AND (user_id = $2 OR agent_type = 'system') LIMIT 1`,
             [slug, userId],
         );
         return result.rows[0] || null;
@@ -77,8 +77,9 @@ export class AgentRegistryRepository {
     async listByUser(userId: string): Promise<AgentRegistryEntry[]> {
         const result = await query<AgentRegistryEntry>(
             `SELECT * FROM agent_registry
-             WHERE user_id = $1 AND agent_type IN ('private', 'public')
-             ORDER BY created_at DESC`,
+             WHERE (user_id = $1 AND agent_type IN ('private', 'public'))
+                OR agent_type = 'system'
+             ORDER BY agent_type ASC, created_at DESC`,
             [userId],
         );
         return result.rows;

--- a/xerus_backend/src/domains/agents/service.ts
+++ b/xerus_backend/src/domains/agents/service.ts
@@ -296,6 +296,12 @@ export class AgentService {
 
         const validatedData = this.validator.validateUpdate(data);
 
+        if (entry.agent_type === 'system') {
+            if (validatedData.name !== undefined || validatedData.description !== undefined) {
+                throw new AgentAccessDeniedError(id);
+            }
+        }
+
         if (validatedData.ai_model) {
             await this.validator.validateModel(validatedData.ai_model);
         }
@@ -351,6 +357,10 @@ export class AgentService {
     async delete(id: number, userId: string): Promise<Agent> {
         const entry = await this.registry.findById(id);
         if (!entry) throw new AgentNotFoundError(id);
+
+        if (entry.agent_type === 'system') {
+            throw new AgentAccessDeniedError(id);
+        }
 
         const fs = this.getFs();
         const config = await fs.getAgentConfig(userId, entry.slug);

--- a/xerus_backend/src/domains/agents/types.ts
+++ b/xerus_backend/src/domains/agents/types.ts
@@ -20,7 +20,7 @@ export type {
     AgentCapabilities,
 } from '../../shared/types/agent-shared.types';
 
-export type AgentType = 'internal' | 'public' | 'private';
+export type AgentType = 'internal' | 'public' | 'private' | 'system';
 
 // Public Metadata Structure
 export interface PublicMetadata {

--- a/xerus_backend/src/domains/company/company.routes.ts
+++ b/xerus_backend/src/domains/company/company.routes.ts
@@ -20,7 +20,7 @@ import { shellEscapePath } from '../../utils/shell-safety';
 import { slugify, sanitizeSlug } from '../../shared/slugify';
 import { strictRateLimit } from '../../middleware/rate-limit';
 import { scaffoldProject, scaffoldChannel } from './workspace-scaffold.service';
-import { executeWorkspaceJsonQuery as execWsQuery } from '../conversations/workspace-db.helpers';
+import { executeWorkspaceJsonQuery as execWsQuery, executeWorkspaceQuery as execWsMutate, escapeSQL } from '../conversations/workspace-db.helpers';
 import {
     listDomainsWithChannels,
     createDomain,
@@ -39,6 +39,19 @@ const log = logger('CompanyRoutes');
 const MAX_NAME_LENGTH = 100;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_MESSAGE_CONTENT_LENGTH = 50000;
+
+const SYSTEM_AGENT_SLUGS = ['xerus-master', 'xerus-cto'];
+
+async function addSystemAgentsToChannel(
+    provider: import('../sandbox-infra/sandbox/providers/daytona.provider').DaytonaProvider,
+    sandboxId: string,
+    channelSlug: string,
+): Promise<void> {
+    for (const slug of SYSTEM_AGENT_SLUGS) {
+        const sql = `INSERT OR IGNORE INTO channel_members (channel_slug, agent_slug, role) VALUES ('${escapeSQL(channelSlug)}', '${escapeSQL(slug)}', 'member')`;
+        await execWsMutate(provider, sandboxId, sql).catch(() => {});
+    }
+}
 
 const router = Router();
 const auth = authenticateFirebaseToken;
@@ -180,6 +193,8 @@ router.post('/domains', auth, strictRateLimit, async (req: AuthenticatedRequest,
             CHANNEL_MISSION: `Default channel for ${name}`,
         }).catch(err => log.warn('Channel scaffold failed (non-critical)', { error: (err as Error).message }));
 
+        await addSystemAgentsToChannel(provider, sandboxId, generalSlug);
+
         sendResponse(res, 201, {
             domain: {
                 id: domain.slug,
@@ -262,6 +277,8 @@ router.post('/domains/:domainId/channels', auth, strictRateLimit, async (req: Au
             CHANNEL_NAME: name,
             CHANNEL_MISSION: description || `Channel: ${name}`,
         }).catch(err => log.warn('Channel scaffold failed (non-critical)', { error: (err as Error).message }));
+
+        await addSystemAgentsToChannel(provider, sandboxId, channelDbSlug);
 
         sendResponse(res, 201, {
             channel: {

--- a/xerus_backend/src/domains/drive/editability.ts
+++ b/xerus_backend/src/domains/drive/editability.ts
@@ -13,6 +13,7 @@ import { EditabilityStatus } from './types';
 const HIDDEN_PATTERNS: RegExp[] = [
     /^\.xerus\//,
     /(^|\/)\.git(\/|$)/,
+    /(^|\/)\.github(\/|$)/,
     /(^|\/)\.gitignore$/,
     /(^|\/)\.gitattributes$/,
     /(^|\/)\.gitmodules$/,

--- a/xerus_backend/src/domains/execution/__tests__/event-slug-filter.test.ts
+++ b/xerus_backend/src/domains/execution/__tests__/event-slug-filter.test.ts
@@ -79,7 +79,7 @@ function createContext(agentSlug: string, overrides?: Partial<PipelineContext>):
         toolCallCount: 0, status: 'running', streamOffset: 0, conversationId: null,
         responseText: '', responseChunks: [], creditsUsed: 0, keySource: null,
         agentSessionCount: 0, announceQueue: null, thinkingChunks: [], toolCallDetails: [],
-        eventsFiltered: 0, setupReport: null, hookHealth: null, sdkSessionId: null, triggerType: 'user_message' as const, toolCallMap: new Map(),
+        eventsFiltered: 0, setupReport: null, hookHealth: null, sdkSessionId: null, triggerType: 'user_message' as const, toolCallMap: new Map(), executionFailed: false, executionError: null,
         ...overrides,
     };
 }

--- a/xerus_backend/src/domains/execution/__tests__/runner-event-router.test.ts
+++ b/xerus_backend/src/domains/execution/__tests__/runner-event-router.test.ts
@@ -153,6 +153,8 @@ function createTestContext(overrides?: Partial<PipelineContext>): PipelineContex
         setupReport: null,
         hookHealth: null,
         triggerType: 'user_message',
+        executionFailed: false,
+        executionError: null,
         ...overrides,
     };
 }

--- a/xerus_backend/src/domains/execution/agent-config-resolver.ts
+++ b/xerus_backend/src/domains/execution/agent-config-resolver.ts
@@ -44,21 +44,29 @@ export async function resolveAgentConfig(
         }
     }
 
-    try {
-        const configPath = `${ws}/agents/${agentSlug}/config.json`;
-        const raw = await provider.readFile(sandboxId, configPath);
-        const config = JSON.parse(raw) as { adapter_type?: string; model?: string };
-        return {
-            adapterType: config.adapter_type === 'codex' ? 'codex' : 'claudecode',
-            model: config.model || undefined,
-        };
-    } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.includes('ENOENT') || message.includes('No such file') || message.includes('not found')) {
-            return { adapterType: 'claudecode', model: undefined };
+    const configPaths = [
+        `${ws}/agents/${agentSlug}/config.json`,
+        `${ws}/.claude/agents/${agentSlug}/config.json`,
+    ];
+
+    for (const configPath of configPaths) {
+        try {
+            const raw = await provider.readFile(sandboxId, configPath);
+            const config = JSON.parse(raw) as { adapter_type?: string; model?: string; ai_model?: string };
+            return {
+                adapterType: config.adapter_type === 'codex' ? 'codex' : 'claudecode',
+                model: config.ai_model || config.model || undefined,
+            };
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (message.includes('ENOENT') || message.includes('No such file') || message.includes('not found')) {
+                continue;
+            }
+            throw err;
         }
-        throw err;
     }
+
+    return { adapterType: 'claudecode', model: undefined };
 }
 
 /** @deprecated Use resolveAgentConfig instead */

--- a/xerus_backend/src/domains/execution/agent-files.routes.ts
+++ b/xerus_backend/src/domains/execution/agent-files.routes.ts
@@ -94,10 +94,10 @@ async function resolveAndVerifyAgent(
                 EXISTS(
                     SELECT 1 FROM execution_sessions es
                     JOIN workspaces w ON es.workspace_id = w.id
-                    WHERE w.user_id = a.user_id AND es.agent_slug = a.slug AND es.status = 'running'
+                    WHERE w.user_id = $1 AND es.agent_slug = a.slug AND es.status = 'running'
                 ) AS has_running_execution
          FROM agent_registry a
-         WHERE a.user_id = $1
+         WHERE (a.user_id = $1 OR a.agent_type = 'system')
          AND a.slug = $2
          LIMIT 1`,
         [userId, agentSlug],

--- a/xerus_backend/src/domains/execution/cli-stream-router.ts
+++ b/xerus_backend/src/domains/execution/cli-stream-router.ts
@@ -96,6 +96,9 @@ export async function handleCliStreamEvent(
                                 } else {
                                     const tracked = ctx.toolCallMap.get(callId)!;
                                     tracked.arguments = args;
+                                    if (Object.keys(args).length > 0) {
+                                        ctx.stream.send('tool_call' as StreamEventType, { toolName, arguments: args, callId });
+                                    }
                                 }
                                 break;
                             }

--- a/xerus_backend/src/domains/execution/cli-stream-router.ts
+++ b/xerus_backend/src/domains/execution/cli-stream-router.ts
@@ -29,6 +29,10 @@ export async function handleCliStreamEvent(
 
             if (streamType === 'content_block_delta' && delta) {
                 if (delta.type === 'text_delta' && typeof delta.text === 'string') {
+                    // Filter out raw error JSON from upstream LLM providers
+                    if (delta.text.includes('"type":"error"') && delta.text.includes('"api_error"')) {
+                        return true;
+                    }
                     ctx.responseChunks.push(delta.text);
                     ctx.stream.send('token' as StreamEventType, { text: delta.text, tokenCount: 0 });
                 } else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
@@ -146,7 +150,10 @@ export async function handleCliStreamEvent(
             const totalCost = d.total_cost_usd as number | undefined;
             const numTurns = d.num_turns as number | undefined;
 
-            if (result && !isError) {
+            if (isError) {
+                ctx.executionFailed = true;
+                ctx.executionError = result || 'Agent execution failed';
+            } else if (result) {
                 ctx.responseText = result;
             }
             if (totalCost) {

--- a/xerus_backend/src/domains/execution/entity-sync-handlers.ts
+++ b/xerus_backend/src/domains/execution/entity-sync-handlers.ts
@@ -149,7 +149,7 @@ export async function handleTriggerSync(
     }
 
     const agentResult = await deps.db.query<{ id: number }>(
-        `SELECT id FROM agent_registry WHERE slug = $1 AND user_id = $2 LIMIT 1`,
+        `SELECT id FROM agent_registry WHERE slug = $1 AND (user_id = $2 OR agent_type = 'system') LIMIT 1`,
         [d.agent_slug, ctx.request.userId],
     );
     if (agentResult.rows.length === 0) {

--- a/xerus_backend/src/domains/execution/execution-pipeline.types.ts
+++ b/xerus_backend/src/domains/execution/execution-pipeline.types.ts
@@ -149,6 +149,10 @@ export interface PipelineContext {
     hookHealth: HookHealth | null;
     /** Trigger type that initiated this execution (user_message, heartbeat, schedule, etc.) */
     triggerType: TriggerType;
+    /** Set to true when CLI result reports is_error (e.g., "stream closed before completion") */
+    executionFailed: boolean;
+    /** Error message from CLI result when is_error is true */
+    executionError: string | null;
 }
 
 // -----------------------------------------------------------------------------

--- a/xerus_backend/src/domains/execution/execution.service.ts
+++ b/xerus_backend/src/domains/execution/execution.service.ts
@@ -150,6 +150,8 @@ export class ExecutionService {
             setupReport: null,
             hookHealth: null,
             triggerType: triggerType || 'user_message',
+            executionFailed: false,
+            executionError: null,
         };
 
         // Track preflight promises for cleanup if early failure occurs
@@ -347,12 +349,19 @@ export class ExecutionService {
             await updateSessionRecord(resolved, ctx);
 
             const summary = buildSummary(ctx);
-            stream.sendDone(ctx.responseText || undefined, summary, {
-                runId: null,
-                requestId: ctx.executionId,
-                traceId: ctx.executionId,
-                responseTimeMs: Date.now() - startedAt,
-            }, { databaseUpdated: true, conversationId: ctx.conversationId });
+            if (ctx.executionFailed) {
+                stream.sendError(
+                    { message: ctx.executionError || 'Agent execution failed', code: 'EXECUTION_ERROR', type: 'llm_error' },
+                    { runId: null, requestId: ctx.executionId, traceId: ctx.executionId, responseTimeMs: Date.now() - startedAt },
+                );
+            } else {
+                stream.sendDone(ctx.responseText || undefined, summary, {
+                    runId: null,
+                    requestId: ctx.executionId,
+                    traceId: ctx.executionId,
+                    responseTimeMs: Date.now() - startedAt,
+                }, { databaseUpdated: true, conversationId: ctx.conversationId });
+            }
 
         } catch (error) {
             ctx.status = 'failed';

--- a/xerus_backend/src/domains/execution/metadata-sync-router.ts
+++ b/xerus_backend/src/domains/execution/metadata-sync-router.ts
@@ -77,7 +77,7 @@ export async function handleMetadataSync(
             const agentSlug = data.agent_id as string | undefined;
             if (appSlug && agentSlug) {
                 const agentCheck = await deps.db.query<{ id: number }>(
-                    `SELECT id FROM agent_registry WHERE slug = $1 AND user_id = $2 LIMIT 1`,
+                    `SELECT id FROM agent_registry WHERE slug = $1 AND (user_id = $2 OR agent_type = 'system') LIMIT 1`,
                     [agentSlug, userId],
                 );
                 if (agentCheck.rows.length > 0) {

--- a/xerus_backend/src/domains/execution/runner-event-router.ts
+++ b/xerus_backend/src/domains/execution/runner-event-router.ts
@@ -4,7 +4,7 @@
 import { logger } from '../../utils/logger';
 import type { PipelineContext, ResolvedExecutionDeps } from './execution-pipeline.types';
 import { requireAgent } from './pipeline-guards';
-import { STREAM_EVENT_TYPES, type RunnerEventType } from './types';
+import { STREAM_EVENT_TYPES, type RunnerEventType, type StreamEventType } from './types';
 import type { HITLRequest } from './hitl/hitl.types';
 import { handleMetadataSync } from './metadata-sync-router';
 import { handleTriggerIndexing } from './indexing-event-handler';
@@ -75,6 +75,11 @@ export async function routeEventToBackend(
             };
             ctx.toolCallDetails.push(tcDetail);
             ctx.toolCallMap.set(tcDetail.call_id, tcDetail);
+            ctx.stream.send('tool_call' as StreamEventType, {
+                toolName: tc.tool_name,
+                arguments: tc.arguments ?? {},
+                callId: tcDetail.call_id,
+            });
             break;
         }
         case 'tool_result': {
@@ -85,6 +90,13 @@ export async function routeEventToBackend(
                     entry.result = tr.result;
                     entry.success = tr.success ?? true;
                     entry.duration_ms = Date.now() - entry.started_at;
+
+                    ctx.stream.send('tool_result' as StreamEventType, {
+                        callId: tr.call_id,
+                        result: tr.result,
+                        durationMs: entry.duration_ms,
+                        success: entry.success,
+                    });
 
                     // Sync to Neon AFTER write succeeds (not on tool_call)
                     // Prevents phantom agent_registry entries from failed writes

--- a/xerus_backend/src/domains/execution/runner-event-router.ts
+++ b/xerus_backend/src/domains/execution/runner-event-router.ts
@@ -211,7 +211,7 @@ async function handleSessionStarted(
         ctx.stream.send('meta', {
             model: runnerModel || ctx.agent?.ai_model || 'unknown',
             agentSlug: evt.agent_slug || ctx.agent?.slug || '',
-            agentName: evt.agent_slug || ctx.agent?.slug || '',
+            agentName: ctx.agent?.name || evt.agent_slug || ctx.agent?.slug || '',
             startedAt: new Date().toISOString(),
         });
     }

--- a/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
+++ b/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
@@ -150,7 +150,7 @@ export class AgentConfigLoader {
             return {
                 agent_slug: agentSlug,
                 system_prompt,
-                model: String(parsed.model || DEFAULT_SDK_MODEL),
+                model: String(parsed.ai_model || parsed.model || DEFAULT_SDK_MODEL),
                 tools,
                 max_turns: Number(parsed.max_turns) || 50,
                 mcp_servers,
@@ -252,7 +252,7 @@ export class AgentConfigLoader {
                 description: String(parsed.description || parsed.name || slug),
                 prompt: soulAppend,
                 tools,
-                model: resolveModelAlias(String(parsed.model || '')),
+                model: resolveModelAlias(String(parsed.ai_model || parsed.model || '')),
                 maxTurns: Number(parsed.max_turns) || 50,
             };
         } catch (error) {

--- a/xerus_backend/src/domains/execution/types.ts
+++ b/xerus_backend/src/domains/execution/types.ts
@@ -77,6 +77,12 @@ export const STREAM_EVENT_TYPES = [
     'credit_warning',
     'insufficient_credits',
     'provider_unavailable',
+    'tool_progress',
+    'tool_use_summary',
+    'task_started',
+    'task_progress',
+    'task_updated',
+    'task_notification',
 ] as const;
 
 export type StreamEventType = (typeof STREAM_EVENT_TYPES)[number];

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/session-control.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/session-control.routes.ts
@@ -159,7 +159,7 @@ router.post('/get_status', async (req: InternalMcpRequest, res: Response, next: 
 
         if (include_agents !== false) {
             const agentResult = await query<{ slug: string; status: string; adapter_type: string }>(
-                `SELECT slug, status, adapter_type FROM agent_registry WHERE user_id = $1 ORDER BY slug`,
+                `SELECT slug, status, adapter_type FROM agent_registry WHERE (user_id = $1 OR agent_type = 'system') ORDER BY slug`,
                 [userId]
             );
             statusData.agents = agentResult.rows;

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/trigger.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/trigger.routes.ts
@@ -35,7 +35,7 @@ router.post('/register_trigger', async (req: InternalMcpRequest, res: Response, 
 
         // Look up agent_id from slug
         const agentResult = await query<{ id: number }>(
-            `SELECT id FROM agent_registry WHERE slug = $1 AND user_id = $2`,
+            `SELECT id FROM agent_registry WHERE slug = $1 AND (user_id = $2 OR agent_type = 'system')`,
             [agent_slug, userId]
         );
 

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-health.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-health.ts
@@ -107,7 +107,7 @@ export async function syncAgentsToWorkspace(
 ): Promise<void> {
     const result = await db.query<{ id: number; slug: string; name: string; role: string | null }>(
         `SELECT id, slug, slug AS name, 'specialist' AS role
-         FROM agent_registry WHERE user_id = $1`,
+         FROM agent_registry WHERE (user_id = $1 OR agent_type = 'system')`,
         [userId],
     );
 

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-template-sync.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-template-sync.ts
@@ -37,6 +37,7 @@ const PLATFORM_OVERLAY_PATHS: ReadonlyArray<string> = [
     'agents/index.json',
     'agents/xerus-master',
     'agents/xerus-cto',
+    'drive/welcome.md',
 ];
 
 export interface WorkspaceTemplateSyncOptions {
@@ -86,7 +87,8 @@ export async function syncWorkspaceTemplate(
     const script = [
         `set -e`,
         `rm -rf ${tempDir}`,
-        `git clone --recurse-submodules --depth 1 ${branchFlag} '${templateUrl}' ${tempDir} >/dev/null 2>&1`,
+        `git clone --recurse-submodules --depth 1 ${branchFlag} '${templateUrl}' ${tempDir} 2>/dev/null`,
+        `if [ ! -f "${tempDir}/CLAUDE.md" ]; then echo "CLONE_FAILED: template missing CLAUDE.md"; exit 1; fi`,
         `mkdir -p '${basePath}'`,
         `cd '${basePath}'`,
         `for path in ${pathsLiteral}; do`,
@@ -94,6 +96,21 @@ export async function syncWorkspaceTemplate(
         `  dst="${basePath}/$path"`,
         `  if [ ! -e "$src" ]; then`,
         `    echo "MISSING:$path"`,
+        `    continue`,
+        `  fi`,
+        `  changed=1`,
+        `  if [ -d "$src" ]; then`,
+        `    if [ -d "$dst" ]; then`,
+        `      diff_out=$(diff -rq "$src" "$dst" 2>/dev/null) || true`,
+        `      if [ -z "$diff_out" ]; then changed=0; fi`,
+        `    fi`,
+        `  else`,
+        `    if [ -f "$dst" ] && cmp -s "$src" "$dst"; then`,
+        `      changed=0`,
+        `    fi`,
+        `  fi`,
+        `  if [ "$changed" = "0" ]; then`,
+        `    echo "UNCHANGED:$path"`,
         `    continue`,
         `  fi`,
         ...(dryRun

--- a/xerus_backend/src/domains/sandbox-infra/scaffold/scaffold-payload.service.ts
+++ b/xerus_backend/src/domains/sandbox-infra/scaffold/scaffold-payload.service.ts
@@ -65,9 +65,20 @@ function buildInitialModuleClaudeMd(opts: {
     tools: string[];
     autonomyLevel: string;
 }): string {
-    const toolsList = opts.tools.length > 0
-        ? opts.tools.map((t) => `- ${t} [status: check Pipedream MCP]`).join('\n')
-        : 'No tool integrations assigned. Use code-first approach for external API calls.';
+    let toolsSection: string;
+    if (opts.tools.length > 0) {
+        const toolLines = opts.tools.map((t) =>
+            `- ${t} [NOT_CONNECTED — needs OAuth authentication]`
+        ).join('\n');
+        toolsSection = [
+            'Tools are assigned but not yet connected. Ask @human to authenticate these integrations in Settings > Connectors:',
+            toolLines,
+            '',
+            'Once connected, these tools become available as MCP servers. Use mcp__<tool_name>__* tool calls to interact with them.',
+        ].join('\n');
+    } else {
+        toolsSection = 'No tool integrations assigned. Use code-first approach for external API calls.';
+    }
 
     return `## Identity
 
@@ -83,10 +94,7 @@ No specialized skills assigned. Use your general capabilities.
 
 ## Connected Tools
 
-Integrations available to you (via MCP):
-${toolsList}
-
-If a tool action fails with "NOT_CONNECTED", ask @human to authenticate the integration.
+${toolsSection}
 
 ## Colleagues
 

--- a/xerus_backend/src/domains/sandbox-infra/workspace/module-claude-md.generator.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/module-claude-md.generator.ts
@@ -47,10 +47,7 @@ Auto-activated expertise available to you:
 
 ## Connected Tools
 
-Integrations available to you (via MCP):
 {connected_tools}
-
-If a tool action fails with "NOT_CONNECTED", ask @human to authenticate the integration.
 
 ## Colleagues
 
@@ -129,6 +126,18 @@ async function listInstalledSkills(
     return skills;
 }
 
+async function listMcpServers(sandboxFs: SandboxFileSystem, workspacePath: string): Promise<string[]> {
+    const mcpJsonPath = `${workspacePath}/.mcp.json`;
+    try {
+        const raw = await sandboxFs.readFile(mcpJsonPath);
+        const doc = JSON.parse(raw) as { mcpServers?: Record<string, unknown> };
+        if (!doc.mcpServers || typeof doc.mcpServers !== 'object') return [];
+        return Object.keys(doc.mcpServers);
+    } catch {
+        return [];
+    }
+}
+
 async function readColleagues(
     slug: string,
     sandboxFs: SandboxFileSystem,
@@ -176,9 +185,41 @@ function formatSkills(skills: Array<{ name: string; scope: 'global' | 'channel';
     }).join('\n');
 }
 
-function formatConnectedTools(tools: string[]): string {
-    if (tools.length === 0) return 'No tool integrations assigned. Use code-first approach for external API calls.';
-    return tools.map((t) => `- ${t} [status: check Pipedream MCP]`).join('\n');
+function formatConnectedTools(tools: string[], mcpServers: string[]): string {
+    if (tools.length === 0 && mcpServers.length === 0) {
+        return 'No tool integrations assigned. Use code-first approach for external API calls.';
+    }
+
+    const lines: string[] = [];
+
+    lines.push('You have external integrations connected via MCP (Model Context Protocol) servers.');
+    lines.push('These tools are ALREADY configured and available — use them by calling their MCP tools directly.');
+    lines.push('');
+
+    if (mcpServers.length > 0) {
+        lines.push('Available MCP servers (call their tools like any other tool):');
+        for (const server of mcpServers) {
+            const displayName = server.replace(/-/g, ' ').replace(/_/g, ' ');
+            lines.push(`- **${server}**: Use mcp__${server}__* tool calls to interact with ${displayName}`);
+        }
+    }
+
+    if (tools.length > 0) {
+        const toolsNotInMcp = tools.filter(t => !mcpServers.includes(t));
+        if (toolsNotInMcp.length > 0) {
+            lines.push('');
+            lines.push('Assigned but not yet connected (ask @human to authenticate):');
+            for (const t of toolsNotInMcp) {
+                lines.push(`- ${t} [NOT_CONNECTED — needs OAuth authentication]`);
+            }
+        }
+    }
+
+    lines.push('');
+    lines.push('To discover available actions for any MCP server, call its tools. Each server exposes actions specific to that integration (e.g., list files, send messages, create records).');
+    lines.push('If a tool call fails with an auth error, ask @human to re-authenticate the integration in Settings > Connectors.');
+
+    return lines.join('\n');
 }
 
 function formatColleagues(colleagues: Array<{ slug: string; description: string }>): string {
@@ -217,10 +258,11 @@ export class ModuleClaudeMdGenerator {
         // Resolve agent's channel paths for channel-scoped skill discovery
         const agentChannelPaths = this.resolveAgentChannelPaths(config);
 
-        const [kbDocs, skills, colleagues] = await Promise.all([
+        const [kbDocs, skills, colleagues, mcpServers] = await Promise.all([
             listKbDocs(slug, sandboxFs, workspacePath),
             listInstalledSkills(sandboxFs, workspacePath, agentChannelPaths),
             readColleagues(slug, sandboxFs, workspacePath),
+            listMcpServers(sandboxFs, workspacePath),
         ]);
 
         const agentName = config.name || slug;
@@ -233,7 +275,7 @@ export class ModuleClaudeMdGenerator {
             .replaceAll('{agent_description}', agentDescription)
             .replaceAll('{kb_documents}', formatKbDocs(kbDocs, slug))
             .replaceAll('{skills}', formatSkills(skills))
-            .replaceAll('{connected_tools}', formatConnectedTools(tools))
+            .replaceAll('{connected_tools}', formatConnectedTools(tools, mcpServers))
             .replaceAll('{colleagues}', formatColleagues(colleagues))
             .replaceAll('{autonomy_level}', autonomyLevel)
             .replaceAll('{autonomy_rules}', AUTONOMY_RULES[autonomyLevel] || AUTONOMY_RULES.supervised);

--- a/xerus_web/app/ai-agents/[id]/client.tsx
+++ b/xerus_web/app/ai-agents/[id]/client.tsx
@@ -157,7 +157,7 @@ export default function AgentDetailsClient({ agentId }: AgentDetailsClientProps)
   const isPublic = agent?.agentType === 'public'
   const canPublish = isOwner && isPrivate
   const canUnpublish = isOwner && isPublic && agent?.userId !== null
-  const canDelete = isOwner && isPrivate
+  const canDelete = isOwner && isPrivate && agent?.agentType !== 'system'
 
   // --- Render ---
   if (isLoadingAgent) {

--- a/xerus_web/app/chat/page.tsx
+++ b/xerus_web/app/chat/page.tsx
@@ -10,11 +10,13 @@ function ChatPageInner() {
     const searchParams = useSearchParams()
     const initialMessage = searchParams.get('q') || undefined
     const agentId = searchParams.get('agent') || undefined
+    const conversationId = searchParams.get('c') || undefined
 
     return (
         <ChatContainer
             initialMessage={initialMessage}
             initialAgentId={agentId}
+            conversationId={conversationId}
         />
     )
 }

--- a/xerus_web/app/workspace/page.tsx
+++ b/xerus_web/app/workspace/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { FolderOpen } from 'lucide-react'
+import { FolderOpen, LayoutGrid, List } from 'lucide-react'
 import { Panel, Group as PanelGroup, Separator as PanelResizeHandle } from 'react-resizable-panels'
 import { motion, useReducedMotion } from 'framer-motion'
 import { XerusLoader } from '@/components/common/XerusLoader'
@@ -26,7 +26,7 @@ import { cn } from '@/lib/utils'
 
 const SECTION_PATHS: Partial<Record<WorkspaceSection, string>> = {
   agents: 'agents',
-  skills: 'marketplace',
+  skills: 'marketplace/skills',
   connectors: 'connectors',
   knowledge: 'drive',
   memory: '.memory',
@@ -93,6 +93,7 @@ export default function WorkspacePage() {
     if (!tree?.root) return []
     const folders: Array<{ id: string; name: string }> = []
     function walk(node: FileNode) {
+      if (node.type === 'directory' && node.path.startsWith('.claude/')) return
       if (node.type === 'directory' && (node.path.endsWith('/knowledge') || node.name === 'knowledge')) {
         folders.push({ id: node.path, name: node.path })
       }
@@ -204,6 +205,31 @@ export default function WorkspacePage() {
 
   const reduceMotion = useReducedMotion()
 
+  const viewToggleElement = (
+    <div className="flex items-center bg-surface-hover rounded-lg p-0.5 border border-surface-active/60">
+      <button
+        onClick={() => handleContentViewChange('ui')}
+        className={cn(
+          'p-1.5 rounded-md transition-all',
+          contentViewMode === 'ui' ? 'bg-card text-text shadow-sm' : 'text-text-secondary hover:text-text'
+        )}
+        title="Card view"
+      >
+        <LayoutGrid className="w-4 h-4" />
+      </button>
+      <button
+        onClick={() => handleContentViewChange('browse')}
+        className={cn(
+          'p-1.5 rounded-md transition-all',
+          contentViewMode === 'browse' ? 'bg-card text-text shadow-sm' : 'text-text-secondary hover:text-text'
+        )}
+        title="File view"
+      >
+        <List className="w-4 h-4" />
+      </button>
+    </div>
+  )
+
   // Stable callbacks for panels (rule: rerender-functional-setstate)
   const handleAgentSelect = useCallback((agent: Assistant) => {
     setDetailView({ type: 'agent', id: agent.slug || agent.id })
@@ -249,13 +275,13 @@ export default function WorkspacePage() {
               /* ---- UI Mode: Card grid ---- */
               <div className="h-full">
                 {activeSection === 'agents' && (
-                  <AgentsPanel onSelect={handleAgentSelect} />
+                  <AgentsPanel onSelect={handleAgentSelect} viewToggle={viewToggleElement} />
                 )}
                 {activeSection === 'skills' && (
-                  <SkillsPanel onSelect={handleSkillSelect} />
+                  <SkillsPanel onSelect={handleSkillSelect} viewToggle={viewToggleElement} />
                 )}
                 {activeSection === 'connectors' && (
-                  <ConnectorsPanel />
+                  <ConnectorsPanel viewToggle={viewToggleElement} />
                 )}
               </div>
             ) : (
@@ -299,6 +325,7 @@ export default function WorkspacePage() {
                         onUploadClick={(path) => { setUploadTargetPath(path); setUploadPanelOpen(true) }}
                         onNewFolder={confirmNewFolder}
                         showPropertyBar={currentDirPath?.startsWith('drive') ?? false}
+                        sectionToggle={hasUIMode ? viewToggleElement : undefined}
                       />
                     </div>
                   </Panel>

--- a/xerus_web/components/agents/AgentCard.tsx
+++ b/xerus_web/components/agents/AgentCard.tsx
@@ -3,8 +3,8 @@
 import React from 'react'
 import type { Assistant } from "@/lib/api/types"
 import { AgentAvatarWithModel, ModelIcon, AdapterIcon } from './AgentAvatar'
-import { Loader2, Lock, Users, Plus, Upload, Wrench, Settings, Copy, ArrowRight } from 'lucide-react'
-import { canCloneAgent, getAgentVisibilityClass } from "@/utils/agentLabels"
+import { Loader2, Lock, Users, Plus, Upload, Wrench, Settings, Copy, ArrowRight, Shield } from 'lucide-react'
+import { canCloneAgent, getAgentVisibilityClass, isSystemAgent } from "@/utils/agentLabels"
 import { formatModelName, getAdapterIconPath } from "@/utils/models"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
@@ -19,10 +19,13 @@ interface AgentCardProps {
 
 const AgentCardComponent = ({ agent, onClone, onChat, onClick, isCloning, isOwner }: AgentCardProps) => {
     const isPublic = agent.agentType === 'public' || agent.agentType === 'shared'
+    const isSystem = isSystemAgent(agent.agentType)
 
     // Get visibility icon based on agent type
     const getVisibilityIcon = () => {
         switch (agent.agentType) {
+            case 'system':
+                return <Shield className="w-3 h-3" />;
             case 'private':
                 return <Lock className="w-3 h-3" />;
             case 'shared':
@@ -129,9 +132,13 @@ const AgentCardComponent = ({ agent, onClone, onChat, onClick, isCloning, isOwne
                         </div>
                     )}
                     {/* Visibility Badge */}
-                    <div className={`flex items-center gap-1 text-[10px] font-medium px-2 py-1 rounded-md border ${agent.agentType === 'public' ? 'text-text-secondary bg-surface-alt border-surface-active' : getAgentVisibilityClass(agent.agentType)}`}>
+                    <div className={`flex items-center gap-1 text-[10px] font-medium px-2 py-1 rounded-md border ${
+                        isSystem ? 'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-400 dark:bg-amber-950/30 dark:border-amber-800'
+                        : agent.agentType === 'public' ? 'text-text-secondary bg-surface-alt border-surface-active'
+                        : getAgentVisibilityClass(agent.agentType)
+                    }`}>
                         {getVisibilityIcon()}
-                        <span className="capitalize">{agent.agentType || 'public'}</span>
+                        <span className="capitalize">{isSystem ? 'System' : agent.agentType || 'public'}</span>
                     </div>
                 </div>
             </div>

--- a/xerus_web/components/agents/ide/AgentProfileCard.tsx
+++ b/xerus_web/components/agents/ide/AgentProfileCard.tsx
@@ -25,7 +25,7 @@ interface Agent {
     is_active?: boolean
     avatar?: string
     avatarUrl?: string | null
-    agentType?: 'public' | 'private' | 'shared'
+    agentType?: 'public' | 'private' | 'shared' | 'system'
     userId?: string | null
     isVerified?: boolean
     cloneCount?: number
@@ -51,6 +51,7 @@ export function AgentProfileCard({ agent, onUpdate, isSaving }: AgentProfileCard
 
     // Check if user can edit this agent
     const isEditable = canEditAgent(agent.userId, user?.uid, agent.agentType)
+    const isSystem = agent.agentType === 'system'
     const isPublic = agent.agentType === 'public'
 
     useEffect(() => {
@@ -245,7 +246,7 @@ export function AgentProfileCard({ agent, onUpdate, isSaving }: AgentProfileCard
             <div className="flex-1 min-w-0 ml-6">
                 {/* Name & Status Row */}
                 <div className="flex items-center gap-3 mb-2">
-                    {isEditingName && isEditable ? (
+                    {isEditingName && isEditable && !isSystem ? (
                         <Input
                             ref={nameInputRef}
                             value={localAgent.name}
@@ -261,8 +262,8 @@ export function AgentProfileCard({ agent, onUpdate, isSaving }: AgentProfileCard
                     ) : (
                         <div className="flex items-center gap-2">
                             <h1
-                                onClick={() => isEditable && setIsEditingName(true)}
-                                className={`font-serif text-3xl tracking-tight text-text ${isEditable ? 'cursor-text hover:text-text/80' : ''} transition-colors`}
+                                onClick={() => isEditable && !isSystem && setIsEditingName(true)}
+                                className={`font-serif text-3xl tracking-tight text-text ${isEditable && !isSystem ? 'cursor-text hover:text-text/80' : ''} transition-colors`}
                             >
                                 {localAgent.name}
                             </h1>
@@ -274,7 +275,7 @@ export function AgentProfileCard({ agent, onUpdate, isSaving }: AgentProfileCard
                                     </svg>
                                 </span>
                             )}
-                            {isEditable && (
+                            {isEditable && !isSystem && (
                                 <button
                                     onClick={() => setIsEditingName(true)}
                                     className="p-1.5 rounded-lg hover:bg-surface-hover text-text-secondary hover:text-secondary transition-colors"
@@ -295,7 +296,7 @@ export function AgentProfileCard({ agent, onUpdate, isSaving }: AgentProfileCard
 
                 {/* Description */}
                 <div className="mb-3">
-                    {isEditingDesc && isEditable ? (
+                    {isEditingDesc && isEditable && !isSystem ? (
                         <Textarea
                             ref={descInputRef}
                             value={localAgent.description}
@@ -313,12 +314,12 @@ export function AgentProfileCard({ agent, onUpdate, isSaving }: AgentProfileCard
                     ) : (
                         <div className="flex items-start gap-2">
                             <p
-                                onClick={() => isEditable && setIsEditingDesc(true)}
-                                className={`text-base text-text-secondary leading-relaxed ${isEditable ? 'cursor-text hover:text-text-secondary/80' : ''} transition-colors flex-1`}
+                                onClick={() => isEditable && !isSystem && setIsEditingDesc(true)}
+                                className={`text-base text-text-secondary leading-relaxed ${isEditable && !isSystem ? 'cursor-text hover:text-text-secondary/80' : ''} transition-colors flex-1`}
                             >
                                 {localAgent.description || (isEditable ? "Add a description..." : "No description")}
                             </p>
-                            {isEditable && (
+                            {isEditable && !isSystem && (
                                 <button
                                     onClick={() => setIsEditingDesc(true)}
                                     className="p-1.5 rounded-lg hover:bg-surface-hover text-text-secondary hover:text-secondary transition-colors shrink-0"

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -102,15 +102,19 @@ export function ChatContainer({
   // ---- Task dock (subagent progress) ----
   const taskDock = useTaskDock()
 
-  // Sync subagent events from executionState to task dock
+  // Sync delegation tasks to task dock (skip raw infra steps like sandbox/executing)
+  const INFRA_NOISE = new Set(['sandbox', 'executing', 'provisioning', 'connecting'])
   useEffect(() => {
     const steps = state.executionState?.steps ?? []
     for (const step of steps) {
       const rawName = step.name ?? ''
       const cleanName = rawName.replace(/^Spawning\s+/i, '').replace(/\s*\(failed\)\s*$/i, '')
-      const displayName = cleanName || 'Processing'
+      if (INFRA_NOISE.has(cleanName.toLowerCase())) continue
+      if (!cleanName) continue
+      const meta = step.metadata as Record<string, string> | undefined
+      const subtitle = meta?.toAgent ? `@${meta.toAgent}` : ''
       if (step.status === 'active') {
-        taskDock.addTask(step.id, displayName, rawName)
+        taskDock.addTask(step.id, cleanName, subtitle)
       } else if (step.status === 'completed') {
         const durationMs = step.endTime && step.startTime ? step.endTime - step.startTime : undefined
         const success = !rawName.includes('failed')

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -5,6 +5,8 @@ import dynamic from 'next/dynamic'
 import { MessageList } from './MessageList'
 import { ChatInput } from './ChatInput'
 import { DeliverableChips } from './DeliverableChips'
+import { TaskDock } from './TaskDock'
+import { useTaskDock } from './useTaskDock'
 import type { SandboxTab } from './SandboxPanel'
 
 // Heavy panels loaded only when user opens them (bundle-dynamic-imports + bundle-conditional rules)
@@ -96,6 +98,26 @@ export function ChatContainer({
   const [terminalUrl, setTerminalUrl] = useState<string | null>(null)
   const [isTerminalLoading, setIsTerminalLoading] = useState(false)
   const [sandboxTab, setSandboxTab] = useState<SandboxTab>('terminal')
+
+  // ---- Task dock (subagent progress) ----
+  const taskDock = useTaskDock()
+
+  // Sync subagent events from executionState to task dock
+  const prevStepsRef = useRef<number>(0)
+  useEffect(() => {
+    const steps = state.executionState?.steps ?? []
+    if (steps.length === prevStepsRef.current) return
+    prevStepsRef.current = steps.length
+    for (const step of steps) {
+      if (step.status === 'active') {
+        taskDock.addTask(step.id, step.name ?? 'Working', step.name ?? '')
+      } else if (step.status === 'completed') {
+        const durationMs = step.endTime && step.startTime ? step.endTime - step.startTime : undefined
+        const success = !step.name?.includes('failed')
+        taskDock.completeTask(step.id, success, durationMs)
+      }
+    }
+  }, [state.executionState?.steps, taskDock])
 
   // ---- Tool auth (Pipedream OAuth) ----
   const handleToolAuthConnect = useCallback((appSlug: string) => {
@@ -325,6 +347,16 @@ export function ChatContainer({
               onSelect={handleOpenDeliverable}
             />
 
+            {taskDock.isVisible && (
+              <TaskDock
+                tasks={taskDock.tasks}
+                activeCount={taskDock.activeCount}
+                isCollapsed={taskDock.isCollapsed}
+                onCollapse={taskDock.collapse}
+                onExpand={taskDock.expand}
+              />
+            )}
+
             <ChatInput
               onSendMessage={chat.sendMessage}
               disabled={state.isLoading}
@@ -342,6 +374,7 @@ export function ChatContainer({
               onOpenBrowser={handleOpenBrowser}
               isBrowserLoading={isBrowserLoading}
               isBrowserOpen={!!browserUrl}
+              conversationId={conversationId}
             />
           </div>
         </Panel>

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -347,8 +347,8 @@ export function ChatContainer({
               onSelect={handleOpenDeliverable}
             />
 
-            <div className="relative shrink-0">
-              {taskDock.isVisible && (
+            <ChatInput
+              headerContent={taskDock.isVisible ? (
                 <TaskDock
                   tasks={taskDock.tasks}
                   activeCount={taskDock.activeCount}
@@ -357,8 +357,7 @@ export function ChatContainer({
                   onExpand={taskDock.expand}
                   onDismiss={taskDock.clearTasks}
                 />
-              )}
-            <ChatInput
+              ) : undefined}
               onSendMessage={chat.sendMessage}
               disabled={state.isLoading}
               placeholder={
@@ -377,7 +376,6 @@ export function ChatContainer({
               isBrowserOpen={!!browserUrl}
               conversationId={conversationId}
             />
-            </div>
           </div>
         </Panel>
 

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -347,16 +347,17 @@ export function ChatContainer({
               onSelect={handleOpenDeliverable}
             />
 
-            {taskDock.isVisible && (
-              <TaskDock
-                tasks={taskDock.tasks}
-                activeCount={taskDock.activeCount}
-                isCollapsed={taskDock.isCollapsed}
-                onCollapse={taskDock.collapse}
-                onExpand={taskDock.expand}
-              />
-            )}
-
+            <div className="relative shrink-0">
+              {taskDock.isVisible && (
+                <TaskDock
+                  tasks={taskDock.tasks}
+                  activeCount={taskDock.activeCount}
+                  isCollapsed={taskDock.isCollapsed}
+                  onCollapse={taskDock.collapse}
+                  onExpand={taskDock.expand}
+                  onDismiss={taskDock.clearTasks}
+                />
+              )}
             <ChatInput
               onSendMessage={chat.sendMessage}
               disabled={state.isLoading}
@@ -376,6 +377,7 @@ export function ChatContainer({
               isBrowserOpen={!!browserUrl}
               conversationId={conversationId}
             />
+            </div>
           </div>
         </Panel>
 

--- a/xerus_web/components/chat/ChatContainer.tsx
+++ b/xerus_web/components/chat/ChatContainer.tsx
@@ -103,17 +103,17 @@ export function ChatContainer({
   const taskDock = useTaskDock()
 
   // Sync subagent events from executionState to task dock
-  const prevStepsRef = useRef<number>(0)
   useEffect(() => {
     const steps = state.executionState?.steps ?? []
-    if (steps.length === prevStepsRef.current) return
-    prevStepsRef.current = steps.length
     for (const step of steps) {
+      const rawName = step.name ?? ''
+      const cleanName = rawName.replace(/^Spawning\s+/i, '').replace(/\s*\(failed\)\s*$/i, '')
+      const displayName = cleanName || 'Processing'
       if (step.status === 'active') {
-        taskDock.addTask(step.id, step.name ?? 'Working', step.name ?? '')
+        taskDock.addTask(step.id, displayName, rawName)
       } else if (step.status === 'completed') {
         const durationMs = step.endTime && step.startTime ? step.endTime - step.startTime : undefined
-        const success = !step.name?.includes('failed')
+        const success = !rawName.includes('failed')
         taskDock.completeTask(step.id, success, durationMs)
       }
     }

--- a/xerus_web/components/chat/ChatInput.tsx
+++ b/xerus_web/components/chat/ChatInput.tsx
@@ -26,6 +26,7 @@ interface ChatInputProps {
   isBrowserLoading?: boolean
   isBrowserOpen?: boolean
   conversationId?: string
+  headerContent?: React.ReactNode
 }
 
 export function ChatInput({
@@ -43,6 +44,7 @@ export function ChatInput({
   isBrowserLoading,
   isBrowserOpen,
   conversationId,
+  headerContent,
 }: ChatInputProps) {
   const [value, setValue] = useState('')
   const [focused, setFocused] = useState(false)
@@ -345,6 +347,9 @@ export function ChatInput({
               : 'border-border shadow-sm hover:border-border/80'
           )}
         >
+          {/* Dynamic header content (task dock, etc.) */}
+          {headerContent}
+
           {/* Textarea */}
           <textarea
             ref={textareaRef}

--- a/xerus_web/components/chat/ChatInput.tsx
+++ b/xerus_web/components/chat/ChatInput.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { ArrowUp, AtSign, Paperclip, Bot, Monitor, TerminalSquare } from 'lucide-react'
+import { ArrowUp, AtSign, Paperclip, Monitor, TerminalSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Agent } from './types'
 import { AgentDropdown } from './AgentDropdown'
-import { isMascotConfig } from '@/lib/mascot-config'
-import { MascotAvatar } from '@/components/agents/MascotAvatar'
+import { SlashCommandPicker } from './SlashCommandPicker'
+import { useSlashCommands } from './useSlashCommands'
+import { UnifiedMentionPicker, type MentionItem } from './UnifiedMentionPicker'
+import { useWorkspaceFiles } from '@/hooks/useWorkspaceFiles'
+import { useKBSearch } from '@/hooks/useKBSearch'
 
 interface ChatInputProps {
   onSendMessage: (message: string) => void
@@ -22,6 +25,7 @@ interface ChatInputProps {
   onOpenBrowser?: () => void
   isBrowserLoading?: boolean
   isBrowserOpen?: boolean
+  conversationId?: string
 }
 
 export function ChatInput({
@@ -38,6 +42,7 @@ export function ChatInput({
   onOpenBrowser,
   isBrowserLoading,
   isBrowserOpen,
+  conversationId,
 }: ChatInputProps) {
   const [value, setValue] = useState('')
   const [focused, setFocused] = useState(false)
@@ -49,7 +54,19 @@ export function ChatInput({
   const [mentionQuery, setMentionQuery] = useState('')
   const [mentionStart, setMentionStart] = useState(-1)
   const [selectedIdx, setSelectedIdx] = useState(0)
-  const pickerRef = useRef<HTMLDivElement>(null)
+
+  // Slash command state
+  const [showSlashPicker, setShowSlashPicker] = useState(false)
+  const [slashQuery, setSlashQuery] = useState('')
+  const [slashSelectedIdx, setSlashSelectedIdx] = useState(0)
+  const { commands, executeCommand } = useSlashCommands({
+    currentAgent: selectedAgent,
+    onSendMessage,
+  })
+
+  // File and KB search for unified @mention
+  const { files: workspaceFiles, loading: filesLoading, search: searchFiles } = useWorkspaceFiles(conversationId)
+  const { entries: kbEntries, loading: kbLoading, search: searchKB } = useKBSearch()
 
   const hasContent = value.trim().length > 0
 
@@ -58,6 +75,14 @@ export function ChatInput({
       a.name.toLowerCase().includes(mentionQuery.toLowerCase()) ||
       (a.domain ?? '').toLowerCase().includes(mentionQuery.toLowerCase())
   ).slice(0, 6)
+
+  const isFileMode = mentionQuery.startsWith('/')
+  const isKBMode = mentionQuery.startsWith('kb:')
+  const mentionItems: MentionItem[] = [
+    ...(isFileMode || isKBMode ? [] : filteredAgents.map((a): MentionItem => ({ type: 'agent', agent: a }))),
+    ...(isFileMode ? workspaceFiles.filter(f => f.path.toLowerCase().includes(mentionQuery.slice(1).toLowerCase())).slice(0, 6).map((f): MentionItem => ({ type: 'file', file: f })) : []),
+    ...(isKBMode ? kbEntries.filter(e => e.title.toLowerCase().includes(mentionQuery.slice(3).toLowerCase())).slice(0, 6).map((e): MentionItem => ({ type: 'kb', entry: e })) : []),
+  ]
 
   // Auto-resize textarea
   useEffect(() => {
@@ -71,12 +96,6 @@ export function ChatInput({
     setSelectedIdx(0)
   }, [mentionQuery])
 
-  // Scroll selected picker item into view
-  useEffect(() => {
-    if (!showPicker || !pickerRef.current) return
-    const item = pickerRef.current.children[1]?.children[selectedIdx] as HTMLElement | undefined
-    item?.scrollIntoView({ block: 'nearest' })
-  }, [selectedIdx, showPicker])
 
   const closePicker = useCallback(() => {
     setShowPicker(false)
@@ -84,26 +103,50 @@ export function ChatInput({
     setMentionStart(-1)
   }, [])
 
-  const insertMention = useCallback(
-    (agent: Agent) => {
+  const insertMentionItem = useCallback(
+    (item: MentionItem) => {
       if (mentionStart < 0) return
-      const slug = agent.name.toLowerCase().replace(/\s+/g, '-')
+      let insertText: string
+      switch (item.type) {
+        case 'agent': {
+          const slug = item.agent.name.toLowerCase().replace(/\s+/g, '-')
+          insertText = `@${slug} `
+          break
+        }
+        case 'file':
+          insertText = `@file:${item.file.path} `
+          break
+        case 'kb':
+          insertText = `@kb:${item.entry.id} `
+          break
+      }
       const before = value.slice(0, mentionStart)
       const after = value.slice(textareaRef.current?.selectionStart ?? value.length)
-      const newValue = `${before}@${slug} ${after}`
+      const newValue = `${before}${insertText}${after}`
       setValue(newValue)
       closePicker()
       requestAnimationFrame(() => {
         const textarea = textareaRef.current
         if (textarea) {
           textarea.focus()
-          const cursorPos = mentionStart + slug.length + 2
+          const cursorPos = mentionStart + insertText.length
           textarea.setSelectionRange(cursorPos, cursorPos)
         }
       })
     },
-    [mentionStart, value, closePicker]
+    [mentionStart, value, closePicker],
   )
+
+  const insertMention = useCallback(
+    (agent: Agent) => insertMentionItem({ type: 'agent', agent }),
+    [insertMentionItem],
+  )
+
+  const closeSlashPicker = useCallback(() => {
+    setShowSlashPicker(false)
+    setSlashQuery('')
+    setSlashSelectedIdx(0)
+  }, [])
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -114,6 +157,7 @@ export function ChatInput({
       const textBeforeCursor = newValue.slice(0, cursorPos)
       const lastAt = textBeforeCursor.lastIndexOf('@')
 
+      // @mention detection
       if (lastAt >= 0) {
         const charBefore = lastAt > 0 ? newValue[lastAt - 1] : ' '
         if (charBefore === ' ' || charBefore === '\n' || lastAt === 0) {
@@ -122,13 +166,30 @@ export function ChatInput({
             setMentionStart(lastAt)
             setMentionQuery(mentionText)
             setShowPicker(true)
+            closeSlashPicker()
+            if (mentionText.startsWith('/')) searchFiles(mentionText.slice(1))
+            else if (mentionText.startsWith('kb:')) searchKB(mentionText.slice(3))
             return
           }
         }
       }
       closePicker()
+
+      // Slash command detection — only at line start, not after @
+      const lineStart = textBeforeCursor.lastIndexOf('\n') + 1
+      const lineText = textBeforeCursor.slice(lineStart)
+      if (lineText.startsWith('/') && (lineStart === 0 || textBeforeCursor[lineStart - 1] === '\n')) {
+        const charBeforeSlash = lineStart > 0 ? textBeforeCursor[lineStart - 1] : undefined
+        if (charBeforeSlash !== '@') {
+          setSlashQuery(lineText.slice(1))
+          setShowSlashPicker(true)
+          setSlashSelectedIdx(0)
+          return
+        }
+      }
+      closeSlashPicker()
     },
-    [closePicker]
+    [closePicker, closeSlashPicker]
   )
 
   const handleSend = useCallback(() => {
@@ -142,23 +203,70 @@ export function ChatInput({
     }
   }, [value, disabled, onSendMessage, closePicker])
 
+  const handleSelectSlashCommand = useCallback(
+    (cmd: (typeof commands)[number]) => {
+      const textarea = textareaRef.current
+      if (!textarea) return
+      const cursorPos = textarea.selectionStart
+      const textBeforeCursor = value.slice(0, cursorPos)
+      const lineStart = textBeforeCursor.lastIndexOf('\n') + 1
+      const before = value.slice(0, lineStart)
+      const after = value.slice(cursorPos)
+      executeCommand(cmd, after.trim())
+      setValue('')
+      closeSlashPicker()
+      if (textareaRef.current) textareaRef.current.style.height = 'auto'
+    },
+    [value, executeCommand, closeSlashPicker],
+  )
+
+  const slashFilteredCommands = commands.filter(
+    (cmd) =>
+      cmd.name.toLowerCase().includes(slashQuery.toLowerCase()) ||
+      cmd.description.toLowerCase().includes(slashQuery.toLowerCase()),
+  )
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      // Mention picker navigation
-      if (showPicker && filteredAgents.length > 0) {
+      // Slash picker navigation (higher priority)
+      if (showSlashPicker && slashFilteredCommands.length > 0) {
         if (e.key === 'ArrowDown') {
           e.preventDefault()
-          setSelectedIdx((prev) => (prev + 1) % filteredAgents.length)
+          setSlashSelectedIdx((prev) => (prev + 1) % slashFilteredCommands.length)
           return
         }
         if (e.key === 'ArrowUp') {
           e.preventDefault()
-          setSelectedIdx((prev) => (prev - 1 + filteredAgents.length) % filteredAgents.length)
+          setSlashSelectedIdx((prev) => (prev - 1 + slashFilteredCommands.length) % slashFilteredCommands.length)
           return
         }
         if (e.key === 'Tab' || e.key === 'Enter') {
           e.preventDefault()
-          insertMention(filteredAgents[selectedIdx])
+          handleSelectSlashCommand(slashFilteredCommands[slashSelectedIdx])
+          return
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          closeSlashPicker()
+          return
+        }
+      }
+
+      // Mention picker navigation
+      if (showPicker && mentionItems.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault()
+          setSelectedIdx((prev) => (prev + 1) % mentionItems.length)
+          return
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault()
+          setSelectedIdx((prev) => (prev - 1 + mentionItems.length) % mentionItems.length)
+          return
+        }
+        if (e.key === 'Tab' || e.key === 'Enter') {
+          e.preventDefault()
+          insertMentionItem(mentionItems[selectedIdx])
           return
         }
         if (e.key === 'Escape') {
@@ -174,7 +282,8 @@ export function ChatInput({
         handleSend()
       }
     },
-    [showPicker, filteredAgents, selectedIdx, insertMention, closePicker, isComposing, handleSend]
+    [showSlashPicker, slashFilteredCommands, slashSelectedIdx, handleSelectSlashCommand, closeSlashPicker,
+     showPicker, mentionItems, selectedIdx, insertMentionItem, closePicker, isComposing, handleSend]
   )
 
   const triggerMention = useCallback(() => {
@@ -199,53 +308,32 @@ export function ChatInput({
   return (
     <div className={cn('w-full max-w-3xl mx-auto px-4 pb-1.5 pt-2 shrink-0', className)}>
       <div className="relative">
-        {/* @mention Picker */}
-        {showPicker && filteredAgents.length > 0 && (
-          <div
-            ref={pickerRef}
-            className="absolute bottom-full left-0 w-[280px] mb-2 bg-card border border-border rounded-xl shadow-lg backdrop-blur-sm overflow-hidden max-h-[220px] overflow-y-auto z-10"
-            role="listbox"
-            aria-label="Mention an agent"
-          >
-            <div className="px-3 py-1.5 border-b border-border">
-              <span className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
-                Agents
-              </span>
-            </div>
-            <div className="p-1">
-              {filteredAgents.map((agent, idx) => (
-                <button
-                  key={agent.id}
-                  type="button"
-                  role="option"
-                  aria-selected={idx === selectedIdx}
-                  className={cn(
-                    'flex items-center gap-2.5 w-full px-2 py-1.5 text-left text-sm rounded-md transition-colors duration-100',
-                    idx === selectedIdx
-                      ? 'bg-surface-hover text-text'
-                      : 'text-text hover:bg-surface-hover'
-                  )}
-                  onMouseDown={(e) => {
-                    e.preventDefault()
-                    insertMention(agent)
-                  }}
-                  onMouseEnter={() => setSelectedIdx(idx)}
-                >
-                  <div className="w-6 h-6 rounded-lg overflow-hidden shrink-0 flex items-center justify-center bg-surface-hover text-text-secondary">
-                    {isMascotConfig(agent.avatarUrl) ? (
-                      <MascotAvatar config={agent.avatarUrl!} size={24} className="w-full h-full" alt={agent.name} />
-                    ) : agent.avatarUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={agent.avatarUrl} alt={agent.name} className="w-full h-full object-cover" />
-                    ) : (
-                      <Bot className="w-3.5 h-3.5" />
-                    )}
-                  </div>
-                  <span className="font-medium truncate">{agent.name}</span>
-                </button>
-              ))}
-            </div>
-          </div>
+        {/* Slash Command Picker */}
+        {showSlashPicker && (
+          <SlashCommandPicker
+            query={slashQuery}
+            commands={commands}
+            selectedIdx={slashSelectedIdx}
+            onSelect={handleSelectSlashCommand}
+            onClose={closeSlashPicker}
+            onSelectedIdxChange={setSlashSelectedIdx}
+          />
+        )}
+
+        {/* Unified @mention Picker */}
+        {showPicker && (
+          <UnifiedMentionPicker
+            query={mentionQuery}
+            agents={agents}
+            files={workspaceFiles}
+            kbEntries={kbEntries}
+            filesLoading={filesLoading}
+            kbLoading={kbLoading}
+            selectedIdx={selectedIdx}
+            onSelect={insertMentionItem}
+            onClose={closePicker}
+            onSelectedIdxChange={setSelectedIdx}
+          />
         )}
 
         {/* Composer Card */}
@@ -266,7 +354,7 @@ export function ChatInput({
             onFocus={() => setFocused(true)}
             onBlur={() => {
               setFocused(false)
-              setTimeout(() => closePicker(), 150)
+              setTimeout(() => { closePicker(); closeSlashPicker() }, 150)
             }}
             onCompositionStart={() => setIsComposing(true)}
             onCompositionEnd={() => setIsComposing(false)}
@@ -375,7 +463,7 @@ export function ChatInput({
                   hasContent || focused ? 'opacity-0' : 'opacity-100'
                 )}
               >
-                @ mention &middot; Enter to send
+                / commands &middot; @ mention &middot; Enter to send
               </span>
             </div>
 

--- a/xerus_web/components/chat/ChatInput.tsx
+++ b/xerus_web/components/chat/ChatInput.tsx
@@ -317,7 +317,6 @@ export function ChatInput({
             commands={commands}
             selectedIdx={slashSelectedIdx}
             onSelect={handleSelectSlashCommand}
-            onClose={closeSlashPicker}
             onSelectedIdxChange={setSlashSelectedIdx}
           />
         )}

--- a/xerus_web/components/chat/MessageBubble.tsx
+++ b/xerus_web/components/chat/MessageBubble.tsx
@@ -11,13 +11,14 @@ import {
 import type { ChatMessageExtended, ToolCall, TodoItem, WorkspaceArtifact } from './chat-message.types'
 import type { TurnPart } from './streaming-turn.types'
 import type { Agent } from './types'
-import { XERUS_AGENT } from './AgentDropdown'
+import { XERUS_AGENT, XERUS_MASTER_SLUG, CTO_AGENT, XERUS_CTO_SLUG } from './AgentDropdown'
 import { isMascotConfig } from '@/lib/mascot-config'
 import { MascotAvatar } from '@/components/agents/MascotAvatar'
 import { MarkdownContent } from './MarkdownContent'
 import { ToolCallCard, type ToolCallCardData } from './ToolCallCard'
 import { ToolActionGroup } from './ToolActionGroup'
 import { ThinkingSection } from './ThinkingSection'
+import { RichThinkingIndicator } from './RichThinkingIndicator'
 import { extractTextFromParts, groupConsecutiveTools } from './streaming-turn.utils'
 
 // ---------------------------------------------------------------------------
@@ -243,8 +244,12 @@ function partToToolCall(part: TurnPart & { type: 'tool' }, agents?: Agent[]): To
   return {
     id: part.id,
     name: part.name,
+    label: part.label,
     icon: part.icon,
     target: part.target,
+    detail: part.detail,
+    progressMessage: part.progressMessage,
+    args: part.args,
     output: part.result != null
       ? (typeof part.result === 'string' ? part.result : JSON.stringify(part.result))
       : undefined,
@@ -275,6 +280,7 @@ function legacyToolCallToCardData(tool: ToolCall): ToolCallCardData {
   return {
     id: tool.id,
     name: tool.name,
+    label: tool.name,
     icon: tool.icon,
     target: tool.target,
     detail: tool.detail,
@@ -316,14 +322,18 @@ export const MessageBubble = memo(function MessageBubble({
   // This prevents the bug where the Xerus logo flashes on a message that was
   // actually produced by a specific agent. Fall back to the canonical XERUS_AGENT
   // so the header always renders with a real agent identity (no hardcoded logos).
-  const resolvedAgent: Agent = agent ?? (
-    agents && (message.agentSlug || message.agentName)
-      ? agents.find((a) =>
-          (message.agentSlug && a.slug === message.agentSlug) ||
-          (message.agentName && a.name === message.agentName)
-        ) ?? XERUS_AGENT
-      : XERUS_AGENT
-  )
+  const resolvedAgent: Agent = agent ?? (() => {
+    // System agents use their static definitions (correct SVG avatars)
+    if (message.agentSlug === XERUS_MASTER_SLUG) return XERUS_AGENT
+    if (message.agentSlug === XERUS_CTO_SLUG) return CTO_AGENT
+    if (agents && (message.agentSlug || message.agentName)) {
+      return agents.find((a) =>
+        (message.agentSlug && a.slug === message.agentSlug) ||
+        (message.agentName && a.name === message.agentName)
+      ) ?? XERUS_AGENT
+    }
+    return XERUS_AGENT
+  })()
   const hasExecution =
     !isUser &&
     !isStreaming &&
@@ -368,7 +378,7 @@ export const MessageBubble = memo(function MessageBubble({
         )}>
           {isUser ? 'You' : resolvedAgent.name}
         </span>
-        {!isUser && (
+        {!isUser && !isStreaming && (
           <span className="text-[10px] font-medium text-text-muted bg-surface-hover rounded-full px-1.5 py-0.5">
             AI
           </span>
@@ -377,10 +387,7 @@ export const MessageBubble = memo(function MessageBubble({
           {formatTime(message.timestamp)}
         </span>
         {isStreaming && (
-          <span className="inline-flex items-center gap-1.5 text-[11px] text-text-muted">
-            <span className="h-1.5 w-1.5 rounded-full bg-secondary animate-pulse" />
-            Generating
-          </span>
+          <RichThinkingIndicator parts={message.parts} />
         )}
       </div>
 

--- a/xerus_web/components/chat/MessageBubble.tsx
+++ b/xerus_web/components/chat/MessageBubble.tsx
@@ -377,9 +377,9 @@ export const MessageBubble = memo(function MessageBubble({
           {formatTime(message.timestamp)}
         </span>
         {isStreaming && (
-          <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary">
-            <span className="h-1.5 w-1.5 rounded-full bg-secondary" />
-            Live
+          <span className="inline-flex items-center gap-1.5 text-[11px] text-text-muted">
+            <span className="h-1.5 w-1.5 rounded-full bg-secondary animate-pulse" />
+            Generating
           </span>
         )}
       </div>
@@ -415,9 +415,8 @@ export const MessageBubble = memo(function MessageBubble({
             })}
           </div>
         ) : isStreaming ? (
-          <div className="flex items-center gap-2 text-sm text-text-secondary">
-            <span className="h-1.5 w-1.5 rounded-full bg-secondary" />
-            Waiting for response...
+          <div className="flex items-center gap-2 text-sm text-text-muted">
+            <span className="h-1.5 w-1.5 rounded-full bg-secondary animate-pulse" />
           </div>
         ) : null
       ) : (

--- a/xerus_web/components/chat/MessageBubble.tsx
+++ b/xerus_web/components/chat/MessageBubble.tsx
@@ -16,8 +16,9 @@ import { isMascotConfig } from '@/lib/mascot-config'
 import { MascotAvatar } from '@/components/agents/MascotAvatar'
 import { MarkdownContent } from './MarkdownContent'
 import { ToolCallCard, type ToolCallCardData } from './ToolCallCard'
+import { ToolActionGroup } from './ToolActionGroup'
 import { ThinkingSection } from './ThinkingSection'
-import { extractTextFromParts } from './streaming-turn.utils'
+import { extractTextFromParts, groupConsecutiveTools } from './streaming-turn.utils'
 
 // ---------------------------------------------------------------------------
 // TodoProgress - expandable checklist
@@ -387,7 +388,10 @@ export const MessageBubble = memo(function MessageBubble({
       {message.parts ? (
         message.parts.length > 0 ? (
           <div className="space-y-2">
-            {message.parts.map((part) => {
+            {groupConsecutiveTools(message.parts).map((part) => {
+              if (part.type === 'tool-group') {
+                return <ToolActionGroup key={part.id} tools={part.parts} agents={agents} />
+              }
               switch (part.type) {
                 case 'text':
                   return <MarkdownContent key={part.id} content={part.text} />

--- a/xerus_web/components/chat/MessageList.tsx
+++ b/xerus_web/components/chat/MessageList.tsx
@@ -120,15 +120,11 @@ export function MessageList({
           })}
         </div>
 
-        {/* Thinking indicator — show while waiting for first token. Prefer the
-            delegated subagent (from executionState) over currentAgent so the avatar
-            matches the agent actually working. */}
+        {/* Thinking indicator — show while waiting for first token.
+            Always show the user's selected agent (currentAgent). Delegated
+            subagents are visible in the TaskDock instead. */}
         {isLoading && !streamingTurn && (() => {
-          const delegatedSlug = executionState?.agents?.[executionState.agents.length - 1]
-          const thinkingAgent =
-            (delegatedSlug && agents?.find((a) => a.slug === delegatedSlug || a.name === delegatedSlug)) ||
-            currentAgent ||
-            XERUS_AGENT
+          const thinkingAgent = currentAgent || XERUS_AGENT
           return (
             <div className="px-6 py-5">
               <div className="flex items-start gap-3">

--- a/xerus_web/components/chat/MessageList.tsx
+++ b/xerus_web/components/chat/MessageList.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { MessageBubble } from './MessageBubble'
 import { ChatWelcome } from './ChatWelcome'
-import { ThinkingIndicator } from './ThinkingIndicator'
+import { RichThinkingIndicator } from './RichThinkingIndicator'
 import { XERUS_AGENT } from './AgentDropdown'
 import { cn } from '@/lib/utils'
 import { Agent, ExecutionState } from './types'
@@ -141,7 +141,7 @@ export function MessageList({
                   <span className="text-base font-semibold text-secondary block">
                     {thinkingAgent.name}
                   </span>
-                  <ThinkingIndicator executionState={executionState} />
+                  <RichThinkingIndicator executionState={executionState} />
                 </div>
               </div>
             </div>

--- a/xerus_web/components/chat/RichThinkingIndicator.tsx
+++ b/xerus_web/components/chat/RichThinkingIndicator.tsx
@@ -35,17 +35,17 @@ const VERB_MAP: Record<ToolCallIcon, string> = {
   task: 'Tracking', question: 'Asking',
 }
 
-const AMBIENT_VERBS = ['thinking...', 'pondering...', 'considering...', 'working on it...']
+const AMBIENT_VERBS = ['Thinking...', 'Analyzing...', 'Processing...', 'Working...']
 const VERB_CYCLE_MS = 3500
 
 function resolvePhaseVerb(phase: string | undefined): string | null {
   if (!phase) return null
   const p = phase.toLowerCase()
-  if (p.includes('workspace') || p.includes('scaffold')) return 'preparing workspace...'
-  if (p.includes('plan')) return 'crafting a plan...'
-  if (p.includes('analyz') || p.includes('assess')) return 'analyzing your request...'
-  if (p.includes('generat') || p.includes('complet')) return 'generating a response...'
-  if (p.includes('verif') || p.includes('review')) return 'verifying results...'
+  if (p.includes('workspace') || p.includes('scaffold')) return 'Setting up workspace...'
+  if (p.includes('plan')) return 'Creating a plan...'
+  if (p.includes('analyz') || p.includes('assess')) return 'Analyzing request...'
+  if (p.includes('generat') || p.includes('complet')) return 'Generating response...'
+  if (p.includes('verif') || p.includes('review')) return 'Reviewing results...'
   return null
 }
 
@@ -101,7 +101,7 @@ export function RichThinkingIndicator({ executionState, parts }: RichThinkingInd
 
   const displayText = toolSummary
     ?? phaseVerb
-    ?? (executionState?.error ? 'ran into a problem...' : null)
+    ?? (executionState?.error ? 'Something went wrong' : null)
     ?? AMBIENT_VERBS[ambientIndex]
 
   useEffect(() => {

--- a/xerus_web/components/chat/RichThinkingIndicator.tsx
+++ b/xerus_web/components/chat/RichThinkingIndicator.tsx
@@ -1,33 +1,10 @@
 'use client'
 
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { cn } from '@/lib/utils'
-import {
-  Terminal, FileText, Pencil, Search, Globe, Brain,
-  Bot, Puzzle, ListChecks, HelpCircle,
-} from 'lucide-react'
 import type { ExecutionState } from './types'
 import type { TurnPart, ToolCallIcon } from './streaming-turn.types'
-
-const TOOL_ICON: Record<ToolCallIcon, typeof Terminal> = {
-  bash: Terminal, read: FileText, write: Pencil, search: Search,
-  web: Globe, think: Brain, agent: Bot, skill: Puzzle,
-  task: ListChecks, question: HelpCircle,
-}
-
-const TOOL_COLOR: Record<ToolCallIcon, string> = {
-  bash: 'text-emerald-600', read: 'text-blue-600', write: 'text-violet-600',
-  search: 'text-amber-600', web: 'text-cyan-600', think: 'text-slate-500',
-  agent: 'text-secondary', skill: 'text-purple-600', task: 'text-teal-600',
-  question: 'text-rose-600',
-}
-
-const ICON_BG: Record<ToolCallIcon, string> = {
-  bash: 'bg-emerald-500/10', read: 'bg-blue-500/10', write: 'bg-violet-500/10',
-  search: 'bg-amber-500/10', web: 'bg-cyan-500/10', think: 'bg-slate-500/10',
-  agent: 'bg-secondary/10', skill: 'bg-purple-500/10', task: 'bg-teal-500/10',
-  question: 'bg-rose-500/10',
-}
+import { TOOL_ICON_MAP, TOOL_COLOR_MAP } from './tool-icon.utils'
 
 const VERB_MAP: Record<ToolCallIcon, string> = {
   read: 'Reading', write: 'Writing', bash: 'Running', search: 'Searching',
@@ -81,7 +58,6 @@ interface RichThinkingIndicatorProps {
 
 export function RichThinkingIndicator({ executionState, parts }: RichThinkingIndicatorProps) {
   const [ambientIndex, setAmbientIndex] = useState(0)
-  const lastVerbRef = useRef(Date.now())
 
   const toolSummary = useMemo(() => {
     if (!parts || parts.length === 0) return null
@@ -108,7 +84,6 @@ export function RichThinkingIndicator({ executionState, parts }: RichThinkingInd
     if (toolSummary || phaseVerb) return
     const interval = setInterval(() => {
       setAmbientIndex((prev) => (prev + 1) % AMBIENT_VERBS.length)
-      lastVerbRef.current = Date.now()
     }, VERB_CYCLE_MS)
     return () => clearInterval(interval)
   }, [toolSummary, phaseVerb])
@@ -120,13 +95,13 @@ export function RichThinkingIndicator({ executionState, parts }: RichThinkingInd
       {runningIcons.length > 0 ? (
         <span className="inline-flex items-center gap-0.5 mr-0.5">
           {runningIcons.map((icon) => {
-            const Icon = TOOL_ICON[icon]
+            const Icon = TOOL_ICON_MAP[icon]
             return (
               <span
                 key={icon}
                 className={cn(
                   'w-5 h-5 rounded-md inline-flex items-center justify-center animate-pulse',
-                  ICON_BG[icon], TOOL_COLOR[icon],
+                  TOOL_COLOR_MAP[icon],
                 )}
               >
                 <Icon className="w-2.5 h-2.5" />

--- a/xerus_web/components/chat/RichThinkingIndicator.tsx
+++ b/xerus_web/components/chat/RichThinkingIndicator.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { cn } from '@/lib/utils'
+import {
+  Terminal, FileText, Pencil, Search, Globe, Brain,
+  Bot, Puzzle, ListChecks, HelpCircle,
+} from 'lucide-react'
+import type { ExecutionState } from './types'
+import type { TurnPart, ToolCallIcon } from './streaming-turn.types'
+
+const TOOL_ICON: Record<ToolCallIcon, typeof Terminal> = {
+  bash: Terminal, read: FileText, write: Pencil, search: Search,
+  web: Globe, think: Brain, agent: Bot, skill: Puzzle,
+  task: ListChecks, question: HelpCircle,
+}
+
+const TOOL_COLOR: Record<ToolCallIcon, string> = {
+  bash: 'text-emerald-600', read: 'text-blue-600', write: 'text-violet-600',
+  search: 'text-amber-600', web: 'text-cyan-600', think: 'text-slate-500',
+  agent: 'text-secondary', skill: 'text-purple-600', task: 'text-teal-600',
+  question: 'text-rose-600',
+}
+
+const ICON_BG: Record<ToolCallIcon, string> = {
+  bash: 'bg-emerald-500/10', read: 'bg-blue-500/10', write: 'bg-violet-500/10',
+  search: 'bg-amber-500/10', web: 'bg-cyan-500/10', think: 'bg-slate-500/10',
+  agent: 'bg-secondary/10', skill: 'bg-purple-500/10', task: 'bg-teal-500/10',
+  question: 'bg-rose-500/10',
+}
+
+const VERB_MAP: Record<ToolCallIcon, string> = {
+  read: 'Reading', write: 'Writing', bash: 'Running', search: 'Searching',
+  web: 'Fetching', think: 'Thinking', agent: 'Delegating', skill: 'Executing',
+  task: 'Tracking', question: 'Asking',
+}
+
+const AMBIENT_VERBS = ['thinking...', 'pondering...', 'considering...', 'working on it...']
+const VERB_CYCLE_MS = 3500
+
+function resolvePhaseVerb(phase: string | undefined): string | null {
+  if (!phase) return null
+  const p = phase.toLowerCase()
+  if (p.includes('workspace') || p.includes('scaffold')) return 'preparing workspace...'
+  if (p.includes('plan')) return 'crafting a plan...'
+  if (p.includes('analyz') || p.includes('assess')) return 'analyzing your request...'
+  if (p.includes('generat') || p.includes('complet')) return 'generating a response...'
+  if (p.includes('verif') || p.includes('review')) return 'verifying results...'
+  return null
+}
+
+function formatToolSummary(parts: TurnPart[]): string | null {
+  const running = parts.filter(
+    (p): p is Extract<TurnPart, { type: 'tool' }> => p.type === 'tool' && p.state === 'running',
+  )
+  if (running.length === 0) return null
+
+  const byCategory = new Map<ToolCallIcon, number>()
+  for (const t of running) {
+    byCategory.set(t.icon, (byCategory.get(t.icon) ?? 0) + 1)
+  }
+
+  const fragments: string[] = []
+  for (const [icon, count] of byCategory) {
+    const verb = VERB_MAP[icon] ?? 'Processing'
+    if (count === 1) {
+      const tool = running.find(t => t.icon === icon)
+      const target = tool?.target ? ` ${tool.target}` : ''
+      fragments.push(`${verb}${target}`)
+    } else {
+      fragments.push(`${verb} ${count} items`)
+    }
+  }
+  return fragments.join(', ') + '...'
+}
+
+interface RichThinkingIndicatorProps {
+  executionState?: ExecutionState | null
+  parts?: TurnPart[]
+}
+
+export function RichThinkingIndicator({ executionState, parts }: RichThinkingIndicatorProps) {
+  const [ambientIndex, setAmbientIndex] = useState(0)
+  const lastVerbRef = useRef(Date.now())
+
+  const toolSummary = useMemo(() => {
+    if (!parts || parts.length === 0) return null
+    return formatToolSummary(parts)
+  }, [parts])
+
+  const runningIcons = useMemo(() => {
+    if (!parts) return []
+    const running = parts.filter(
+      (p): p is Extract<TurnPart, { type: 'tool' }> => p.type === 'tool' && p.state === 'running',
+    )
+    return [...new Set(running.map(t => t.icon))]
+  }, [parts])
+
+  const activeStep = executionState?.steps?.find((s) => s.status === 'active')
+  const phaseVerb = resolvePhaseVerb(activeStep?.name)
+
+  const displayText = toolSummary
+    ?? phaseVerb
+    ?? (executionState?.error ? 'ran into a problem...' : null)
+    ?? AMBIENT_VERBS[ambientIndex]
+
+  useEffect(() => {
+    if (toolSummary || phaseVerb) return
+    const interval = setInterval(() => {
+      setAmbientIndex((prev) => (prev + 1) % AMBIENT_VERBS.length)
+      lastVerbRef.current = Date.now()
+    }, VERB_CYCLE_MS)
+    return () => clearInterval(interval)
+  }, [toolSummary, phaseVerb])
+
+  const isError = executionState?.error
+
+  return (
+    <span data-testid="thinking-indicator" className="inline-flex items-center gap-1.5 text-[14px] text-text-secondary flex-wrap">
+      {runningIcons.length > 0 ? (
+        <span className="inline-flex items-center gap-0.5 mr-0.5">
+          {runningIcons.map((icon) => {
+            const Icon = TOOL_ICON[icon]
+            return (
+              <span
+                key={icon}
+                className={cn(
+                  'w-5 h-5 rounded-md inline-flex items-center justify-center animate-pulse',
+                  ICON_BG[icon], TOOL_COLOR[icon],
+                )}
+              >
+                <Icon className="w-2.5 h-2.5" />
+              </span>
+            )
+          })}
+        </span>
+      ) : !isError ? (
+        <svg className="w-3.5 h-3.5 text-secondary animate-thinking-breathe shrink-0" fill="currentColor" fillRule="evenodd" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
+        </svg>
+      ) : null}
+
+      <span className={cn('transition-opacity duration-300', isError && 'text-red-500/80')}>
+        {displayText}
+      </span>
+
+      {!isError && runningIcons.length === 0 && (
+        <span className="inline-flex items-center gap-[3px] ml-0.5" aria-hidden="true">
+          {[0, 0.2, 0.4].map((delay, i) => (
+            <span
+              key={i}
+              className="w-1 h-1 rounded-full bg-secondary animate-thinking-dot"
+              style={{ animationDelay: `${delay}s` }}
+            />
+          ))}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/xerus_web/components/chat/SlashCommandPicker.tsx
+++ b/xerus_web/components/chat/SlashCommandPicker.tsx
@@ -16,7 +16,6 @@ interface SlashCommandPickerProps {
   commands: SlashCommand[]
   selectedIdx: number
   onSelect: (cmd: SlashCommand) => void
-  onClose: () => void
   onSelectedIdxChange: (idx: number) => void
 }
 
@@ -31,7 +30,6 @@ export function SlashCommandPicker({
   commands,
   selectedIdx,
   onSelect,
-  onClose,
   onSelectedIdxChange,
 }: SlashCommandPickerProps) {
   const pickerRef = useRef<HTMLDivElement>(null)
@@ -61,8 +59,6 @@ export function SlashCommandPicker({
 
   if (flatItems.length === 0) return null
 
-  let globalIdx = 0
-
   return (
     <div
       ref={pickerRef}
@@ -79,7 +75,7 @@ export function SlashCommandPicker({
           </div>
           <div className="p-1">
             {group.items.map((cmd) => {
-              const idx = globalIdx++
+              const idx = flatItems.indexOf(cmd)
               const Icon = cmd.icon
               return (
                 <button

--- a/xerus_web/components/chat/SlashCommandPicker.tsx
+++ b/xerus_web/components/chat/SlashCommandPicker.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+import type { LucideIcon } from 'lucide-react'
+
+export interface SlashCommand {
+  name: string
+  description: string
+  category: 'skill' | 'action' | 'context'
+  icon: LucideIcon
+}
+
+interface SlashCommandPickerProps {
+  query: string
+  commands: SlashCommand[]
+  selectedIdx: number
+  onSelect: (cmd: SlashCommand) => void
+  onClose: () => void
+  onSelectedIdxChange: (idx: number) => void
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  skill: 'Skills',
+  action: 'Actions',
+  context: 'Context',
+}
+
+export function SlashCommandPicker({
+  query,
+  commands,
+  selectedIdx,
+  onSelect,
+  onClose,
+  onSelectedIdxChange,
+}: SlashCommandPickerProps) {
+  const pickerRef = useRef<HTMLDivElement>(null)
+
+  const filtered = commands.filter(
+    (cmd) =>
+      cmd.name.toLowerCase().includes(query.toLowerCase()) ||
+      cmd.description.toLowerCase().includes(query.toLowerCase()),
+  )
+
+  const grouped = (['skill', 'action', 'context'] as const)
+    .map((cat) => ({
+      category: cat,
+      label: CATEGORY_LABELS[cat],
+      items: filtered.filter((c) => c.category === cat),
+    }))
+    .filter((g) => g.items.length > 0)
+
+  const flatItems = grouped.flatMap((g) => g.items)
+
+  useEffect(() => {
+    if (!pickerRef.current || flatItems.length === 0) return
+    const allButtons = pickerRef.current.querySelectorAll('[role="option"]')
+    const target = allButtons[selectedIdx] as HTMLElement | undefined
+    target?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIdx, flatItems.length])
+
+  if (flatItems.length === 0) return null
+
+  let globalIdx = 0
+
+  return (
+    <div
+      ref={pickerRef}
+      className="absolute bottom-full left-0 w-[320px] mb-2 bg-card border border-border rounded-xl shadow-lg backdrop-blur-sm overflow-hidden max-h-[280px] overflow-y-auto z-10"
+      role="listbox"
+      aria-label="Slash commands"
+    >
+      {grouped.map((group) => (
+        <div key={group.category}>
+          <div className="px-3 py-1.5 border-b border-border">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+              {group.label}
+            </span>
+          </div>
+          <div className="p-1">
+            {group.items.map((cmd) => {
+              const idx = globalIdx++
+              const Icon = cmd.icon
+              return (
+                <button
+                  key={cmd.name}
+                  type="button"
+                  role="option"
+                  aria-selected={idx === selectedIdx}
+                  className={cn(
+                    'flex items-center gap-2.5 w-full px-2 py-1.5 text-left rounded-md transition-colors duration-100',
+                    idx === selectedIdx
+                      ? 'bg-surface-hover text-text'
+                      : 'text-text hover:bg-surface-hover',
+                  )}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    onSelect(cmd)
+                  }}
+                  onMouseEnter={() => onSelectedIdxChange(idx)}
+                >
+                  <div className="w-6 h-6 rounded-lg flex items-center justify-center shrink-0 bg-surface-hover text-text-secondary">
+                    <Icon className="w-3.5 h-3.5" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium">/{cmd.name}</span>
+                    <span className="text-[11px] text-text-muted ml-2 truncate">
+                      {cmd.description}
+                    </span>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/xerus_web/components/chat/TaskDock.tsx
+++ b/xerus_web/components/chat/TaskDock.tsx
@@ -42,7 +42,7 @@ export function TaskDock({
   const completedCount = tasks.filter((t) => t.status !== 'running').length
 
   return (
-    <div className="shrink-0 mx-4 mb-2">
+    <div className="shrink-0 mx-4 mb-2 max-w-md">
       <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
         {/* Header */}
         <button

--- a/xerus_web/components/chat/TaskDock.tsx
+++ b/xerus_web/components/chat/TaskDock.tsx
@@ -1,13 +1,24 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { ChevronUp, ChevronDown, Loader2, Check, X, Square } from 'lucide-react'
+import { ChevronUp, ChevronDown, Loader2, Check, X } from 'lucide-react'
 import type { DockTask } from './useTaskDock'
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
   return `${(ms / 1000).toFixed(1)}s`
 }
+
+const TASK_COLORS = [
+  'text-blue-600',
+  'text-violet-600',
+  'text-amber-600',
+  'text-emerald-600',
+  'text-cyan-600',
+  'text-rose-600',
+  'text-purple-600',
+  'text-teal-600',
+]
 
 interface TaskDockProps {
   tasks: DockTask[]
@@ -28,76 +39,94 @@ export function TaskDock({
 }: TaskDockProps) {
   if (tasks.length === 0) return null
 
-  return (
-    <div className="shrink-0 border-t border-border bg-surface transition-all duration-200">
-      {/* Header row */}
-      <div className="flex items-center justify-between px-4 py-2">
-        <div className="flex items-center gap-2">
-          {activeCount > 0 && (
-            <Loader2 className="w-3.5 h-3.5 animate-spin text-secondary" />
-          )}
-          <span className="text-xs font-medium text-text-secondary">
-            {activeCount > 0
-              ? `${activeCount} Working`
-              : `${tasks.length} Completed`
-            }
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          {activeCount > 0 && onStopAll && (
-            <button
-              type="button"
-              onClick={onStopAll}
-              className="text-[11px] text-red-500 hover:text-red-600 hover:bg-red-50 px-2 py-1 rounded-md transition-colors"
-            >
-              Stop All
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={isCollapsed ? onExpand : onCollapse}
-            className="p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
-            aria-label={isCollapsed ? 'Expand task dock' : 'Collapse task dock'}
-          >
-            {isCollapsed ? (
-              <ChevronUp className="w-3.5 h-3.5" />
-            ) : (
-              <ChevronDown className="w-3.5 h-3.5" />
-            )}
-          </button>
-        </div>
-      </div>
+  const completedCount = tasks.filter((t) => t.status !== 'running').length
 
-      {/* Expanded task list */}
-      {!isCollapsed && (
-        <div className="px-4 pb-2 space-y-1 max-h-[160px] overflow-y-auto">
-          {tasks.map((task) => (
-            <div
-              key={task.id}
-              className="flex items-center gap-2.5 py-1 px-2 rounded-md bg-surface-alt/50"
-            >
-              {task.status === 'running' ? (
-                <Loader2 className="w-3 h-3 animate-spin text-secondary shrink-0" />
-              ) : task.status === 'completed' ? (
-                <Check className="w-3 h-3 text-emerald-500 shrink-0" />
-              ) : (
-                <X className="w-3 h-3 text-red-500 shrink-0" />
-              )}
-              <span className="text-xs font-medium text-text truncate flex-1">
-                {task.name}
+  return (
+    <div className="shrink-0 mx-4 mb-2">
+      <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
+        {/* Header */}
+        <button
+          type="button"
+          onClick={isCollapsed ? onExpand : onCollapse}
+          className="flex items-center justify-between w-full px-4 py-2.5 hover:bg-surface-hover/50 transition-colors"
+        >
+          <div className="flex items-center gap-2.5">
+            {activeCount > 0 ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin text-secondary" />
+            ) : (
+              <Check className="w-3.5 h-3.5 text-emerald-500" />
+            )}
+            <span className="text-[13px] font-medium text-text">
+              {activeCount > 0 ? `${activeCount} Working` : 'All tasks completed'}
+            </span>
+            {activeCount > 0 && completedCount > 0 && (
+              <span className="text-[11px] text-text-muted">
+                {completedCount} done
               </span>
-              <span className="text-[11px] text-text-muted truncate max-w-[180px]">
-                {task.status === 'running'
-                  ? task.description
-                  : task.durationMs != null
-                    ? `Done (${formatDuration(task.durationMs)})`
-                    : task.error ?? 'Done'
-                }
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {activeCount > 0 && onStopAll && (
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => { e.stopPropagation(); onStopAll() }}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onStopAll() } }}
+                className="text-[11px] font-medium text-text-muted hover:text-red-500 px-2 py-0.5 rounded-md hover:bg-red-50 transition-colors"
+              >
+                Stop All
               </span>
-            </div>
-          ))}
-        </div>
-      )}
+            )}
+            {isCollapsed ? (
+              <ChevronUp className="w-3.5 h-3.5 text-text-muted" />
+            ) : (
+              <ChevronDown className="w-3.5 h-3.5 text-text-muted" />
+            )}
+          </div>
+        </button>
+
+        {/* Task list */}
+        {!isCollapsed && (
+          <div className="border-t border-border/50 px-3 py-2 space-y-1 max-h-[140px] overflow-y-auto">
+            {tasks.map((task, idx) => {
+              const color = TASK_COLORS[idx % TASK_COLORS.length]
+              return (
+                <div
+                  key={task.id}
+                  className={cn(
+                    'flex items-center gap-2.5 py-1.5 px-2 rounded-lg transition-colors',
+                    task.status === 'running' && 'bg-surface-alt/30',
+                  )}
+                >
+                  {task.status === 'running' ? (
+                    <span className={cn('flex items-center justify-center w-4 h-4 shrink-0', color)}>
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    </span>
+                  ) : task.status === 'completed' ? (
+                    <Check className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
+                  ) : (
+                    <X className="w-3.5 h-3.5 text-red-400 shrink-0" />
+                  )}
+                  <span className={cn(
+                    'text-[13px] font-medium truncate flex-1',
+                    task.status === 'running' ? color : 'text-text-muted',
+                  )}>
+                    {task.name}
+                  </span>
+                  <span className="text-[11px] text-text-muted shrink-0 tabular-nums">
+                    {task.status === 'running'
+                      ? task.description
+                      : task.durationMs != null
+                        ? formatDuration(task.durationMs)
+                        : task.error ?? 'Done'
+                    }
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/xerus_web/components/chat/TaskDock.tsx
+++ b/xerus_web/components/chat/TaskDock.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { ChevronUp, ChevronDown, Loader2, Check, X, Square } from 'lucide-react'
+import type { DockTask } from './useTaskDock'
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+interface TaskDockProps {
+  tasks: DockTask[]
+  activeCount: number
+  isCollapsed: boolean
+  onCollapse: () => void
+  onExpand: () => void
+  onStopAll?: () => void
+}
+
+export function TaskDock({
+  tasks,
+  activeCount,
+  isCollapsed,
+  onCollapse,
+  onExpand,
+  onStopAll,
+}: TaskDockProps) {
+  if (tasks.length === 0) return null
+
+  return (
+    <div className="shrink-0 border-t border-border bg-surface transition-all duration-200">
+      {/* Header row */}
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center gap-2">
+          {activeCount > 0 && (
+            <Loader2 className="w-3.5 h-3.5 animate-spin text-secondary" />
+          )}
+          <span className="text-xs font-medium text-text-secondary">
+            {activeCount > 0
+              ? `${activeCount} Working`
+              : `${tasks.length} Completed`
+            }
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {activeCount > 0 && onStopAll && (
+            <button
+              type="button"
+              onClick={onStopAll}
+              className="text-[11px] text-red-500 hover:text-red-600 hover:bg-red-50 px-2 py-1 rounded-md transition-colors"
+            >
+              Stop All
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={isCollapsed ? onExpand : onCollapse}
+            className="p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            aria-label={isCollapsed ? 'Expand task dock' : 'Collapse task dock'}
+          >
+            {isCollapsed ? (
+              <ChevronUp className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronDown className="w-3.5 h-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded task list */}
+      {!isCollapsed && (
+        <div className="px-4 pb-2 space-y-1 max-h-[160px] overflow-y-auto">
+          {tasks.map((task) => (
+            <div
+              key={task.id}
+              className="flex items-center gap-2.5 py-1 px-2 rounded-md bg-surface-alt/50"
+            >
+              {task.status === 'running' ? (
+                <Loader2 className="w-3 h-3 animate-spin text-secondary shrink-0" />
+              ) : task.status === 'completed' ? (
+                <Check className="w-3 h-3 text-emerald-500 shrink-0" />
+              ) : (
+                <X className="w-3 h-3 text-red-500 shrink-0" />
+              )}
+              <span className="text-xs font-medium text-text truncate flex-1">
+                {task.name}
+              </span>
+              <span className="text-[11px] text-text-muted truncate max-w-[180px]">
+                {task.status === 'running'
+                  ? task.description
+                  : task.durationMs != null
+                    ? `Done (${formatDuration(task.durationMs)})`
+                    : task.error ?? 'Done'
+                }
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/xerus_web/components/chat/TaskDock.tsx
+++ b/xerus_web/components/chat/TaskDock.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { ChevronUp, ChevronDown, Loader2, Check, X as XIcon } from 'lucide-react'
+import { ChevronDown, ChevronUp, Loader2, Check, X as XIcon } from 'lucide-react'
 import type { DockTask } from './useTaskDock'
 
 function formatDuration(ms: number): string {
@@ -33,92 +33,84 @@ export function TaskDock({
   const completedCount = tasks.filter((t) => t.status !== 'running').length
 
   return (
-    <div className="absolute bottom-full left-4 right-4 mb-2 z-20 pointer-events-none">
-      <div className="max-w-sm pointer-events-auto rounded-xl bg-card border border-border shadow-lg overflow-hidden">
-        {/* Header */}
+    <div className="border-b border-border/50 px-3 py-2">
+      {/* Header */}
+      <div className="flex items-center justify-between">
         <button
           type="button"
           onClick={isCollapsed ? onExpand : onCollapse}
-          className="flex items-center justify-between w-full px-3 py-2 hover:bg-surface-hover/50 transition-colors"
+          className="flex items-center gap-2 text-xs hover:text-text transition-colors"
         >
-          <div className="flex items-center gap-2">
-            {activeCount > 0 ? (
-              <Loader2 className="w-3 h-3 animate-spin text-secondary" />
-            ) : (
-              <Check className="w-3 h-3 text-emerald-500" />
-            )}
-            <span className="text-xs font-semibold text-text">
-              {activeCount > 0 ? `${activeCount} Working` : 'Done'}
-            </span>
-            {completedCount > 0 && activeCount > 0 && (
-              <span className="text-[10px] text-text-muted">{completedCount} done</span>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            {activeCount > 0 && onStopAll && (
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={(e) => { e.stopPropagation(); onStopAll() }}
-                onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onStopAll() } }}
-                className="text-[10px] font-medium text-text-muted hover:text-red-500 px-1.5 py-0.5 rounded hover:bg-red-50 transition-colors"
-              >
-                Stop All
-              </span>
-            )}
-            {activeCount === 0 && onDismiss && (
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={(e) => { e.stopPropagation(); onDismiss() }}
-                onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onDismiss() } }}
-                className="p-0.5 rounded text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
-              >
-                <XIcon className="w-3 h-3" />
-              </span>
-            )}
-            {isCollapsed ? (
-              <ChevronUp className="w-3 h-3 text-text-muted" />
-            ) : (
-              <ChevronDown className="w-3 h-3 text-text-muted" />
-            )}
-          </div>
+          {activeCount > 0 ? (
+            <Loader2 className="w-3 h-3 animate-spin text-secondary" />
+          ) : (
+            <Check className="w-3 h-3 text-emerald-500" />
+          )}
+          <span className="font-semibold text-text">
+            {activeCount > 0 ? `${activeCount} Working` : 'Done'}
+          </span>
+          {completedCount > 0 && activeCount > 0 && (
+            <span className="text-text-muted">{completedCount} done</span>
+          )}
+          {isCollapsed ? (
+            <ChevronDown className="w-3 h-3 text-text-muted" />
+          ) : (
+            <ChevronUp className="w-3 h-3 text-text-muted" />
+          )}
         </button>
-
-        {/* Task list */}
-        {!isCollapsed && (
-          <div className="border-t border-border/50 px-2 py-1.5 space-y-0.5 max-h-[120px] overflow-y-auto">
-            {tasks.map((task) => (
-              <div
-                key={task.id}
-                className="flex items-center gap-2 py-1 px-1.5 rounded-md"
-              >
-                {task.status === 'running' ? (
-                  <Loader2 className="w-3 h-3 animate-spin text-secondary shrink-0" />
-                ) : task.status === 'completed' ? (
-                  <Check className="w-3 h-3 text-emerald-500 shrink-0" />
-                ) : (
-                  <XIcon className="w-3 h-3 text-red-400 shrink-0" />
-                )}
-                <span className={cn(
-                  'text-xs truncate flex-1',
-                  task.status === 'running' ? 'font-medium text-text' : 'text-text-muted',
-                )}>
-                  {task.name}
-                </span>
-                <span className="text-[10px] text-text-muted shrink-0 tabular-nums">
-                  {task.status === 'running'
-                    ? task.description
-                    : task.durationMs != null
-                      ? formatDuration(task.durationMs)
-                      : 'Done'
-                  }
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          {activeCount > 0 && onStopAll && (
+            <button
+              type="button"
+              onClick={onStopAll}
+              className="text-[10px] font-medium text-text-muted hover:text-red-500 px-1.5 py-0.5 rounded hover:bg-red-50 transition-colors"
+            >
+              Stop All
+            </button>
+          )}
+          {activeCount === 0 && onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="p-0.5 rounded text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+              aria-label="Dismiss"
+            >
+              <XIcon className="w-3 h-3" />
+            </button>
+          )}
+        </div>
       </div>
+
+      {/* Task list */}
+      {!isCollapsed && (
+        <div className="mt-1.5 space-y-0.5 max-h-[100px] overflow-y-auto">
+          {tasks.map((task) => (
+            <div key={task.id} className="flex items-center gap-2 py-0.5">
+              {task.status === 'running' ? (
+                <Loader2 className="w-3 h-3 animate-spin text-secondary shrink-0" />
+              ) : task.status === 'completed' ? (
+                <Check className="w-3 h-3 text-emerald-500 shrink-0" />
+              ) : (
+                <XIcon className="w-3 h-3 text-red-400 shrink-0" />
+              )}
+              <span className={cn(
+                'text-xs truncate flex-1',
+                task.status === 'running' ? 'font-medium text-text' : 'text-text-muted',
+              )}>
+                {task.name}
+              </span>
+              <span className="text-[10px] text-text-muted shrink-0 tabular-nums">
+                {task.status === 'running'
+                  ? task.description
+                  : task.durationMs != null
+                    ? formatDuration(task.durationMs)
+                    : 'Done'
+                }
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/xerus_web/components/chat/TaskDock.tsx
+++ b/xerus_web/components/chat/TaskDock.tsx
@@ -1,24 +1,13 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { ChevronUp, ChevronDown, Loader2, Check, X } from 'lucide-react'
+import { ChevronUp, ChevronDown, Loader2, Check, X as XIcon } from 'lucide-react'
 import type { DockTask } from './useTaskDock'
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
   return `${(ms / 1000).toFixed(1)}s`
 }
-
-const TASK_COLORS = [
-  'text-blue-600',
-  'text-violet-600',
-  'text-amber-600',
-  'text-emerald-600',
-  'text-cyan-600',
-  'text-rose-600',
-  'text-purple-600',
-  'text-teal-600',
-]
 
 interface TaskDockProps {
   tasks: DockTask[]
@@ -27,6 +16,7 @@ interface TaskDockProps {
   onCollapse: () => void
   onExpand: () => void
   onStopAll?: () => void
+  onDismiss?: () => void
 }
 
 export function TaskDock({
@@ -36,94 +26,96 @@ export function TaskDock({
   onCollapse,
   onExpand,
   onStopAll,
+  onDismiss,
 }: TaskDockProps) {
   if (tasks.length === 0) return null
 
   const completedCount = tasks.filter((t) => t.status !== 'running').length
 
   return (
-    <div className="shrink-0 mx-4 mb-2 max-w-md">
-      <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
+    <div className="absolute bottom-full left-4 right-4 mb-2 z-20 pointer-events-none">
+      <div className="max-w-sm pointer-events-auto rounded-xl bg-card border border-border shadow-lg overflow-hidden">
         {/* Header */}
         <button
           type="button"
           onClick={isCollapsed ? onExpand : onCollapse}
-          className="flex items-center justify-between w-full px-4 py-2.5 hover:bg-surface-hover/50 transition-colors"
+          className="flex items-center justify-between w-full px-3 py-2 hover:bg-surface-hover/50 transition-colors"
         >
-          <div className="flex items-center gap-2.5">
+          <div className="flex items-center gap-2">
             {activeCount > 0 ? (
-              <Loader2 className="w-3.5 h-3.5 animate-spin text-secondary" />
+              <Loader2 className="w-3 h-3 animate-spin text-secondary" />
             ) : (
-              <Check className="w-3.5 h-3.5 text-emerald-500" />
+              <Check className="w-3 h-3 text-emerald-500" />
             )}
-            <span className="text-[13px] font-medium text-text">
-              {activeCount > 0 ? `${activeCount} Working` : 'All tasks completed'}
+            <span className="text-xs font-semibold text-text">
+              {activeCount > 0 ? `${activeCount} Working` : 'Done'}
             </span>
-            {activeCount > 0 && completedCount > 0 && (
-              <span className="text-[11px] text-text-muted">
-                {completedCount} done
-              </span>
+            {completedCount > 0 && activeCount > 0 && (
+              <span className="text-[10px] text-text-muted">{completedCount} done</span>
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
             {activeCount > 0 && onStopAll && (
               <span
                 role="button"
                 tabIndex={0}
                 onClick={(e) => { e.stopPropagation(); onStopAll() }}
                 onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onStopAll() } }}
-                className="text-[11px] font-medium text-text-muted hover:text-red-500 px-2 py-0.5 rounded-md hover:bg-red-50 transition-colors"
+                className="text-[10px] font-medium text-text-muted hover:text-red-500 px-1.5 py-0.5 rounded hover:bg-red-50 transition-colors"
               >
                 Stop All
               </span>
             )}
+            {activeCount === 0 && onDismiss && (
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => { e.stopPropagation(); onDismiss() }}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onDismiss() } }}
+                className="p-0.5 rounded text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+              >
+                <XIcon className="w-3 h-3" />
+              </span>
+            )}
             {isCollapsed ? (
-              <ChevronUp className="w-3.5 h-3.5 text-text-muted" />
+              <ChevronUp className="w-3 h-3 text-text-muted" />
             ) : (
-              <ChevronDown className="w-3.5 h-3.5 text-text-muted" />
+              <ChevronDown className="w-3 h-3 text-text-muted" />
             )}
           </div>
         </button>
 
         {/* Task list */}
         {!isCollapsed && (
-          <div className="border-t border-border/50 px-3 py-2 space-y-1 max-h-[140px] overflow-y-auto">
-            {tasks.map((task, idx) => {
-              const color = TASK_COLORS[idx % TASK_COLORS.length]
-              return (
-                <div
-                  key={task.id}
-                  className={cn(
-                    'flex items-center gap-2.5 py-1.5 px-2 rounded-lg transition-colors',
-                    task.status === 'running' && 'bg-surface-alt/30',
-                  )}
-                >
-                  {task.status === 'running' ? (
-                    <span className={cn('flex items-center justify-center w-4 h-4 shrink-0', color)}>
-                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                    </span>
-                  ) : task.status === 'completed' ? (
-                    <Check className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
-                  ) : (
-                    <X className="w-3.5 h-3.5 text-red-400 shrink-0" />
-                  )}
-                  <span className={cn(
-                    'text-[13px] font-medium truncate flex-1',
-                    task.status === 'running' ? color : 'text-text-muted',
-                  )}>
-                    {task.name}
-                  </span>
-                  <span className="text-[11px] text-text-muted shrink-0 tabular-nums">
-                    {task.status === 'running'
-                      ? task.description
-                      : task.durationMs != null
-                        ? formatDuration(task.durationMs)
-                        : task.error ?? 'Done'
-                    }
-                  </span>
-                </div>
-              )
-            })}
+          <div className="border-t border-border/50 px-2 py-1.5 space-y-0.5 max-h-[120px] overflow-y-auto">
+            {tasks.map((task) => (
+              <div
+                key={task.id}
+                className="flex items-center gap-2 py-1 px-1.5 rounded-md"
+              >
+                {task.status === 'running' ? (
+                  <Loader2 className="w-3 h-3 animate-spin text-secondary shrink-0" />
+                ) : task.status === 'completed' ? (
+                  <Check className="w-3 h-3 text-emerald-500 shrink-0" />
+                ) : (
+                  <XIcon className="w-3 h-3 text-red-400 shrink-0" />
+                )}
+                <span className={cn(
+                  'text-xs truncate flex-1',
+                  task.status === 'running' ? 'font-medium text-text' : 'text-text-muted',
+                )}>
+                  {task.name}
+                </span>
+                <span className="text-[10px] text-text-muted shrink-0 tabular-nums">
+                  {task.status === 'running'
+                    ? task.description
+                    : task.durationMs != null
+                      ? formatDuration(task.durationMs)
+                      : 'Done'
+                  }
+                </span>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/xerus_web/components/chat/ToolActionGroup.tsx
+++ b/xerus_web/components/chat/ToolActionGroup.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import {
+  ChevronRight, ChevronDown, Loader2,
+  Terminal, FileText, Pencil, Search, Globe, Brain,
+  Bot, Puzzle, ListChecks, HelpCircle,
+} from 'lucide-react'
+import type { TurnPart, ToolCallIcon } from './streaming-turn.types'
+import { ToolCallCard, type ToolCallCardData } from './ToolCallCard'
+import type { Agent } from './types'
+
+const TOOL_ICON: Record<ToolCallIcon, typeof Terminal> = {
+  bash: Terminal,
+  read: FileText,
+  write: Pencil,
+  search: Search,
+  web: Globe,
+  think: Brain,
+  agent: Bot,
+  skill: Puzzle,
+  task: ListChecks,
+  question: HelpCircle,
+}
+
+const TOOL_COLOR: Record<ToolCallIcon, string> = {
+  bash: 'bg-emerald-500/10 text-emerald-600',
+  read: 'bg-blue-500/10 text-blue-600',
+  write: 'bg-violet-500/10 text-violet-600',
+  search: 'bg-amber-500/10 text-amber-600',
+  web: 'bg-cyan-500/10 text-cyan-600',
+  think: 'bg-slate-500/10 text-slate-600',
+  agent: 'bg-secondary/10 text-secondary',
+  skill: 'bg-purple-500/10 text-purple-600',
+  task: 'bg-teal-500/10 text-teal-600',
+  question: 'bg-rose-500/10 text-rose-600',
+}
+
+type ToolPart = Extract<TurnPart, { type: 'tool' }>
+
+function partToToolCall(part: ToolPart, agents?: Agent[]): ToolCallCardData {
+  let avatarUrl: string | undefined
+  if (part.name === 'Agent' && part.args && agents) {
+    const subagentSlug = (part.args.subagent_type || part.args.agent_type || '') as string
+    const matched = subagentSlug
+      ? agents.find(a => a.slug === subagentSlug || a.name === subagentSlug)
+      : undefined
+    avatarUrl = matched?.avatarUrl ?? undefined
+  }
+
+  return {
+    id: part.id,
+    name: part.name,
+    icon: part.icon,
+    target: part.target,
+    output: part.result != null
+      ? (typeof part.result === 'string' ? part.result : JSON.stringify(part.result))
+      : undefined,
+    status: part.state === 'running' ? 'running' : part.state === 'error' ? 'error' : 'success',
+    duration_ms: part.state === 'running' ? undefined : part.durationMs,
+    avatarUrl,
+  }
+}
+
+interface ToolActionGroupProps {
+  tools: ToolPart[]
+  agents?: Agent[]
+  defaultExpanded?: boolean
+}
+
+export function ToolActionGroup({ tools, agents, defaultExpanded = false }: ToolActionGroupProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const anyRunning = tools.some(t => t.state === 'running')
+  const completedCount = tools.filter(t => t.state !== 'running').length
+  const totalCount = tools.length
+
+  const uniqueIcons = [...new Set(tools.map(t => t.icon))]
+
+  return (
+    <div className="flex flex-col items-start">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className={cn(
+          'inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-surface-active bg-surface-alt/50',
+          'hover:bg-surface-hover/80 transition-colors duration-150',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+        )}
+      >
+        <div className="flex items-center gap-1">
+          {uniqueIcons.map((icon) => {
+            const Icon = TOOL_ICON[icon] ?? Terminal
+            const colorClass = TOOL_COLOR[icon] ?? TOOL_COLOR.bash
+            return (
+              <div
+                key={icon}
+                className={cn(
+                  'w-5 h-5 rounded-md flex items-center justify-center shrink-0',
+                  colorClass,
+                  anyRunning && 'animate-pulse',
+                )}
+              >
+                <Icon className="w-2.5 h-2.5" />
+              </div>
+            )
+          })}
+        </div>
+
+        {anyRunning ? (
+          <span className="inline-flex items-center gap-1.5 text-xs text-text-muted">
+            <Loader2 className="w-3 h-3 animate-spin text-secondary" />
+            {completedCount}/{totalCount} actions
+          </span>
+        ) : (
+          <span className="text-xs text-text-muted">
+            {totalCount} {totalCount === 1 ? 'action' : 'actions'}
+          </span>
+        )}
+
+        {expanded ? (
+          <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="flex flex-col items-start gap-1.5 mt-1.5 ml-1">
+          {tools.map((part) => (
+            <ToolCallCard key={part.id} tool={partToToolCall(part, agents)} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/xerus_web/components/chat/ToolActionGroup.tsx
+++ b/xerus_web/components/chat/ToolActionGroup.tsx
@@ -3,39 +3,12 @@
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
 import {
-  ChevronRight, ChevronDown, Loader2,
-  Terminal, FileText, Pencil, Search, Globe, Brain,
-  Bot, Puzzle, ListChecks, HelpCircle,
+  ChevronRight, ChevronDown, Loader2, Terminal,
 } from 'lucide-react'
-import type { TurnPart, ToolCallIcon } from './streaming-turn.types'
+import type { TurnPart } from './streaming-turn.types'
+import { TOOL_ICON_MAP, TOOL_COLOR_MAP } from './tool-icon.utils'
 import { ToolCallCard, type ToolCallCardData } from './ToolCallCard'
 import type { Agent } from './types'
-
-const TOOL_ICON: Record<ToolCallIcon, typeof Terminal> = {
-  bash: Terminal,
-  read: FileText,
-  write: Pencil,
-  search: Search,
-  web: Globe,
-  think: Brain,
-  agent: Bot,
-  skill: Puzzle,
-  task: ListChecks,
-  question: HelpCircle,
-}
-
-const TOOL_COLOR: Record<ToolCallIcon, string> = {
-  bash: 'bg-emerald-500/10 text-emerald-600',
-  read: 'bg-blue-500/10 text-blue-600',
-  write: 'bg-violet-500/10 text-violet-600',
-  search: 'bg-amber-500/10 text-amber-600',
-  web: 'bg-cyan-500/10 text-cyan-600',
-  think: 'bg-slate-500/10 text-slate-600',
-  agent: 'bg-secondary/10 text-secondary',
-  skill: 'bg-purple-500/10 text-purple-600',
-  task: 'bg-teal-500/10 text-teal-600',
-  question: 'bg-rose-500/10 text-rose-600',
-}
 
 type ToolPart = Extract<TurnPart, { type: 'tool' }>
 
@@ -90,8 +63,8 @@ export function ToolActionGroup({ tools, agents, defaultExpanded = false }: Tool
       >
         <div className="flex items-center gap-1">
           {uniqueIcons.map((icon) => {
-            const Icon = TOOL_ICON[icon] ?? Terminal
-            const colorClass = TOOL_COLOR[icon] ?? TOOL_COLOR.bash
+            const Icon = TOOL_ICON_MAP[icon] ?? Terminal
+            const colorClass = TOOL_COLOR_MAP[icon] ?? TOOL_COLOR_MAP.bash
             return (
               <div
                 key={icon}

--- a/xerus_web/components/chat/ToolActionGroup.tsx
+++ b/xerus_web/components/chat/ToolActionGroup.tsx
@@ -25,8 +25,12 @@ function partToToolCall(part: ToolPart, agents?: Agent[]): ToolCallCardData {
   return {
     id: part.id,
     name: part.name,
+    label: part.label,
     icon: part.icon,
     target: part.target,
+    detail: part.detail,
+    progressMessage: part.progressMessage,
+    args: part.args,
     output: part.result != null
       ? (typeof part.result === 'string' ? part.result : JSON.stringify(part.result))
       : undefined,

--- a/xerus_web/components/chat/ToolCallCard.tsx
+++ b/xerus_web/components/chat/ToolCallCard.tsx
@@ -61,21 +61,26 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
   const Icon = TOOL_ICON[tool.icon] ?? Terminal
   const colorClass = TOOL_COLOR[tool.icon] ?? TOOL_COLOR.bash
   const isRunning = tool.status === 'running'
+  const isQuestion = tool.icon === 'question'
+  const isAwaitingResponse = isQuestion && isRunning
 
   return (
     <button
       type="button"
       onClick={() => !isRunning && setExpanded(!expanded)}
       className={cn(
-        'inline-flex flex-col items-start max-w-full text-left rounded-xl border border-surface-active bg-surface-alt/50 overflow-hidden',
+        'inline-flex flex-col items-start max-w-full text-left rounded-xl border overflow-hidden',
         'hover:bg-surface-hover/80 transition-colors duration-150',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary'
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+        isAwaitingResponse
+          ? 'border-rose-200 bg-rose-50/50'
+          : 'border-surface-active bg-surface-alt/50',
       )}
     >
       {/* Header row */}
       <div className="flex items-center gap-2.5 px-3 py-2 min-w-0">
         <div className={cn('w-6 h-6 rounded-lg flex items-center justify-center shrink-0 overflow-hidden', colorClass)}>
-          {isRunning ? (
+          {isRunning && !isQuestion ? (
             <Loader2 className="w-3 h-3 animate-spin" />
           ) : tool.avatarUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
@@ -95,7 +100,9 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
             ({tool.detail})
           </span>
         )}
-        {isRunning ? (
+        {isAwaitingResponse ? (
+          <span className="text-[10px] font-medium text-rose-500 shrink-0 animate-pulse">Awaiting response</span>
+        ) : isRunning ? (
           <Loader2 className="w-3 h-3 animate-spin text-text-muted shrink-0" />
         ) : tool.duration_ms != null ? (
           <span className="text-[10px] text-text-muted tabular-nums shrink-0">

--- a/xerus_web/components/chat/ToolCallCard.tsx
+++ b/xerus_web/components/chat/ToolCallCard.tsx
@@ -96,7 +96,7 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
           </span>
         )}
         {isRunning ? (
-          <span className="text-[10px] text-text-muted shrink-0">running...</span>
+          <Loader2 className="w-3 h-3 animate-spin text-text-muted shrink-0" />
         ) : tool.duration_ms != null ? (
           <span className="text-[10px] text-text-muted tabular-nums shrink-0">
             {formatDuration(tool.duration_ms)}

--- a/xerus_web/components/chat/ToolCallCard.tsx
+++ b/xerus_web/components/chat/ToolCallCard.tsx
@@ -3,37 +3,10 @@
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
 import {
-  ChevronRight, ChevronDown,
-  Terminal, FileText, Pencil, Search, Globe, Brain,
-  Loader2, Bot, Puzzle, ListChecks, HelpCircle,
+  ChevronRight, ChevronDown, Terminal, Loader2,
 } from 'lucide-react'
 import type { ToolCallIcon } from './streaming-turn.types'
-
-const TOOL_ICON: Record<ToolCallIcon, typeof Terminal> = {
-  bash: Terminal,
-  read: FileText,
-  write: Pencil,
-  search: Search,
-  web: Globe,
-  think: Brain,
-  agent: Bot,
-  skill: Puzzle,
-  task: ListChecks,
-  question: HelpCircle,
-}
-
-const TOOL_COLOR: Record<ToolCallIcon, string> = {
-  bash: 'bg-emerald-500/10 text-emerald-600',
-  read: 'bg-blue-500/10 text-blue-600',
-  write: 'bg-violet-500/10 text-violet-600',
-  search: 'bg-amber-500/10 text-amber-600',
-  web: 'bg-cyan-500/10 text-cyan-600',
-  think: 'bg-slate-500/10 text-slate-600',
-  agent: 'bg-secondary/10 text-secondary',
-  skill: 'bg-purple-500/10 text-purple-600',
-  task: 'bg-teal-500/10 text-teal-600',
-  question: 'bg-rose-500/10 text-rose-600',
-}
+import { TOOL_ICON_MAP, TOOL_COLOR_MAP } from './tool-icon.utils'
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
@@ -58,8 +31,8 @@ interface ToolCallCardProps {
 
 export function ToolCallCard({ tool }: ToolCallCardProps) {
   const [expanded, setExpanded] = useState(false)
-  const Icon = TOOL_ICON[tool.icon] ?? Terminal
-  const colorClass = TOOL_COLOR[tool.icon] ?? TOOL_COLOR.bash
+  const Icon = TOOL_ICON_MAP[tool.icon] ?? Terminal
+  const colorClass = TOOL_COLOR_MAP[tool.icon] ?? TOOL_COLOR_MAP.bash
   const isRunning = tool.status === 'running'
   const isQuestion = tool.icon === 'question'
   const isAwaitingResponse = isQuestion && isRunning
@@ -109,7 +82,7 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
             {formatDuration(tool.duration_ms)}
           </span>
         ) : null}
-        {!isRunning && (
+        {!isRunning && tool.output && (
           expanded ? (
             <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
           ) : (

--- a/xerus_web/components/chat/ToolCallCard.tsx
+++ b/xerus_web/components/chat/ToolCallCard.tsx
@@ -10,16 +10,28 @@ import { TOOL_ICON_MAP, TOOL_COLOR_MAP } from './tool-icon.utils'
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(1)}s`
+  const seconds = Math.round(ms / 1000)
+  if (seconds === 1) return '1 second'
+  if (seconds < 60) return `${seconds} seconds`
+  const minutes = Math.round(seconds / 60)
+  return `${minutes} min`
+}
+
+function isEditTool(name: string): boolean {
+  const n = name.toLowerCase()
+  return n === 'edit' || n === 'multiedit'
 }
 
 export interface ToolCallCardData {
   id: string
   name: string
+  label: string
   icon: ToolCallIcon
   target?: string
   detail?: string
+  progressMessage?: string
   output?: string
+  args?: Record<string, unknown>
   status: 'success' | 'error' | 'running'
   duration_ms?: number
   avatarUrl?: string
@@ -36,69 +48,120 @@ export function ToolCallCard({ tool }: ToolCallCardProps) {
   const isRunning = tool.status === 'running'
   const isQuestion = tool.icon === 'question'
   const isAwaitingResponse = isQuestion && isRunning
+  const hasExpandableContent = !isRunning && (tool.output || (isEditTool(tool.name) && tool.args))
+
+  const durationText = tool.duration_ms != null ? formatDuration(tool.duration_ms) : null
 
   return (
-    <button
-      type="button"
-      onClick={() => !isRunning && setExpanded(!expanded)}
-      className={cn(
-        'inline-flex flex-col items-start max-w-full text-left rounded-xl border overflow-hidden',
-        'hover:bg-surface-hover/80 transition-colors duration-150',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
-        isAwaitingResponse
-          ? 'border-rose-200 bg-rose-50/50'
-          : 'border-surface-active bg-surface-alt/50',
-      )}
-    >
+    <div className={cn(
+      'inline-flex flex-col items-start max-w-full rounded-xl border overflow-hidden',
+      'transition-colors duration-150',
+      isAwaitingResponse
+        ? 'border-rose-200 bg-rose-50/50'
+        : 'border-surface-active bg-surface-alt/50',
+    )}>
       {/* Header row */}
-      <div className="flex items-center gap-2.5 px-3 py-2 min-w-0">
-        <div className={cn('w-6 h-6 rounded-lg flex items-center justify-center shrink-0 overflow-hidden', colorClass)}>
+      <button
+        type="button"
+        onClick={() => hasExpandableContent && setExpanded(!expanded)}
+        className={cn(
+          'flex items-center gap-2 px-3 py-2 min-w-0 w-full text-left',
+          hasExpandableContent && 'hover:bg-surface-hover/80 cursor-pointer',
+          !hasExpandableContent && 'cursor-default',
+        )}
+      >
+        <div className={cn('w-5 h-5 rounded-md flex items-center justify-center shrink-0 overflow-hidden', colorClass)}>
           {isRunning && !isQuestion ? (
-            <Loader2 className="w-3 h-3 animate-spin" />
+            <Loader2 className="w-2.5 h-2.5 animate-spin" />
           ) : tool.avatarUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={tool.avatarUrl} alt={tool.name} className="w-6 h-6 object-cover" />
+            <img src={tool.avatarUrl} alt={tool.name} className="w-5 h-5 object-cover" />
           ) : (
-            <Icon className="w-3 h-3" />
+            <Icon className="w-2.5 h-2.5" />
           )}
         </div>
-        <span className="text-xs font-medium text-text shrink-0">{tool.name}</span>
-        {tool.target && (
-          <span className="text-xs text-secondary font-mono truncate min-w-0 flex-1 px-1.5 py-0.5 rounded-md border border-secondary/15 bg-secondary/5">
-            {tool.target}
-          </span>
-        )}
-        {tool.detail && (
-          <span className="text-[11px] text-text-muted shrink-0 hidden sm:inline">
-            ({tool.detail})
-          </span>
-        )}
+
+        {/* Label + duration inline */}
+        <span className="text-xs text-text min-w-0 flex-1 truncate">
+          <span className="font-medium">{tool.label}</span>
+          {tool.target && (
+            <span className="text-secondary ml-1.5 font-mono">{tool.target}</span>
+          )}
+          {tool.detail && (
+            <span className="text-text-muted ml-1 hidden sm:inline">({tool.detail})</span>
+          )}
+          {isRunning && tool.progressMessage && (
+            <span className="text-text-muted ml-1.5 italic">{tool.progressMessage}</span>
+          )}
+          {!isRunning && durationText && (
+            <span className="text-text-muted ml-1.5">({durationText})</span>
+          )}
+        </span>
+
         {isAwaitingResponse ? (
           <span className="text-[10px] font-medium text-rose-500 shrink-0 animate-pulse">Awaiting response</span>
         ) : isRunning ? (
           <Loader2 className="w-3 h-3 animate-spin text-text-muted shrink-0" />
-        ) : tool.duration_ms != null ? (
-          <span className="text-[10px] text-text-muted tabular-nums shrink-0">
-            {formatDuration(tool.duration_ms)}
-          </span>
         ) : null}
-        {!isRunning && tool.output && (
+
+        {hasExpandableContent && (
           expanded ? (
             <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
           ) : (
             <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
           )
         )}
-      </div>
+      </button>
 
       {/* Expanded output */}
-      {expanded && tool.output && (
-        <div className="px-3 pb-2.5 pt-0">
-          <pre className="text-[11px] leading-relaxed text-foreground/80 bg-surface rounded-lg px-3 py-2 overflow-x-auto whitespace-pre-wrap font-mono border border-surface-active">
-            {tool.output}
-          </pre>
+      {expanded && (
+        <div className="px-3 pb-2.5 pt-0 w-full">
+          {/* Diff view for Edit/MultiEdit */}
+          {isEditTool(tool.name) && tool.args?.old_string && tool.args?.new_string ? (
+            <DiffBlock
+              oldStr={tool.args.old_string as string}
+              newStr={tool.args.new_string as string}
+              filePath={tool.target}
+            />
+          ) : tool.output ? (
+            <pre className={cn(
+              'text-[11px] leading-relaxed text-foreground/80 rounded-lg px-3 py-2 overflow-x-auto whitespace-pre-wrap font-mono border border-surface-active max-h-[300px] overflow-y-auto',
+              tool.status === 'error' ? 'bg-red-50/50 border-red-200/50' : 'bg-surface',
+            )}>
+              {tool.output}
+            </pre>
+          ) : null}
         </div>
       )}
-    </button>
+    </div>
+  )
+}
+
+function DiffBlock({ oldStr, newStr, filePath }: { oldStr: string; newStr: string; filePath?: string }) {
+  const oldLines = oldStr.split('\n')
+  const newLines = newStr.split('\n')
+
+  return (
+    <div className="rounded-lg border border-surface-active overflow-hidden text-[11px] font-mono">
+      {filePath && (
+        <div className="px-3 py-1.5 bg-surface-alt border-b border-surface-active text-text-muted text-[10px]">
+          {filePath}
+        </div>
+      )}
+      <div className="max-h-[250px] overflow-y-auto">
+        {oldLines.map((line, i) => (
+          <div key={`old-${i}`} className="flex bg-red-50/60">
+            <span className="w-8 text-right pr-2 text-red-400/70 select-none shrink-0 border-r border-red-200/30">-</span>
+            <span className="px-2 text-red-700/80 whitespace-pre-wrap break-all flex-1">{line}</span>
+          </div>
+        ))}
+        {newLines.map((line, i) => (
+          <div key={`new-${i}`} className="flex bg-emerald-50/60">
+            <span className="w-8 text-right pr-2 text-emerald-400/70 select-none shrink-0 border-r border-emerald-200/30">+</span>
+            <span className="px-2 text-emerald-700/80 whitespace-pre-wrap break-all flex-1">{line}</span>
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }

--- a/xerus_web/components/chat/UnifiedMentionPicker.tsx
+++ b/xerus_web/components/chat/UnifiedMentionPicker.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+import { Bot, FileText, BookOpen, Loader2, Folder } from 'lucide-react'
+import type { Agent } from './types'
+import { isMascotConfig } from '@/lib/mascot-config'
+import { MascotAvatar } from '@/components/agents/MascotAvatar'
+
+export interface FileItem {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+}
+
+export interface KBEntry {
+  id: string
+  title: string
+  summary?: string
+}
+
+export type MentionItem =
+  | { type: 'agent'; agent: Agent }
+  | { type: 'file'; file: FileItem }
+  | { type: 'kb'; entry: KBEntry }
+
+interface UnifiedMentionPickerProps {
+  query: string
+  agents: Agent[]
+  files: FileItem[]
+  kbEntries: KBEntry[]
+  filesLoading?: boolean
+  kbLoading?: boolean
+  selectedIdx: number
+  onSelect: (item: MentionItem) => void
+  onClose: () => void
+  onSelectedIdxChange: (idx: number) => void
+}
+
+export function UnifiedMentionPicker({
+  query,
+  agents,
+  files,
+  kbEntries,
+  filesLoading,
+  kbLoading,
+  selectedIdx,
+  onSelect,
+  onClose,
+  onSelectedIdxChange,
+}: UnifiedMentionPickerProps) {
+  const pickerRef = useRef<HTMLDivElement>(null)
+
+  const isFileMode = query.startsWith('/')
+  const isKBMode = query.startsWith('kb:')
+
+  const filteredAgents = isFileMode || isKBMode ? [] : agents.filter(
+    (a) =>
+      a.name.toLowerCase().includes(query.toLowerCase()) ||
+      (a.domain ?? '').toLowerCase().includes(query.toLowerCase()),
+  ).slice(0, 6)
+
+  const filteredFiles = isFileMode
+    ? files.filter((f) => f.path.toLowerCase().includes(query.slice(1).toLowerCase())).slice(0, 6)
+    : []
+
+  const filteredKB = isKBMode
+    ? kbEntries.filter((e) => e.title.toLowerCase().includes(query.slice(3).toLowerCase())).slice(0, 6)
+    : []
+
+  const allItems: MentionItem[] = [
+    ...filteredAgents.map((a): MentionItem => ({ type: 'agent', agent: a })),
+    ...filteredFiles.map((f): MentionItem => ({ type: 'file', file: f })),
+    ...filteredKB.map((e): MentionItem => ({ type: 'kb', entry: e })),
+  ]
+
+  useEffect(() => {
+    if (!pickerRef.current || allItems.length === 0) return
+    const allButtons = pickerRef.current.querySelectorAll('[role="option"]')
+    const target = allButtons[selectedIdx] as HTMLElement | undefined
+    target?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIdx, allItems.length])
+
+  if (allItems.length === 0 && !filesLoading && !kbLoading) return null
+
+  let globalIdx = 0
+
+  return (
+    <div
+      ref={pickerRef}
+      className="absolute bottom-full left-0 w-[280px] mb-2 bg-card border border-border rounded-xl shadow-lg backdrop-blur-sm overflow-hidden max-h-[280px] overflow-y-auto z-10"
+      role="listbox"
+      aria-label="Mention picker"
+    >
+      {/* Agents section */}
+      {filteredAgents.length > 0 && (
+        <>
+          <div className="px-3 py-1.5 border-b border-border">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-text-muted">Agents</span>
+          </div>
+          <div className="p-1">
+            {filteredAgents.map((agent) => {
+              const idx = globalIdx++
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  role="option"
+                  aria-selected={idx === selectedIdx}
+                  className={cn(
+                    'flex items-center gap-2.5 w-full px-2 py-1.5 text-left text-sm rounded-md transition-colors duration-100',
+                    idx === selectedIdx ? 'bg-surface-hover text-text' : 'text-text hover:bg-surface-hover',
+                  )}
+                  onMouseDown={(e) => { e.preventDefault(); onSelect({ type: 'agent', agent }) }}
+                  onMouseEnter={() => onSelectedIdxChange(idx)}
+                >
+                  <div className="w-6 h-6 rounded-lg overflow-hidden shrink-0 flex items-center justify-center bg-surface-hover text-text-secondary">
+                    {isMascotConfig(agent.avatarUrl) ? (
+                      <MascotAvatar config={agent.avatarUrl!} size={24} className="w-full h-full" alt={agent.name} />
+                    ) : agent.avatarUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={agent.avatarUrl} alt={agent.name} className="w-full h-full object-cover" />
+                    ) : (
+                      <Bot className="w-3.5 h-3.5" />
+                    )}
+                  </div>
+                  <span className="font-medium truncate">{agent.name}</span>
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Files section */}
+      {(filteredFiles.length > 0 || filesLoading) && (
+        <>
+          <div className="px-3 py-1.5 border-b border-border">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-text-muted">Files</span>
+            {filesLoading && <Loader2 className="inline w-3 h-3 ml-1.5 animate-spin text-text-muted" />}
+          </div>
+          <div className="p-1">
+            {filteredFiles.map((file) => {
+              const idx = globalIdx++
+              return (
+                <button
+                  key={file.path}
+                  type="button"
+                  role="option"
+                  aria-selected={idx === selectedIdx}
+                  className={cn(
+                    'flex items-center gap-2.5 w-full px-2 py-1.5 text-left text-sm rounded-md transition-colors duration-100',
+                    idx === selectedIdx ? 'bg-surface-hover text-text' : 'text-text hover:bg-surface-hover',
+                  )}
+                  onMouseDown={(e) => { e.preventDefault(); onSelect({ type: 'file', file }) }}
+                  onMouseEnter={() => onSelectedIdxChange(idx)}
+                >
+                  <div className="w-6 h-6 rounded-lg flex items-center justify-center shrink-0 bg-blue-500/10 text-blue-600">
+                    {file.type === 'directory' ? <Folder className="w-3.5 h-3.5" /> : <FileText className="w-3.5 h-3.5" />}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <span className="font-medium truncate block">{file.name}</span>
+                    <span className="text-[11px] text-text-muted truncate block">{file.path}</span>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {/* KB section */}
+      {(filteredKB.length > 0 || kbLoading) && (
+        <>
+          <div className="px-3 py-1.5 border-b border-border">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-text-muted">Knowledge Base</span>
+            {kbLoading && <Loader2 className="inline w-3 h-3 ml-1.5 animate-spin text-text-muted" />}
+          </div>
+          <div className="p-1">
+            {filteredKB.map((entry) => {
+              const idx = globalIdx++
+              return (
+                <button
+                  key={entry.id}
+                  type="button"
+                  role="option"
+                  aria-selected={idx === selectedIdx}
+                  className={cn(
+                    'flex items-center gap-2.5 w-full px-2 py-1.5 text-left text-sm rounded-md transition-colors duration-100',
+                    idx === selectedIdx ? 'bg-surface-hover text-text' : 'text-text hover:bg-surface-hover',
+                  )}
+                  onMouseDown={(e) => { e.preventDefault(); onSelect({ type: 'kb', entry }) }}
+                  onMouseEnter={() => onSelectedIdxChange(idx)}
+                >
+                  <div className="w-6 h-6 rounded-lg flex items-center justify-center shrink-0 bg-purple-500/10 text-purple-600">
+                    <BookOpen className="w-3.5 h-3.5" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <span className="font-medium truncate block">{entry.title}</span>
+                    {entry.summary && (
+                      <span className="text-[11px] text-text-muted truncate block">{entry.summary}</span>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/xerus_web/components/chat/format-tool-display.ts
+++ b/xerus_web/components/chat/format-tool-display.ts
@@ -1,0 +1,303 @@
+// Smart tool display formatting
+// Converts raw tool names + args into human-readable labels.
+// Strips Daytona workspace paths, summarizes bash commands,
+// and produces verb-based labels + target/detail strings.
+
+const WORKSPACE_PREFIXES = [
+  '/home/daytona/projects/',
+  '/home/daytona/',
+  '/workspace/',
+]
+
+function stripWorkspacePath(raw: string): string {
+  for (const prefix of WORKSPACE_PREFIXES) {
+    if (raw.startsWith(prefix)) {
+      const stripped = raw.slice(prefix.length)
+      const parts = stripped.split('/')
+      if (parts.length > 2) {
+        return parts.slice(1).join('/')
+      }
+      return stripped
+    }
+  }
+  return raw
+}
+
+function basename(path: string): string {
+  const segments = path.split('/')
+  return segments[segments.length - 1] || path
+}
+
+function getString(args: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const val = args[key]
+    if (typeof val === 'string' && val) return val
+  }
+  return undefined
+}
+
+export interface ToolDisplay {
+  label: string
+  target?: string
+  detail?: string
+}
+
+function formatFilePath(path: string): { file: string; relative?: string } {
+  const clean = stripWorkspacePath(path)
+  const file = basename(clean)
+  if (file === clean) return { file }
+  return { file, relative: clean }
+}
+
+function formatBash(command: string): ToolDisplay {
+  const trimmed = command.trim()
+  const cdMatch = trimmed.match(/^cd\s+\S+\s*&&\s*(.+)$/)
+  const effective = cdMatch ? cdMatch[1].trim() : trimmed
+
+  if (/^(npm|npx|yarn|pnpm|bun)\s/.test(effective)) {
+    const first80 = effective.length > 80 ? effective.slice(0, 77) + '...' : effective
+    return { label: 'Ran command', target: first80 }
+  }
+
+  if (/^git\s/.test(effective)) {
+    const first80 = effective.length > 80 ? effective.slice(0, 77) + '...' : effective
+    return { label: 'Ran command', target: first80 }
+  }
+
+  const mkdirMatch = effective.match(/^mkdir\s+(?:-p\s+)?(.+)$/)
+  if (mkdirMatch) {
+    return { label: 'Created directory', target: basename(stripWorkspacePath(mkdirMatch[1].trim())) }
+  }
+
+  const rmMatch = effective.match(/^rm\s+(?:-rf?\s+)?(.+)$/)
+  if (rmMatch) {
+    return { label: 'Removed', target: basename(stripWorkspacePath(rmMatch[1].trim())) }
+  }
+
+  const catMatch = effective.match(/^(cat|head|tail)\s+(.+)$/)
+  if (catMatch) {
+    return { label: 'Read file', target: basename(stripWorkspacePath(catMatch[2].trim())) }
+  }
+
+  const curlMatch = effective.match(/curl\s+.*?(https?:\/\/\S+)/)
+  if (curlMatch) {
+    try {
+      const url = new URL(curlMatch[1])
+      return { label: 'Fetched URL', target: url.hostname + url.pathname.slice(0, 30) }
+    } catch {
+      return { label: 'Fetched URL' }
+    }
+  }
+
+  if (/^ls\b/.test(effective)) {
+    const lsPath = effective.replace(/^ls\s*(-\S+\s+)*/, '').trim()
+    if (lsPath) return { label: 'Listed files', target: basename(stripWorkspacePath(lsPath)) }
+    return { label: 'Listed files' }
+  }
+
+  if (effective.includes(' | ')) {
+    const firstCmd = effective.split(' | ')[0].trim()
+    const truncated = firstCmd.length > 50 ? firstCmd.slice(0, 47) + '...' : firstCmd
+    return { label: 'Executed action', target: truncated + ' | ...' }
+  }
+
+  if (effective.length > 80) {
+    return { label: 'Executed action', target: effective.slice(0, 77) + '...' }
+  }
+  return { label: 'Executed action', target: effective }
+}
+
+export function formatToolDisplay(
+  toolName: string,
+  args?: Record<string, unknown>,
+): ToolDisplay {
+  const name = toolName.toLowerCase()
+
+  if (!args || Object.keys(args).length === 0) {
+    return { label: TOOL_LABELS[name] ?? toolName }
+  }
+
+  // Bash / shell
+  if (name === 'bash' || name === 'exec' || name === 'shell' || name === 'powershell') {
+    const cmd = getString(args, 'command')
+    if (cmd) return formatBash(cmd)
+    return { label: 'Executed action' }
+  }
+
+  // Read
+  if (name === 'read') {
+    const path = getString(args, 'file_path', 'path')
+    if (path) {
+      const fp = formatFilePath(path)
+      return { label: 'Read file', target: fp.file, detail: fp.relative }
+    }
+    return { label: 'Read file' }
+  }
+
+  // Write
+  if (name === 'write') {
+    const path = getString(args, 'file_path', 'path')
+    if (path) {
+      const fp = formatFilePath(path)
+      return { label: 'Wrote file', target: fp.file, detail: fp.relative }
+    }
+    return { label: 'Wrote file' }
+  }
+
+  // Edit / MultiEdit
+  if (name === 'edit' || name === 'multiedit') {
+    const path = getString(args, 'file_path', 'path')
+    if (path) {
+      const fp = formatFilePath(path)
+      return { label: 'Edited file', target: fp.file, detail: fp.relative }
+    }
+    return { label: 'Edited file' }
+  }
+
+  // Glob
+  if (name === 'glob') {
+    const pattern = getString(args, 'pattern')
+    if (pattern) return { label: 'Searched files', target: pattern }
+    return { label: 'Searched files' }
+  }
+
+  // Grep
+  if (name === 'grep') {
+    const pattern = getString(args, 'pattern')
+    const path = getString(args, 'path')
+    if (pattern && path) {
+      return { label: 'Searched codebase', target: `"${pattern}"`, detail: `in ${basename(stripWorkspacePath(path))}` }
+    }
+    if (pattern) return { label: 'Searched codebase', target: `"${pattern}"` }
+    return { label: 'Searched codebase' }
+  }
+
+  // WebFetch
+  if (name === 'webfetch') {
+    const url = getString(args, 'url')
+    if (url) {
+      try {
+        const parsed = new URL(url)
+        return { label: 'Fetched page', target: parsed.hostname }
+      } catch {
+        return { label: 'Fetched page', target: url.slice(0, 60) }
+      }
+    }
+    return { label: 'Fetched page' }
+  }
+
+  // WebSearch
+  if (name === 'websearch') {
+    const query = getString(args, 'query', 'q')
+    if (query) return { label: 'Web search', target: `"${query}"` }
+    return { label: 'Web search' }
+  }
+
+  // Agent / Task
+  if (name === 'agent' || name === 'task') {
+    const agentName = getString(args, 'name', 'subagent_type', 'agent_type')
+    const desc = getString(args, 'description')
+    const prompt = getString(args, 'prompt')
+    const detail = desc || (prompt && prompt.length > 60 ? prompt.slice(0, 57) + '...' : prompt)
+    if (agentName && detail) return { label: 'Delegated to agent', target: agentName, detail }
+    if (agentName) return { label: 'Delegated to agent', target: agentName }
+    if (detail) return { label: 'Started task', target: detail }
+    return { label: 'Delegated to agent' }
+  }
+
+  // Skill
+  if (name === 'skill') {
+    const skillName = getString(args, 'skill', 'name')
+    if (skillName) return { label: 'Invoked skill', target: `/${skillName}` }
+    return { label: 'Invoked skill' }
+  }
+
+  // TodoWrite
+  if (name === 'todowrite') {
+    const todos = args.todos
+    if (Array.isArray(todos) && todos.length > 0) {
+      const count = todos.length
+      return { label: 'Updated task list', target: `${count} ${count === 1 ? 'todo' : 'todos'}` }
+    }
+    const desc = getString(args, 'description', 'name', 'task')
+    if (desc) {
+      const short = desc.length > 60 ? desc.slice(0, 57) + '...' : desc
+      return { label: 'Updated task list', target: short }
+    }
+    return { label: 'Updated task list' }
+  }
+
+  // TaskCreate
+  if (name === 'taskcreate') {
+    const desc = getString(args, 'description', 'name', 'task', 'prompt')
+    if (desc) {
+      const short = desc.length > 60 ? desc.slice(0, 57) + '...' : desc
+      return { label: 'Created task', target: short }
+    }
+    return { label: 'Created task' }
+  }
+
+  // AskUserQuestion
+  if (name === 'askuserquestion') {
+    const question = getString(args, 'question', 'text', 'message')
+    if (question) {
+      const short = question.length > 60 ? question.slice(0, 57) + '...' : question
+      return { label: 'Asked a question', target: short }
+    }
+    return { label: 'Asked a question' }
+  }
+
+  // Notebook
+  if (name.includes('notebook')) {
+    const path = getString(args, 'file_path', 'path', 'notebook')
+    if (path) {
+      const fp = formatFilePath(path)
+      return { label: name.includes('edit') ? 'Edited notebook' : 'Read notebook', target: fp.file, detail: fp.relative }
+    }
+    return { label: 'Notebook operation' }
+  }
+
+  // ToolSearch
+  if (name === 'toolsearch') {
+    const query = getString(args, 'query')
+    if (query) return { label: 'Searched tools', target: query }
+    return { label: 'Searched tools' }
+  }
+
+  // Fallback
+  for (const key of ['file_path', 'path', 'command', 'query', 'pattern', 'name', 'description', 'url']) {
+    const val = args[key]
+    if (typeof val === 'string' && val) {
+      if (key === 'file_path' || key === 'path') {
+        const fp = formatFilePath(val)
+        return { label: toolName, target: fp.file, detail: fp.relative }
+      }
+      const short = val.length > 70 ? val.slice(0, 67) + '...' : val
+      return { label: toolName, target: short }
+    }
+  }
+
+  return { label: TOOL_LABELS[name] ?? toolName }
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  bash: 'Executed action',
+  read: 'Read file',
+  write: 'Wrote file',
+  edit: 'Edited file',
+  multiedit: 'Edited file',
+  glob: 'Searched files',
+  grep: 'Searched codebase',
+  webfetch: 'Fetched page',
+  websearch: 'Web search',
+  agent: 'Delegated to agent',
+  task: 'Started task',
+  skill: 'Invoked skill',
+  todowrite: 'Updated task list',
+  taskcreate: 'Created task',
+  askuserquestion: 'Asked a question',
+  toolsearch: 'Searched tools',
+  powershell: 'Executed action',
+  exec: 'Executed action',
+  shell: 'Executed action',
+}

--- a/xerus_web/components/chat/streaming-turn-reducer.ts
+++ b/xerus_web/components/chat/streaming-turn-reducer.ts
@@ -112,6 +112,13 @@ export function completeToolCall(
   success: boolean,
   durationMs?: number,
 ): StreamingAssistantTurn {
+  const found = turn.parts.some((p) => p.type === 'tool' && p.callId === callId)
+  if (!found) {
+    console.warn(
+      `[streaming-turn] completeToolCall: no matching part for callId="${callId}". ` +
+      `Available tool callIds: ${turn.parts.filter((p) => p.type === 'tool').map((p) => (p as { callId: string }).callId).join(', ') || 'none'}`,
+    )
+  }
   const parts = turn.parts.map((part) => {
     if (part.type === 'tool' && part.callId === callId) {
       return {

--- a/xerus_web/components/chat/streaming-turn-reducer.ts
+++ b/xerus_web/components/chat/streaming-turn-reducer.ts
@@ -15,8 +15,10 @@ function formatTarget(value: unknown): string | undefined {
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)
   if (Array.isArray(value)) return `${value.length} items`
   if (typeof value === 'object') {
-    const name = (value as Record<string, unknown>).name ?? (value as Record<string, unknown>).subject
-    if (typeof name === 'string') return name
+    const obj = value as Record<string, unknown>
+    for (const key of ['path', 'file_path', 'command', 'query', 'pattern', 'name', 'subject', 'description', 'url']) {
+      if (typeof obj[key] === 'string' && obj[key]) return obj[key] as string
+    }
     return undefined
   }
   return undefined

--- a/xerus_web/components/chat/streaming-turn-reducer.ts
+++ b/xerus_web/components/chat/streaming-turn-reducer.ts
@@ -4,24 +4,10 @@
 
 import type { StreamingAssistantTurn, TurnPart, ToolCallIcon } from './streaming-turn.types'
 import { finalizeTurnParts } from './streaming-turn.utils'
+import { formatToolDisplay } from './format-tool-display'
 
 function nextPartId(): string {
   return `part-${crypto.randomUUID()}`
-}
-
-function formatTarget(value: unknown): string | undefined {
-  if (value == null) return undefined
-  if (typeof value === 'string') return value || undefined
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
-  if (Array.isArray(value)) return `${value.length} items`
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>
-    for (const key of ['path', 'file_path', 'command', 'query', 'pattern', 'name', 'subject', 'description', 'url']) {
-      if (typeof obj[key] === 'string' && obj[key]) return obj[key] as string
-    }
-    return undefined
-  }
-  return undefined
 }
 
 export function createStreamingTurn(
@@ -80,9 +66,7 @@ export function startToolCall(
   icon: ToolCallIcon,
   args?: Record<string, unknown>,
 ): StreamingAssistantTurn {
-  const target = args && Object.keys(args).length > 0
-    ? formatTarget(Object.values(args)[0])
-    : undefined
+  const display = formatToolDisplay(name, args)
 
   // If a part with this callId already exists, update it with richer data
   // (content_block_start sends empty args; assistant message sends complete args)
@@ -92,15 +76,16 @@ export function startToolCall(
 
   if (existingIndex >= 0) {
     const existing = turn.parts[existingIndex] as TurnPart & { type: 'tool' }
-    // Only update if new data is richer (has args when existing doesn't)
     const hasNewArgs = args && Object.keys(args).length > 0
     if (!hasNewArgs) return turn
 
     const updated: TurnPart = {
       ...existing,
+      label: display.label ?? existing.label,
       icon: icon ?? existing.icon,
       args: args ?? existing.args,
-      target: target ?? existing.target,
+      target: display.target ?? existing.target,
+      detail: display.detail ?? existing.detail,
     }
     const parts = [...turn.parts]
     parts[existingIndex] = updated
@@ -112,10 +97,12 @@ export function startToolCall(
     type: 'tool',
     callId,
     name,
+    label: display.label,
     state: 'running',
     icon,
     args,
-    target,
+    target: display.target,
+    detail: display.detail,
   }
   return { ...turn, parts: [...turn.parts, part] }
 }
@@ -142,6 +129,42 @@ export function completeToolCall(
         state: success ? 'done' as const : 'error' as const,
         result,
         durationMs,
+      }
+    }
+    return part
+  })
+  return { ...turn, parts }
+}
+
+export function updateToolProgress(
+  turn: StreamingAssistantTurn,
+  toolUseId: string,
+  message: string,
+): StreamingAssistantTurn {
+  const parts = turn.parts.map((part) => {
+    if (part.type === 'tool' && part.callId === toolUseId && part.state === 'running') {
+      return { ...part, progressMessage: message }
+    }
+    return part
+  })
+  return { ...turn, parts }
+}
+
+export function enrichToolSummary(
+  turn: StreamingAssistantTurn,
+  toolUseId: string,
+  durationMs: number,
+  output: unknown,
+  status: 'success' | 'error',
+): StreamingAssistantTurn {
+  const parts = turn.parts.map((part) => {
+    if (part.type === 'tool' && part.callId === toolUseId) {
+      return {
+        ...part,
+        state: status === 'success' ? 'done' as const : 'error' as const,
+        result: output ?? part.result,
+        durationMs: durationMs ?? part.durationMs,
+        progressMessage: undefined,
       }
     }
     return part

--- a/xerus_web/components/chat/streaming-turn-reducer.ts
+++ b/xerus_web/components/chat/streaming-turn-reducer.ts
@@ -127,12 +127,13 @@ export function completeToolCall(
   success: boolean,
   durationMs?: number,
 ): StreamingAssistantTurn {
-  const found = turn.parts.some((p) => p.type === 'tool' && p.callId === callId)
-  if (!found) {
-    console.warn(
-      `[streaming-turn] completeToolCall: no matching part for callId="${callId}". ` +
-      `Available tool callIds: ${turn.parts.filter((p) => p.type === 'tool').map((p) => (p as { callId: string }).callId).join(', ') || 'none'}`,
-    )
+  if (process.env.NODE_ENV === 'development') {
+    const found = turn.parts.some((p) => p.type === 'tool' && p.callId === callId)
+    if (!found) {
+      console.warn(
+        `[streaming-turn] completeToolCall: no matching callId="${callId}"`,
+      )
+    }
   }
   const parts = turn.parts.map((part) => {
     if (part.type === 'tool' && part.callId === callId) {

--- a/xerus_web/components/chat/streaming-turn-reducer.ts
+++ b/xerus_web/components/chat/streaming-turn-reducer.ts
@@ -9,6 +9,19 @@ function nextPartId(): string {
   return `part-${crypto.randomUUID()}`
 }
 
+function formatTarget(value: unknown): string | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'string') return value || undefined
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return `${value.length} items`
+  if (typeof value === 'object') {
+    const name = (value as Record<string, unknown>).name ?? (value as Record<string, unknown>).subject
+    if (typeof name === 'string') return name
+    return undefined
+  }
+  return undefined
+}
+
 export function createStreamingTurn(
   agentSlug?: string,
   agentName?: string,
@@ -66,7 +79,7 @@ export function startToolCall(
   args?: Record<string, unknown>,
 ): StreamingAssistantTurn {
   const target = args && Object.keys(args).length > 0
-    ? String(Object.values(args)[0] ?? '')
+    ? formatTarget(Object.values(args)[0])
     : undefined
 
   // If a part with this callId already exists, update it with richer data

--- a/xerus_web/components/chat/streaming-turn.types.ts
+++ b/xerus_web/components/chat/streaming-turn.types.ts
@@ -13,11 +13,14 @@ export type TurnPart =
       type: 'tool'
       callId: string
       name: string
+      label: string
       state: 'running' | 'done' | 'error'
       icon: ToolCallIcon
       args?: Record<string, unknown>
       result?: unknown
       target?: string
+      detail?: string
+      progressMessage?: string
       durationMs?: number
     }
   | { id: string; type: 'status'; label: string }

--- a/xerus_web/components/chat/streaming-turn.utils.ts
+++ b/xerus_web/components/chat/streaming-turn.utils.ts
@@ -25,13 +25,43 @@ export function extractTextFromParts(parts?: TurnPart[]): string {
     .join('')
 }
 
+type ToolPart = Extract<TurnPart, { type: 'tool' }>
+export type GroupedPart = TurnPart | { type: 'tool-group'; parts: ToolPart[]; id: string }
+
+export function groupConsecutiveTools(parts: TurnPart[]): GroupedPart[] {
+  const result: GroupedPart[] = []
+  let toolBuffer: ToolPart[] = []
+
+  const flushBuffer = () => {
+    if (toolBuffer.length >= 3) {
+      result.push({ type: 'tool-group', parts: [...toolBuffer], id: `group-${toolBuffer[0].id}` })
+    } else {
+      result.push(...toolBuffer)
+    }
+    toolBuffer = []
+  }
+
+  for (const part of parts) {
+    if (part.type === 'tool') {
+      toolBuffer.push(part)
+    } else {
+      flushBuffer()
+      result.push(part)
+    }
+  }
+  flushBuffer()
+  return result
+}
+
 export function finalizeTurnParts(parts: TurnPart[], finalText?: string): TurnPart[] {
   const canonicalText = finalText ?? extractTextFromParts(parts)
   const reasoningText = parts
     .filter((part): part is Extract<TurnPart, { type: 'reasoning' }> => part.type === 'reasoning')
     .map((part) => part.text)
     .join('')
-  const toolParts = parts.filter((part): part is Extract<TurnPart, { type: 'tool' }> => part.type === 'tool')
+  const toolParts = parts
+    .filter((part): part is Extract<TurnPart, { type: 'tool' }> => part.type === 'tool')
+    .map((part) => part.state === 'running' ? { ...part, state: 'done' as const } : part)
   const statusParts = parts.filter((part) => part.type === 'status')
   const stableParts: TurnPart[] = []
 

--- a/xerus_web/components/chat/tool-icon.utils.ts
+++ b/xerus_web/components/chat/tool-icon.utils.ts
@@ -1,5 +1,28 @@
-// Shared utility: resolve tool name to icon category
+// Shared utility: resolve tool name to icon category + icon/color maps
+import {
+  Terminal, FileText, Pencil, Search, Globe, Brain,
+  Bot, Puzzle, ListChecks, HelpCircle,
+} from 'lucide-react'
 import type { ToolCallIcon } from './streaming-turn.types'
+
+export const TOOL_ICON_MAP: Record<ToolCallIcon, typeof Terminal> = {
+  bash: Terminal, read: FileText, write: Pencil, search: Search,
+  web: Globe, think: Brain, agent: Bot, skill: Puzzle,
+  task: ListChecks, question: HelpCircle,
+}
+
+export const TOOL_COLOR_MAP: Record<ToolCallIcon, string> = {
+  bash: 'bg-emerald-500/10 text-emerald-600',
+  read: 'bg-blue-500/10 text-blue-600',
+  write: 'bg-violet-500/10 text-violet-600',
+  search: 'bg-amber-500/10 text-amber-600',
+  web: 'bg-cyan-500/10 text-cyan-600',
+  think: 'bg-slate-500/10 text-slate-600',
+  agent: 'bg-secondary/10 text-secondary',
+  skill: 'bg-purple-500/10 text-purple-600',
+  task: 'bg-teal-500/10 text-teal-600',
+  question: 'bg-rose-500/10 text-rose-600',
+}
 
 export function resolveToolIcon(name: string): ToolCallIcon {
   const n = name.toLowerCase()

--- a/xerus_web/components/chat/types.ts
+++ b/xerus_web/components/chat/types.ts
@@ -123,6 +123,7 @@ export interface ExecutionStep {
   startTime?: number
   endTime?: number
   data?: Record<string, unknown>
+  metadata?: Record<string, unknown>
 }
 
 export interface ToolExecution {

--- a/xerus_web/components/chat/useChatExecution.ts
+++ b/xerus_web/components/chat/useChatExecution.ts
@@ -251,13 +251,29 @@ export function useChatExecution({ setState }: UseChatExecutionOptions) {
     onDelegation: useCallback((event: StreamEvent<'delegation'>) => {
       const content = event.content as DelegationEventContent
       if (content) {
-        setState(prev => ({
-          ...prev,
-          executionState: prev.executionState ? {
-            ...prev.executionState,
-            currentNode: `Delegating to ${content.toAgent}`,
-          } : prev.executionState,
-        }))
+        setState(prev => {
+          const delegationStep = {
+            id: `delegation-${Date.now()}`,
+            name: content.task || `Delegating to ${content.toAgent}`,
+            status: 'active' as const,
+            startTime: Date.now(),
+            metadata: { toAgent: content.toAgent, fromAgent: content.fromAgent },
+          }
+          return {
+            ...prev,
+            executionState: prev.executionState ? {
+              ...prev.executionState,
+              currentNode: `Delegating to ${content.toAgent}`,
+              steps: [...(prev.executionState.steps ?? []), delegationStep],
+            } : {
+              mode: 'coordinated' as const,
+              steps: [delegationStep],
+              completedSteps: 0,
+              currentNode: `Delegating to ${content.toAgent}`,
+              agents: [content.toAgent],
+            },
+          }
+        })
       }
     }, [setState]),
     onNotification: useCallback((event: StreamEvent<'notification'>) => {

--- a/xerus_web/components/chat/useChatExecution.ts
+++ b/xerus_web/components/chat/useChatExecution.ts
@@ -29,6 +29,12 @@ import type {
   CreditWarningEventContent,
   InsufficientCreditsEventContent,
   ProviderUnavailableEventContent,
+  TaskStartedEventContent,
+  TaskUpdatedEventContent,
+  TaskProgressEventContent,
+  TaskNotificationEventContent,
+  ToolProgressEventContent,
+  ToolUseSummaryEventContent,
 } from '@/hooks/useExecutionStream'
 import type { ChatState } from './types'
 import type { ChatMessageExtended } from './chat-message.types'
@@ -39,6 +45,8 @@ import {
   appendReasoning,
   startToolCall,
   completeToolCall,
+  updateToolProgress,
+  enrichToolSummary,
   addStatus,
   commitTurn,
 } from './streaming-turn-reducer'
@@ -79,11 +87,14 @@ export function useChatExecution({ setState }: UseChatExecutionOptions) {
   const stream = useExecutionStream({
     onToken: useCallback((event: StreamEvent<'token'>) => {
       const content = event.content as TokenEventContent
-      rawTextRef.current += content.text
+      const text = content.text
+      // Skip raw error JSON chunks from upstream LLM providers
+      if (text.includes('"type":"error"') && text.includes('"api_error"')) return
+      rawTextRef.current += text
       setState(prev => {
         const turn = prev.streamingTurn
         if (!turn) return prev
-        return { ...prev, streamingTurn: appendToken(turn, content.text) }
+        return { ...prev, streamingTurn: appendToken(turn, text) }
       })
     }, [setState]),
     onProgress: useCallback((event: StreamEvent<'progress'>) => {
@@ -355,11 +366,108 @@ export function useChatExecution({ setState }: UseChatExecutionOptions) {
       if (!content) return
       toast.error('AI provider temporarily unavailable', { description: content.message })
     }, []),
+    onTaskStarted: useCallback((event: StreamEvent<'task_started'>) => {
+      const content = event.content as TaskStartedEventContent
+      setState(prev => {
+        const turn = prev.streamingTurn
+        if (!turn) return prev
+        return {
+          ...prev,
+          streamingTurn: addStatus(turn, `Started: ${content.taskName}`),
+        }
+      })
+    }, [setState]),
+    onTaskUpdated: useCallback((event: StreamEvent<'task_updated'>) => {
+      const content = event.content as TaskUpdatedEventContent
+      if (content.status === 'completed') {
+        setState(prev => {
+          const turn = prev.streamingTurn
+          if (!turn) return prev
+          return {
+            ...prev,
+            streamingTurn: addStatus(turn, `Completed task`),
+          }
+        })
+      } else if (content.status === 'failed') {
+        setState(prev => {
+          const turn = prev.streamingTurn
+          if (!turn) return prev
+          return {
+            ...prev,
+            streamingTurn: addStatus(turn, `Task failed`),
+          }
+        })
+      }
+    }, [setState]),
+    onTaskProgress: useCallback((event: StreamEvent<'task_progress'>) => {
+      const content = event.content as TaskProgressEventContent
+      if (content.message) {
+        setState(prev => {
+          const turn = prev.streamingTurn
+          if (!turn) return prev
+          return {
+            ...prev,
+            streamingTurn: addStatus(turn, content.message!),
+          }
+        })
+      }
+    }, [setState]),
+    onTaskNotification: useCallback((event: StreamEvent<'task_notification'>) => {
+      const content = event.content as TaskNotificationEventContent
+      const statusText = content.status === 'completed'
+        ? `Finished: ${content.taskSubject}`
+        : content.status === 'failed'
+          ? `Failed: ${content.taskSubject}`
+          : content.taskSubject
+      setState(prev => {
+        const turn = prev.streamingTurn
+        if (!turn) return prev
+        return {
+          ...prev,
+          streamingTurn: addStatus(turn, statusText),
+        }
+      })
+    }, [setState]),
+    onToolProgress: useCallback((event: StreamEvent<'tool_progress'>) => {
+      const content = event.content as ToolProgressEventContent
+      setState(prev => {
+        const turn = prev.streamingTurn
+        if (!turn) return prev
+        return {
+          ...prev,
+          streamingTurn: updateToolProgress(turn, content.toolUseId, content.progress.message),
+        }
+      })
+    }, [setState]),
+    onToolUseSummary: useCallback((event: StreamEvent<'tool_use_summary'>) => {
+      const content = event.content as ToolUseSummaryEventContent
+      setState(prev => {
+        const turn = prev.streamingTurn
+        if (!turn) return prev
+        return {
+          ...prev,
+          streamingTurn: enrichToolSummary(turn, content.toolUseId, content.durationMs, content.output, content.status),
+        }
+      })
+    }, [setState]),
     onDone: useCallback((event: StreamEvent<'done'>) => {
       if (doneReceivedRef.current) return
       doneReceivedRef.current = true
       const content = event.content as DoneEventContent
-      const finalText = content.finalResponse ?? rawTextRef.current
+      const isError = event.success === false || !!content.error
+
+      let finalText = content.finalResponse ?? rawTextRef.current
+
+      // Strip raw error JSON that upstream LLM providers sometimes inject as text
+      // e.g. {"type":"error","error":{"type":"api_error","message":"stream closed..."}}
+      if (finalText) {
+        finalText = finalText.replace(/\{"type"\s*:\s*"error"[^}]*\{[^}]*\}\s*\}/g, '').trim()
+      }
+
+      if (isError) {
+        const errorMsg = content.error?.message ?? 'The AI provider encountered an error'
+        toast.error('Response interrupted', { description: errorMsg })
+      }
 
       // Clear refs immediately after capturing finalText to prevent stale late-arriving tokens
       rawTextRef.current = ''

--- a/xerus_web/components/chat/useChatExecution.ts
+++ b/xerus_web/components/chat/useChatExecution.ts
@@ -202,7 +202,7 @@ export function useChatExecution({ setState }: UseChatExecutionOptions) {
               ...(prev.executionState.steps ?? []),
               {
                 id: `subagent-${Date.now()}`,
-                name: `Spawning ${content.subagentType}`,
+                name: content.taskDescription || content.subagentType,
                 status: 'active' as const,
                 startTime: Date.now(),
               },

--- a/xerus_web/components/chat/useChatState.ts
+++ b/xerus_web/components/chat/useChatState.ts
@@ -239,6 +239,16 @@ export function useChatState({ initialAgentId, conversationId, initialMessage }:
     )
   }, [agents, state.conversationId, state.conversations])
 
+  // ---- Sync conversationId to URL so reloads preserve the conversation ----
+  useEffect(() => {
+    if (!state.conversationId) return
+    const url = new URL(window.location.href)
+    if (url.searchParams.get('c') !== state.conversationId) {
+      url.searchParams.set('c', state.conversationId)
+      window.history.replaceState({}, '', url.toString())
+    }
+  }, [state.conversationId])
+
   // ---- Connect SSE stream when conversation changes ----
   useEffect(() => {
     if (state.conversationId && isAuthReady) {

--- a/xerus_web/components/chat/useChatState.ts
+++ b/xerus_web/components/chat/useChatState.ts
@@ -31,7 +31,7 @@ function mapConversation(c: ApiConversation): Conversation {
     agentSlug: c.agent_slug ?? undefined,
     messages: [],
     createdAt: new Date(c.created_at).getTime(),
-    updatedAt: new Date(c.last_message_at).getTime(),
+    updatedAt: new Date(c.last_message_at || c.created_at).getTime(),
   }
 }
 
@@ -241,10 +241,14 @@ export function useChatState({ initialAgentId, conversationId, initialMessage }:
 
   // ---- Sync conversationId to URL so reloads preserve the conversation ----
   useEffect(() => {
-    if (!state.conversationId) return
     const url = new URL(window.location.href)
-    if (url.searchParams.get('c') !== state.conversationId) {
-      url.searchParams.set('c', state.conversationId)
+    if (state.conversationId) {
+      if (url.searchParams.get('c') !== state.conversationId) {
+        url.searchParams.set('c', state.conversationId)
+        window.history.replaceState({}, '', url.toString())
+      }
+    } else if (url.searchParams.has('c')) {
+      url.searchParams.delete('c')
       window.history.replaceState({}, '', url.toString())
     }
   }, [state.conversationId])

--- a/xerus_web/components/chat/useSlashCommands.ts
+++ b/xerus_web/components/chat/useSlashCommands.ts
@@ -1,0 +1,79 @@
+import { useMemo, useCallback } from 'react'
+import {
+  Sparkles, MessageSquare, PenTool,
+  Trash2, Plus, ArrowRightLeft,
+  FileText, BookOpen,
+} from 'lucide-react'
+import type { SlashCommand } from './SlashCommandPicker'
+import type { Agent } from './types'
+
+interface UseSlashCommandsOptions {
+  currentAgent?: Agent | null
+  onSendMessage: (message: string) => void
+  onClearConversation?: () => void
+  onNewConversation?: () => void
+  onSwitchAgent?: (agent: Agent) => void
+}
+
+export function useSlashCommands({
+  currentAgent,
+  onSendMessage,
+  onClearConversation,
+  onNewConversation,
+}: UseSlashCommandsOptions) {
+  const commands = useMemo<SlashCommand[]>(() => {
+    const cmds: SlashCommand[] = []
+
+    const agentSkills = (currentAgent as Record<string, unknown> | null | undefined)?.skills as string[] | undefined
+    if (agentSkills && agentSkills.length > 0) {
+      for (const skill of agentSkills.slice(0, 8)) {
+        cmds.push({
+          name: skill,
+          description: `Run ${skill} skill`,
+          category: 'skill',
+          icon: Sparkles,
+        })
+      }
+    } else {
+      cmds.push(
+        { name: 'review', description: 'Review code changes', category: 'skill', icon: Sparkles },
+        { name: 'plan', description: 'Create a plan', category: 'skill', icon: PenTool },
+        { name: 'brainstorm', description: 'Explore ideas', category: 'skill', icon: MessageSquare },
+      )
+    }
+
+    cmds.push(
+      { name: 'clear', description: 'Clear conversation', category: 'action', icon: Trash2 },
+      { name: 'new', description: 'Start new conversation', category: 'action', icon: Plus },
+      { name: 'switch', description: 'Switch active agent', category: 'action', icon: ArrowRightLeft },
+    )
+
+    cmds.push(
+      { name: 'file', description: 'Attach a workspace file', category: 'context', icon: FileText },
+      { name: 'context', description: 'Search knowledge base', category: 'context', icon: BookOpen },
+    )
+
+    return cmds
+  }, [currentAgent])
+
+  const executeCommand = useCallback(
+    (cmd: SlashCommand, args: string) => {
+      switch (cmd.category) {
+        case 'skill':
+          onSendMessage(`/${cmd.name} ${args}`.trim())
+          break
+        case 'action':
+          if (cmd.name === 'clear' && onClearConversation) onClearConversation()
+          else if (cmd.name === 'new' && onNewConversation) onNewConversation()
+          else onSendMessage(`/${cmd.name} ${args}`.trim())
+          break
+        case 'context':
+          onSendMessage(`/${cmd.name} ${args}`.trim())
+          break
+      }
+    },
+    [onSendMessage, onClearConversation, onNewConversation],
+  )
+
+  return { commands, executeCommand }
+}

--- a/xerus_web/components/chat/useTaskDock.ts
+++ b/xerus_web/components/chat/useTaskDock.ts
@@ -1,0 +1,80 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+export interface DockTask {
+  id: string
+  name: string
+  description: string
+  status: 'running' | 'completed' | 'failed'
+  startTime: number
+  endTime?: number
+  durationMs?: number
+  error?: string
+}
+
+interface UseTaskDockReturn {
+  tasks: DockTask[]
+  isVisible: boolean
+  activeCount: number
+  completedCount: number
+  isCollapsed: boolean
+  collapse: () => void
+  expand: () => void
+  clearTasks: () => void
+  addTask: (id: string, name: string, description: string) => void
+  completeTask: (id: string, success: boolean, durationMs?: number, error?: string) => void
+}
+
+const AUTO_HIDE_DELAY = 3000
+
+export function useTaskDock(): UseTaskDockReturn {
+  const [tasks, setTasks] = useState<DockTask[]>([])
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [isVisible, setIsVisible] = useState(false)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const activeCount = tasks.filter((t) => t.status === 'running').length
+  const completedCount = tasks.filter((t) => t.status !== 'running').length
+
+  useEffect(() => {
+    if (tasks.length > 0 && activeCount > 0) {
+      setIsVisible(true)
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    }
+    if (tasks.length > 0 && activeCount === 0) {
+      hideTimerRef.current = setTimeout(() => setIsVisible(false), AUTO_HIDE_DELAY)
+    }
+    return () => { if (hideTimerRef.current) clearTimeout(hideTimerRef.current) }
+  }, [tasks, activeCount])
+
+  const addTask = useCallback((id: string, name: string, description: string) => {
+    setTasks((prev) => {
+      if (prev.some((t) => t.id === id)) return prev
+      return [...prev, { id, name, description, status: 'running', startTime: Date.now() }]
+    })
+    setIsVisible(true)
+  }, [])
+
+  const completeTask = useCallback((id: string, success: boolean, durationMs?: number, error?: string) => {
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === id
+          ? { ...t, status: success ? 'completed' as const : 'failed' as const, endTime: Date.now(), durationMs, error }
+          : t,
+      ),
+    )
+  }, [])
+
+  const clearTasks = useCallback(() => {
+    setTasks([])
+    setIsVisible(false)
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+  }, [])
+
+  const collapse = useCallback(() => setIsCollapsed(true), [])
+  const expand = useCallback(() => setIsCollapsed(false), [])
+
+  return {
+    tasks, isVisible, activeCount, completedCount,
+    isCollapsed, collapse, expand, clearTasks, addTask, completeTask,
+  }
+}

--- a/xerus_web/components/common/PageHeader.tsx
+++ b/xerus_web/components/common/PageHeader.tsx
@@ -30,6 +30,7 @@ interface PageHeaderProps {
     onClearCategories?: () => void
     className?: string
     children?: React.ReactNode
+    actions?: React.ReactNode
 }
 
 export function PageHeader({
@@ -43,7 +44,8 @@ export function PageHeader({
     onToggleCategory,
     onClearCategories,
     className,
-    children
+    children,
+    actions,
 }: PageHeaderProps) {
     const [inputValue, setInputValue] = useState(searchQuery || '')
     const [debouncedValue] = useDebounce(inputValue, 500)
@@ -97,17 +99,22 @@ export function PageHeader({
             {/* Search & Filter Row */}
             {(onSearchChange || categories) && (
                 <div className="flex flex-col items-start gap-6 w-full mt-2">
-                    {onSearchChange && (
-                        <div className="relative w-full max-w-md">
-                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary" />
-                            <input
-                                type="text"
-                                placeholder={searchPlaceholder}
-                                value={inputValue}
-                                onChange={(e) => setInputValue(e.target.value)}
-                                data-testid="agent-search"
-                                className="w-full pl-10 pr-4 py-3 bg-card/60 border border-surface-active rounded-full text-sm focus:outline-none focus:border-primary transition-colors placeholder:text-text/40"
-                            />
+                    {(onSearchChange || actions) && (
+                        <div className="flex items-center gap-3 w-full">
+                            {onSearchChange && (
+                                <div className="relative w-full max-w-md">
+                                    <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary" />
+                                    <input
+                                        type="text"
+                                        placeholder={searchPlaceholder}
+                                        value={inputValue}
+                                        onChange={(e) => setInputValue(e.target.value)}
+                                        data-testid="agent-search"
+                                        className="w-full pl-10 pr-4 py-3 bg-card/60 border border-surface-active rounded-full text-sm focus:outline-none focus:border-primary transition-colors placeholder:text-text/40"
+                                    />
+                                </div>
+                            )}
+                            {actions}
                         </div>
                     )}
 

--- a/xerus_web/components/workspace/AgentDetailView.tsx
+++ b/xerus_web/components/workspace/AgentDetailView.tsx
@@ -77,7 +77,7 @@ export function AgentDetailView({ agentId, onBack }: AgentDetailViewProps) {
 
   const { data: agentConnections = [] } = useSWR(
     isAuthReady && agent?.slug && !isMarketplace ? ['agent-connections', agent.slug] : null,
-    () => (agent?.slug ? listAgentConnections(agent.slug) : Promise.resolve([]))
+    () => (agent?.slug ? listAgentConnections(agent.slug).catch(() => []) : Promise.resolve([]))
   )
 
   const schedules = schedulesData ?? []
@@ -119,7 +119,7 @@ export function AgentDetailView({ agentId, onBack }: AgentDetailViewProps) {
   const isPublic = agent?.agentType === 'public'
   const canPublishAgent = isOwner && isPrivate
   const canUnpublishAgent = isOwner && isPublic && agent?.userId !== null
-  const canDeleteAgent = isOwner && isPrivate
+  const canDeleteAgent = isOwner && isPrivate && agent?.agentType !== 'system'
 
   if (isLoadingAgent) return <XerusLoader />
 

--- a/xerus_web/components/workspace/AgentsPanel.tsx
+++ b/xerus_web/components/workspace/AgentsPanel.tsx
@@ -12,9 +12,10 @@ import { UploadPanel } from '@/components/upload/UploadPanel'
 interface AgentsPanelProps {
   onSelect: (agent: Assistant) => void
   onCountChange?: (count: number) => void
+  viewToggle?: React.ReactNode
 }
 
-export function AgentsPanel({ onSelect, onCountChange }: AgentsPanelProps) {
+export function AgentsPanel({ onSelect, onCountChange, viewToggle }: AgentsPanelProps) {
   const router = useRouter()
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
@@ -90,6 +91,7 @@ export function AgentsPanel({ onSelect, onCountChange }: AgentsPanelProps) {
           selectedCategories={selectedCategories}
           onToggleCategory={handleToggleCategory}
           onClearCategories={handleClearCategories}
+          actions={viewToggle}
         />
 
         {/* My Agents */}

--- a/xerus_web/components/workspace/BrowseView.tsx
+++ b/xerus_web/components/workspace/BrowseView.tsx
@@ -37,6 +37,7 @@ interface BrowseViewProps {
   onNewFolder: (name: string) => Promise<void>
   previews?: Record<string, string>
   showPropertyBar?: boolean
+  sectionToggle?: React.ReactNode
 }
 
 export function BrowseView({
@@ -59,6 +60,7 @@ export function BrowseView({
   onNewFolder,
   previews,
   showPropertyBar = false,
+  sectionToggle,
 }: BrowseViewProps) {
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null)
@@ -152,27 +154,31 @@ export function BrowseView({
             onChange={(e) => onSearchChange(e.target.value)}
             className="flex-1 min-w-0 pl-3 pr-2 py-2.5 bg-transparent text-sm text-text focus:outline-none placeholder:text-text-muted"
           />
-          {/* View toggle — right side of search */}
-          <div className="mr-1 flex items-center gap-1 bg-card rounded-full p-0.5 border border-surface-active shrink-0">
-            <button
-              onClick={() => onViewModeChange('grid')}
-              className={cn(
-                'p-1.5 rounded-full transition-colors',
-                viewMode === 'grid' ? 'bg-surface-active text-text' : 'text-text-muted hover:text-text',
-              )}
-            >
-              <LayoutGrid className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={() => onViewModeChange('list')}
-              className={cn(
-                'p-1.5 rounded-full transition-colors',
-                viewMode === 'list' ? 'bg-surface-active text-text' : 'text-text-muted hover:text-text',
-              )}
-            >
-              <List className="w-3.5 h-3.5" />
-            </button>
-          </div>
+          {/* View toggle — cards↔files when coming from a UI section, grid↔list otherwise */}
+          {sectionToggle ? (
+            <div className="mr-1 shrink-0">{sectionToggle}</div>
+          ) : (
+            <div className="mr-1 flex items-center gap-1 bg-card rounded-full p-0.5 border border-surface-active shrink-0">
+              <button
+                onClick={() => onViewModeChange('grid')}
+                className={cn(
+                  'p-1.5 rounded-full transition-colors',
+                  viewMode === 'grid' ? 'bg-surface-active text-text' : 'text-text-muted hover:text-text',
+                )}
+              >
+                <LayoutGrid className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={() => onViewModeChange('list')}
+                className={cn(
+                  'p-1.5 rounded-full transition-colors',
+                  viewMode === 'list' ? 'bg-surface-active text-text' : 'text-text-muted hover:text-text',
+                )}
+              >
+                <List className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Filter segmented control — matching tools/id page */}

--- a/xerus_web/components/workspace/ConnectorsPanel.tsx
+++ b/xerus_web/components/workspace/ConnectorsPanel.tsx
@@ -8,7 +8,7 @@ import { ToolCard } from '@/components/tools/ToolCard'
 import { useConnectedTools, useToolCatalog } from '@/hooks/useTools'
 import { useToolAuth } from '@/hooks/useToolAuth'
 
-export function ConnectorsPanel() {
+export function ConnectorsPanel({ viewToggle }: { viewToggle?: React.ReactNode }) {
   const router = useRouter()
 
   const {
@@ -102,6 +102,7 @@ export function ConnectorsPanel() {
           selectedCategories={selectedCategories}
           onToggleCategory={toggleCategory}
           onClearCategories={clearCategories}
+          actions={viewToggle}
         />
 
         {/* Active Connections */}

--- a/xerus_web/components/workspace/SkillsPanel.tsx
+++ b/xerus_web/components/workspace/SkillsPanel.tsx
@@ -12,9 +12,10 @@ import { UploadPanel } from '@/components/upload/UploadPanel'
 interface SkillsPanelProps {
   onSelect: (skill: Skill) => void
   onCountChange?: (count: number) => void
+  viewToggle?: React.ReactNode
 }
 
-export function SkillsPanel({ onSelect, onCountChange }: SkillsPanelProps) {
+export function SkillsPanel({ onSelect, onCountChange, viewToggle }: SkillsPanelProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
   const [uploadPanelOpen, setUploadPanelOpen] = useState(false)
@@ -94,6 +95,7 @@ export function SkillsPanel({ onSelect, onCountChange }: SkillsPanelProps) {
           selectedCategories={selectedCategories}
           onToggleCategory={handleToggleCategory}
           onClearCategories={handleClearCategories}
+          actions={viewToggle}
         />
 
         {/* My Skills (user-created + installed) */}

--- a/xerus_web/hooks/__tests__/useExecutionStream.typecheck.ts
+++ b/xerus_web/hooks/__tests__/useExecutionStream.typecheck.ts
@@ -39,9 +39,9 @@ import { STREAM_EVENT_TYPES } from '../useExecutionStream';
 // These will cause TypeScript errors if types are wrong.
 // ---------------------------------------------------------------------------
 
-// Verify all 22 event types are present
+// Verify all 28 event types are present
 const _eventTypes: readonly string[] = STREAM_EVENT_TYPES;
-const _expectedLength: 22 = STREAM_EVENT_TYPES.length;
+const _expectedLength: 28 = STREAM_EVENT_TYPES.length;
 
 // Verify StreamEventType is a union of all event type strings
 const _metaType: StreamEventType = 'meta';
@@ -66,6 +66,12 @@ const _previewType: StreamEventType = 'preview';
 const _creditWarningType: StreamEventType = 'credit_warning';
 const _insufficientCreditsType: StreamEventType = 'insufficient_credits';
 const _providerUnavailableType: StreamEventType = 'provider_unavailable';
+const _toolProgressType: StreamEventType = 'tool_progress';
+const _toolUseSummaryType: StreamEventType = 'tool_use_summary';
+const _taskStartedType: StreamEventType = 'task_started';
+const _taskProgressType: StreamEventType = 'task_progress';
+const _taskUpdatedType: StreamEventType = 'task_updated';
+const _taskNotificationType: StreamEventType = 'task_notification';
 
 // Verify StreamEvent shape
 const _sampleEvent: StreamEvent = {
@@ -222,7 +228,7 @@ function assert(condition: boolean, message: string): void {
 // ---------------------------------------------------------------------------
 
 export function testStreamEventTypesArray(): void {
-  assert(STREAM_EVENT_TYPES.length === 22, 'Should have exactly 22 event types');
+  assert(STREAM_EVENT_TYPES.length === 28, 'Should have exactly 28 event types');
   assert(STREAM_EVENT_TYPES.includes('meta'), 'Should include meta');
   assert(STREAM_EVENT_TYPES.includes('progress'), 'Should include progress');
   assert(STREAM_EVENT_TYPES.includes('token'), 'Should include token');

--- a/xerus_web/hooks/useExecutionStream.ts
+++ b/xerus_web/hooks/useExecutionStream.ts
@@ -19,6 +19,8 @@ export type {
   SubagentStartEventContent, SubagentStopEventContent, DelegationEventContent, NotificationEventContent,
   PreviewEventContent,
   CreditWarningEventContent, InsufficientCreditsEventContent, ProviderUnavailableEventContent,
+  ToolProgressEventContent, ToolUseSummaryEventContent,
+  TaskStartedEventContent, TaskProgressEventContent, TaskUpdatedEventContent, TaskNotificationEventContent,
   StreamEventContentMap, StreamEvent, StreamEventCallback,
   UseExecutionStreamOptions, UseExecutionStreamReturn, ConnectionState,
 } from './useExecutionStream.types';
@@ -57,6 +59,12 @@ export interface UseExecutionStreamCallbacks {
   onCreditWarning?: (event: StreamEvent<'credit_warning'>) => void;
   onInsufficientCredits?: (event: StreamEvent<'insufficient_credits'>) => void;
   onProviderUnavailable?: (event: StreamEvent<'provider_unavailable'>) => void;
+  onToolProgress?: (event: StreamEvent<'tool_progress'>) => void;
+  onToolUseSummary?: (event: StreamEvent<'tool_use_summary'>) => void;
+  onTaskStarted?: (event: StreamEvent<'task_started'>) => void;
+  onTaskProgress?: (event: StreamEvent<'task_progress'>) => void;
+  onTaskUpdated?: (event: StreamEvent<'task_updated'>) => void;
+  onTaskNotification?: (event: StreamEvent<'task_notification'>) => void;
   onError?: (error: Error) => void;
   onConnectionChange?: (connected: boolean) => void;
 }
@@ -159,6 +167,24 @@ export function useExecutionStream(
         break;
       case 'provider_unavailable':
         cbs.onProviderUnavailable?.(event as StreamEvent<'provider_unavailable'>);
+        break;
+      case 'tool_progress':
+        cbs.onToolProgress?.(event as StreamEvent<'tool_progress'>);
+        break;
+      case 'tool_use_summary':
+        cbs.onToolUseSummary?.(event as StreamEvent<'tool_use_summary'>);
+        break;
+      case 'task_started':
+        cbs.onTaskStarted?.(event as StreamEvent<'task_started'>);
+        break;
+      case 'task_progress':
+        cbs.onTaskProgress?.(event as StreamEvent<'task_progress'>);
+        break;
+      case 'task_updated':
+        cbs.onTaskUpdated?.(event as StreamEvent<'task_updated'>);
+        break;
+      case 'task_notification':
+        cbs.onTaskNotification?.(event as StreamEvent<'task_notification'>);
         break;
     }
   }, []);

--- a/xerus_web/hooks/useExecutionStream.types.ts
+++ b/xerus_web/hooks/useExecutionStream.types.ts
@@ -36,6 +36,14 @@ export const STREAM_EVENT_TYPES = [
   'credit_warning',
   'insufficient_credits',
   'provider_unavailable',
+  // Tool lifecycle events (from SDK runner)
+  'tool_progress',
+  'tool_use_summary',
+  // Task/subagent lifecycle events (from SDK runner)
+  'task_started',
+  'task_progress',
+  'task_updated',
+  'task_notification',
 ] as const;
 
 export type StreamEventType = (typeof STREAM_EVENT_TYPES)[number];
@@ -206,6 +214,47 @@ export interface ProviderUnavailableEventContent {
   message: string;
 }
 
+export interface ToolProgressEventContent {
+  toolName: string;
+  toolUseId: string;
+  progress: { status: string; message: string };
+}
+
+export interface ToolUseSummaryEventContent {
+  toolName: string;
+  toolUseId: string;
+  durationMs: number;
+  input?: unknown;
+  output?: unknown;
+  status: 'success' | 'error';
+}
+
+export interface TaskStartedEventContent {
+  taskId: string;
+  taskName: string;
+  taskDescription?: string;
+  parentToolUseId?: string;
+}
+
+export interface TaskProgressEventContent {
+  taskId: string;
+  progress: number;
+  message?: string;
+}
+
+export interface TaskUpdatedEventContent {
+  taskId: string;
+  status: 'running' | 'completed' | 'failed';
+  result?: unknown;
+}
+
+export interface TaskNotificationEventContent {
+  taskId: string;
+  taskSubject: string;
+  status: string;
+  result?: unknown;
+}
+
 // Map from event type string to its content type
 export interface StreamEventContentMap {
   meta: MetaEventContent;
@@ -230,6 +279,12 @@ export interface StreamEventContentMap {
   credit_warning: CreditWarningEventContent;
   insufficient_credits: InsufficientCreditsEventContent;
   provider_unavailable: ProviderUnavailableEventContent;
+  tool_progress: ToolProgressEventContent;
+  tool_use_summary: ToolUseSummaryEventContent;
+  task_started: TaskStartedEventContent;
+  task_progress: TaskProgressEventContent;
+  task_updated: TaskUpdatedEventContent;
+  task_notification: TaskNotificationEventContent;
 }
 
 export interface StreamEvent<T extends StreamEventType = StreamEventType> {
@@ -272,6 +327,12 @@ export interface UseExecutionStreamOptions {
   onDelegation?: StreamEventCallback<'delegation'>;
   onNotification?: StreamEventCallback<'notification'>;
   onPreview?: StreamEventCallback<'preview'>;
+  onToolProgress?: StreamEventCallback<'tool_progress'>;
+  onToolUseSummary?: StreamEventCallback<'tool_use_summary'>;
+  onTaskStarted?: StreamEventCallback<'task_started'>;
+  onTaskProgress?: StreamEventCallback<'task_progress'>;
+  onTaskUpdated?: StreamEventCallback<'task_updated'>;
+  onTaskNotification?: StreamEventCallback<'task_notification'>;
   onError?: (error: Error) => void;
   onConnectionChange?: (connected: boolean) => void;
 }

--- a/xerus_web/hooks/useKBSearch.ts
+++ b/xerus_web/hooks/useKBSearch.ts
@@ -1,0 +1,43 @@
+import { useState, useCallback, useRef } from 'react'
+import type { KBEntry } from '@/components/chat/UnifiedMentionPicker'
+
+interface UseKBSearchReturn {
+  entries: KBEntry[]
+  loading: boolean
+  search: (query: string) => void
+}
+
+export function useKBSearch(): UseKBSearchReturn {
+  const [entries, setEntries] = useState<KBEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const search = useCallback((query: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!query) {
+      setEntries([])
+      return
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true)
+      try {
+        const res = await fetch(
+          `/api/knowledge-base/search?q=${encodeURIComponent(query)}`,
+        )
+        if (res.ok) {
+          const data = await res.json()
+          setEntries(data.entries ?? [])
+        } else {
+          setEntries([])
+        }
+      } catch {
+        setEntries([])
+      } finally {
+        setLoading(false)
+      }
+    }, 300)
+  }, [])
+
+  return { entries, loading, search }
+}

--- a/xerus_web/hooks/useWorkspaceFiles.ts
+++ b/xerus_web/hooks/useWorkspaceFiles.ts
@@ -1,0 +1,46 @@
+import { useState, useCallback, useRef } from 'react'
+import type { FileItem } from '@/components/chat/UnifiedMentionPicker'
+
+interface UseWorkspaceFilesReturn {
+  files: FileItem[]
+  loading: boolean
+  search: (query: string) => void
+}
+
+export function useWorkspaceFiles(conversationId?: string): UseWorkspaceFilesReturn {
+  const [files, setFiles] = useState<FileItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const search = useCallback(
+    (query: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (!query || !conversationId) {
+        setFiles([])
+        return
+      }
+
+      debounceRef.current = setTimeout(async () => {
+        setLoading(true)
+        try {
+          const res = await fetch(
+            `/api/conversations/${conversationId}/workspace/files?q=${encodeURIComponent(query)}`,
+          )
+          if (res.ok) {
+            const data = await res.json()
+            setFiles(data.files ?? [])
+          } else {
+            setFiles([])
+          }
+        } catch {
+          setFiles([])
+        } finally {
+          setLoading(false)
+        }
+      }, 300)
+    },
+    [conversationId],
+  )
+
+  return { files, loading, search }
+}

--- a/xerus_web/lib/api/client.ts
+++ b/xerus_web/lib/api/client.ts
@@ -80,7 +80,8 @@ export const apiCall = async (
   options: ApiCallOptions = {},
   showErrorToast: boolean = true
 ): Promise<Response> => {
-  const [baseUrl, apiHeaders] = await Promise.all([getApiBaseUrl(), getApiHeaders()]);
+  const isFormData = options.body instanceof FormData;
+  const [baseUrl, apiHeaders] = await Promise.all([getApiBaseUrl(), getApiHeaders(isFormData)]);
   const url = `${baseUrl}${endpoint}`;
   const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...restOptions } = options;
 

--- a/xerus_web/lib/api/types.ts
+++ b/xerus_web/lib/api/types.ts
@@ -74,7 +74,7 @@ export interface Assistant {
   isDefault: boolean;
   createdAt: string;
   model?: string;
-  agentType?: 'public' | 'private' | 'shared';
+  agentType?: 'public' | 'private' | 'shared' | 'system';
   workflowConfig?: WorkflowConfig;
   teams?: AgentTeamMembership[];
   userId?: string | null;  // Owner's user_id (null for system templates)

--- a/xerus_web/utils/agentLabels.ts
+++ b/xerus_web/utils/agentLabels.ts
@@ -3,7 +3,7 @@
  * Maps agent_type to user-friendly labels and badges
  */
 
-export type AgentType = 'public' | 'private' | 'shared';
+export type AgentType = 'public' | 'private' | 'shared' | 'system';
 
 /**
  * Get user-friendly label for agent visibility type
@@ -113,6 +113,9 @@ export function canEditAgent(
   // Must have a logged-in user
   if (!currentUserId) return false;
 
+  // System agents are editable by any logged-in user (model, schedules, behaviour)
+  if (agentType === 'system') return true;
+
   // System templates (public agents with no owner) are read-only
   if (agentType === 'public' && !agentUserId) return false;
 
@@ -131,4 +134,12 @@ export function isSystemTemplate(
   agentType?: AgentType
 ): boolean {
   return agentType === 'public' && !agentUserId;
+}
+
+export function isSystemAgent(agentType?: AgentType): boolean {
+  return agentType === 'system';
+}
+
+export function canDeleteAgent(agentType?: AgentType): boolean {
+  return agentType !== 'system';
 }


### PR DESCRIPTION
## Summary

- **Smart tool display**: Replit-style tool call cards with verb-based labels ("Read file", "Ran command"), inline duration, diff previews for Edit/MultiEdit, workspace path stripping
- **6 new SSE event types**: tool_progress, tool_use_summary, task_started, task_progress, task_updated, task_notification — wired end-to-end (backend types → stream hooks → frontend handlers → reducer state)
- **Stream error handling**: Backend filters error JSON from text deltas, tracks executionFailed in PipelineContext, sends proper error events instead of silent sendDone
- **Bug fixes**: New Chat reusing old session (URL param not cleared), Invalid Date on new conversations, wrong avatar for system agents, TaskDock redesign, grouped tool actions

## Changes across 12 commits

### Backend (execution domain)
- Add 6 event types to STREAM_EVENT_TYPES (22 → 28)
- Filter `api_error` JSON from text deltas in cli-stream-router
- Add `executionFailed`/`executionError` to PipelineContext
- execution.service calls sendError when pipeline fails

### Frontend (chat + hooks)
- New `format-tool-display.ts` — verb labels, target extraction, path stripping
- Rewritten `ToolCallCard.tsx` — Replit layout, DiffBlock, progress messages
- `streaming-turn-reducer.ts` — updateToolProgress, enrichToolSummary
- `useChatExecution.ts` — 6 new event handlers, error JSON filtering in onToken/onDone
- `useChatState.ts` — URL ?c= param clearing, Invalid Date fallback
- `MessageBubble.tsx` — system agent avatar resolution, streaming badge fix
- Updated type definitions and typecheck tests for 28 event types

## Test plan
- [ ] Send a message in chat — tool calls show verb labels, targets, durations
- [ ] Edit/MultiEdit tools show inline red/green diff preview
- [ ] "New Chat" creates fresh conversation (no stale URL param)
- [ ] New conversations show valid timestamps (no "Invalid Date")
- [ ] Stream errors surface as toast notifications, not silent failures
- [ ] System agents (xerus-master, xerus-cto) show correct SVG avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)