### PR TITLE
fix(backend): remove module-level throw for XERUS_SANDBOX_USER_ID

### DIFF
--- a/xerus_backend/src/domains/platform-tools/internal-mcp/middleware.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/middleware.ts
@@ -14,10 +14,8 @@ if (!INTERNAL_API_TOKEN) {
 
 // Expected sandbox owner — set per-sandbox to bind token to a specific user.
 // When set, the middleware validates that client-supplied user_id matches.
+// Optional on the backend server (serves all users); required inside sandboxes.
 const SANDBOX_USER_ID = process.env.XERUS_SANDBOX_USER_ID;
-if (process.env.NODE_ENV === 'production' && !SANDBOX_USER_ID) {
-    throw new Error('XERUS_SANDBOX_USER_ID must be set in production');
-}
 
 // Strict format: Firebase UIDs are typically 28+ alphanumeric chars
 const USER_ID_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;


### PR DESCRIPTION
## Summary
- **Root cause**: `middleware.ts:19` throws `XERUS_SANDBOX_USER_ID must be set in production` at module load time, crashing the backend server on startup
- **Why it's wrong**: This env var is per-sandbox (set inside Daytona containers), not on the main API server which serves all users
- **Fix**: Remove the fail-fast throw — the runtime check at line 65 already validates user_id match when the var IS set (graceful no-op when unset)
- **Impact**: Server was down since May 20 with 60 PM2 restart attempts

## Test plan
- [ ] Backend starts without `XERUS_SANDBOX_USER_ID` set (the API server case)
- [ ] Backend still validates user_id against `XERUS_SANDBOX_USER_ID` when the var IS set (sandbox case)
- [ ] `https://api.xerus.ai/health` returns 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)