### PR TITLE
fix: resolve FK constraint violations breaking inbox, tasks, and agent visibility

### DIFF
--- a/xerus_backend/src/domains/company/company-workspace-db.service.ts
+++ b/xerus_backend/src/domains/company/company-workspace-db.service.ts
@@ -45,8 +45,12 @@ export interface ChannelMessageRow {
     posted_at: string;
 }
 
+export interface ChannelWithCount extends ChannelRow {
+    agent_count: number;
+}
+
 export interface DomainWithChannels extends DomainRow {
-    channels: ChannelRow[];
+    channels: ChannelWithCount[];
 }
 
 // -----------------------------------------------------------------------------
@@ -65,13 +69,14 @@ export async function listDomainsWithChannels(
     const domains = await executeWorkspaceJsonQuery<DomainRow>(provider, sandboxId, domainsSql);
 
     const channelsSql = `
-        SELECT slug, name, domain_slug, lead_agent_slug, description, goals, config, created_at, updated_at
-        FROM channels
-        ORDER BY name
+        SELECT c.slug, c.name, c.domain_slug, c.lead_agent_slug, c.description, c.goals, c.config, c.created_at, c.updated_at,
+               (SELECT COUNT(*) FROM channel_members cm WHERE cm.channel_slug = c.slug) AS agent_count
+        FROM channels c
+        ORDER BY c.name
     `;
-    const channels = await executeWorkspaceJsonQuery<ChannelRow>(provider, sandboxId, channelsSql);
+    const channels = await executeWorkspaceJsonQuery<ChannelWithCount>(provider, sandboxId, channelsSql);
 
-    const channelsByDomain = new Map<string, ChannelRow[]>();
+    const channelsByDomain = new Map<string, ChannelWithCount[]>();
     for (const ch of channels) {
         const list = channelsByDomain.get(ch.domain_slug) ?? [];
         list.push(ch);
@@ -202,10 +207,13 @@ export async function createChannelMessage(
     // so the API can reconstruct the full response shape for the frontend.
     const enrichedMetadata = { ...metadata, sender_type: senderType };
     const metadataJson = JSON.stringify(enrichedMetadata);
+    const escaped = escapeSQL(senderSlug);
     const sql = `
         BEGIN;
+        INSERT OR IGNORE INTO agents (slug, name, adapter_type, role, autonomy_level, status)
+        VALUES ('${escaped}', '${escaped}', 'claudecode', 'user', 'manual', 'idle');
         INSERT INTO channel_messages (channel_slug, agent_slug, content, message_type, metadata, posted_at)
-        VALUES ('${escapeSQL(channelSlug)}', '${escapeSQL(senderSlug)}', '${escapeSQL(content)}', '${escapeSQL(messageType)}', '${escapeSQL(metadataJson)}', '${now}');
+        VALUES ('${escapeSQL(channelSlug)}', '${escaped}', '${escapeSQL(content)}', '${escapeSQL(messageType)}', '${escapeSQL(metadataJson)}', '${now}');
         SELECT id, channel_slug, agent_slug, content, message_type, metadata, posted_at
         FROM channel_messages WHERE id = last_insert_rowid();
         COMMIT;
@@ -270,10 +278,12 @@ export async function createSystemEvent(
     const enrichedMetadata = { sender_type: 'system', ...metadata };
     const metadataJson = JSON.stringify(enrichedMetadata);
     const sql = `
+        INSERT OR IGNORE INTO agents (slug, name, adapter_type, role, autonomy_level, status)
+        VALUES ('system', 'System', 'claudecode', 'system', 'manual', 'idle');
         INSERT INTO channel_messages (channel_slug, agent_slug, content, message_type, metadata, posted_at)
         VALUES ('${escapeSQL(channelSlug)}', 'system', '${escapeSQL(content)}', 'system', '${escapeSQL(metadataJson)}', '${now}')
     `;
-    await executeWorkspaceJsonQuery(provider, sandboxId, sql);
+    await executeWorkspaceQuery(provider, sandboxId, sql);
 }
 
 // -----------------------------------------------------------------------------

--- a/xerus_backend/src/domains/company/company.routes.ts
+++ b/xerus_backend/src/domains/company/company.routes.ts
@@ -102,7 +102,7 @@ router.get('/domains', auth, async (req: AuthenticatedRequest, res: Response, ne
                     slug: c.slug.startsWith(prefix) ? c.slug.slice(prefix.length) : c.slug,
                     name: c.name,
                     description: c.description,
-                    agent_count: 0,
+                    agent_count: c.agent_count ?? 0,
                 })),
             };
         });
@@ -396,10 +396,10 @@ router.get('/channels/:channelId/agents', auth, async (req: AuthenticatedRequest
 
         const channelSlug = sanitizeSlug(req.params.channelId);
 
-        // Get all agent slugs for this user from Neon agent_registry
+        // Get all agent slugs for this user from Neon agent_registry (including system agents)
         const registryResult = await query<{ id: string; slug: string }>(
             `SELECT id::text, slug FROM agent_registry
-             WHERE user_id = $1 AND agent_type IN ('private', 'public')
+             WHERE (user_id = $1 OR agent_type = 'system') AND agent_type != 'internal'
              ORDER BY created_at DESC LIMIT 100`,
             [userId],
         );

--- a/xerus_backend/src/domains/company/system-agent-assignment.service.ts
+++ b/xerus_backend/src/domains/company/system-agent-assignment.service.ts
@@ -2,7 +2,6 @@ import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona
 import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
 import {
     executeWorkspaceQuery as execWsMutate,
-    executeWorkspaceJsonQuery,
     escapeSQL,
 } from '../conversations/workspace-db.helpers';
 import { logger } from '../../utils/logger';
@@ -13,15 +12,6 @@ export const SYSTEM_AGENT_SLUGS = ['xerus-master', 'xerus-cto'];
 
 const AGENT_CONFIG_PATHS = ['agents', '.claude/agents'];
 
-async function agentExistsInWorkspaceDb(
-    provider: DaytonaProvider,
-    sandboxId: string,
-    slug: string,
-): Promise<boolean> {
-    const sql = `SELECT slug FROM agents WHERE slug = '${escapeSQL(slug)}' LIMIT 1`;
-    const rows = await executeWorkspaceJsonQuery<{ slug: string }>(provider, sandboxId, sql);
-    return rows.length > 0;
-}
 
 async function readAgentConfig(
     provider: DaytonaProvider,
@@ -49,22 +39,15 @@ export async function addSystemAgentsToChannel(
     channelSlug: string,
 ): Promise<void> {
     for (const slug of SYSTEM_AGENT_SLUGS) {
-        const exists = await agentExistsInWorkspaceDb(provider, sandboxId, slug).catch((err: unknown) => {
-            log.warn('Failed to verify system agent exists in workspace DB', {
+        // Ensure agent row exists in workspace.db (prevents FK violations on channel_members)
+        const ensureSql = `INSERT OR IGNORE INTO agents (slug, name, adapter_type, role, autonomy_level, status) VALUES ('${escapeSQL(slug)}', '${escapeSQL(slug)}', 'claudecode', 'specialist', 'supervised', 'idle')`;
+        await execWsMutate(provider, sandboxId, ensureSql).catch((err: unknown) => {
+            log.warn('Failed to ensure system agent exists in workspace DB', {
                 agent_slug: slug,
                 channel_slug: channelSlug,
                 error: err instanceof Error ? err.message : String(err),
             });
-            return false;
         });
-
-        if (!exists) {
-            log.warn('System agent not found in workspace DB; skipping channel assignment', {
-                agent_slug: slug,
-                channel_slug: channelSlug,
-            });
-            continue;
-        }
 
         const sql = `INSERT OR IGNORE INTO channel_members (channel_slug, agent_slug, role) VALUES ('${escapeSQL(channelSlug)}', '${escapeSQL(slug)}', 'member')`;
         await execWsMutate(provider, sandboxId, sql).catch((err: unknown) => {

--- a/xerus_backend/src/domains/company/task-workspace-db.service.ts
+++ b/xerus_backend/src/domains/company/task-workspace-db.service.ts
@@ -128,8 +128,13 @@ export async function createTask(
     const labelsValue = labels && labels.length > 0 ? `'${escapeSQL(JSON.stringify(labels))}'` : 'NULL';
     const dueDateValue = dueDate ? `'${escapeSQL(dueDate)}'` : 'NULL';
 
+    const ensureAgent = assignedAgent
+        ? `INSERT OR IGNORE INTO agents (slug, name, adapter_type, role, autonomy_level, status)
+           VALUES ('${escapeSQL(assignedAgent)}', '${escapeSQL(assignedAgent)}', 'claudecode', 'specialist', 'supervised', 'idle');`
+        : '';
     const sql = `
         BEGIN;
+        ${ensureAgent}
         INSERT INTO tasks (id, project_slug, title, description, status, priority, assigned_agent, labels, due_date, created_at, updated_at)
         VALUES (
             '${escapeSQL(id)}',

--- a/xerus_backend/src/domains/inbox/inbox-item.repository.ts
+++ b/xerus_backend/src/domains/inbox/inbox-item.repository.ts
@@ -148,9 +148,12 @@ export class DatabaseInboxItemRepository implements InboxItemRepository {
         const senderSlug = input.agent_slug;
         const metadataStr = JSON.stringify(input.metadata);
 
+        const agentEsc = escapeSQL(agentSlug);
         const sql = `
+            INSERT OR IGNORE INTO agents (slug, name, adapter_type, role, autonomy_level, status)
+            VALUES ('${agentEsc}', '${agentEsc}', 'claudecode', 'specialist', 'supervised', 'idle');
             INSERT INTO inbox_items (agent_slug, sender_slug, message_type, subject, content, metadata, priority, status, received_at)
-            VALUES ('${escapeSQL(agentSlug)}', '${escapeSQL(senderSlug)}', '${escapeSQL(messageType)}', '${escapeSQL(input.title)}', '${escapeSQL(input.content)}', '${escapeSQL(metadataStr)}', '${escapeSQL(workspacePriority)}', '${escapeSQL(workspaceStatus)}', '${now}');
+            VALUES ('${agentEsc}', '${escapeSQL(senderSlug)}', '${escapeSQL(messageType)}', '${escapeSQL(input.title)}', '${escapeSQL(input.content)}', '${escapeSQL(metadataStr)}', '${escapeSQL(workspacePriority)}', '${escapeSQL(workspaceStatus)}', '${now}');
             SELECT id, agent_slug, sender_slug, message_type, subject, content,
                    metadata, priority, status, received_at, read_at, actioned_at
             FROM inbox_items WHERE id = last_insert_rowid();

--- a/xerus_backend/src/domains/inbox/messaging/message-bridge.repository.ts
+++ b/xerus_backend/src/domains/inbox/messaging/message-bridge.repository.ts
@@ -46,10 +46,13 @@ export async function insertChannelMessage(
     const enrichedMetadata = { ...input.metadata, sender_type: input.sender_type };
     const metadataJson = JSON.stringify(enrichedMetadata);
 
+    const senderEsc = escapeSQL(input.sender_slug);
     const sql = `
         BEGIN;
+        INSERT OR IGNORE INTO agents (slug, name, adapter_type, role, autonomy_level, status)
+        VALUES ('${senderEsc}', '${senderEsc}', 'claudecode', 'specialist', 'supervised', 'idle');
         INSERT INTO channel_messages (channel_slug, agent_slug, content, message_type, metadata, posted_at)
-        VALUES ('${escapeSQL(input.channel_slug)}', '${escapeSQL(input.sender_slug)}', '${escapeSQL(input.content)}', '${escapeSQL(input.message_type)}', '${escapeSQL(metadataJson)}', '${now}');
+        VALUES ('${escapeSQL(input.channel_slug)}', '${senderEsc}', '${escapeSQL(input.content)}', '${escapeSQL(input.message_type)}', '${escapeSQL(metadataJson)}', '${now}');
         SELECT id, channel_slug, agent_slug, content, message_type, metadata, posted_at
         FROM channel_messages WHERE id = last_insert_rowid();
         COMMIT;


### PR DESCRIPTION
## Summary

Production-critical fix for /inbox being completely broken. Root cause: `workspace.db` enforces `PRAGMA foreign_keys=ON`, but 8 different INSERT code paths reference `agents(slug)` without ensuring the agent row exists first — causing silent FK constraint failures across the platform.

- **Human messages fail** — Firebase UID used as `agent_slug` has no row in agents table
- **System events always fail** — `'system'` agent_slug was never created
- **Channels show 0 agents** — `agent_count` hardcoded to `0` in domains listing
- **CTO/Xerus invisible** — channel agents query excluded `agent_type='system'`
- **System agents not auto-added** — skipped silently if not in agents table
- **Task creation fails** — `assigned_agent` FK violation when agent not in workspace.db
- **Message bridge FK violation** — agent outbound messages fail on sender FK
- **Inbox items FK violation** — inbox creation fails on `agent_slug` FK

## Changes (6 files)

| File | Fix |
|------|-----|
| `company-workspace-db.service.ts` | FK guard on human messages + system events; real `agent_count` via COUNT subquery |
| `company.routes.ts` | Include system agents in channel agents query; use `c.agent_count` not `0` |
| `system-agent-assignment.service.ts` | `INSERT OR IGNORE INTO agents` before `channel_members` insert |
| `task-workspace-db.service.ts` | FK guard on `assigned_agent` |
| `message-bridge.repository.ts` | FK guard on sender slug |
| `inbox-item.repository.ts` | FK guard on `agent_slug` |

## Root cause

All workspace.db queries go through `buildSqliteCommand()` which prepends `PRAGMA foreign_keys=ON`. This means every INSERT into `channel_messages`, `channel_members`, `tasks`, and `inbox_items` must have valid FK references to `agents(slug)`. Multiple code paths assumed agents already existed or silently swallowed the FK errors.

## Test plan

- [ ] Send a message in /inbox as a human user — verify no "Your message can't be sent" error
- [ ] Create a task from /inbox channel — verify task appears in kanban board
- [ ] Create a new channel — verify xerus-master and xerus-cto are auto-added as members
- [ ] View channel in /inbox — verify CTO and Xerus appear in the agent panel
- [ ] Check sidebar — verify channels show correct agent count (not 0)
- [ ] Run `npm run typecheck` — passes clean
- [ ] Run `npm run build` in xerus_web — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)