### PR TITLE
fix(onboarding): resume after payment and detect checkout completion

### DIFF
--- a/xerus_web/components/onboarding/OnboardingChat.tsx
+++ b/xerus_web/components/onboarding/OnboardingChat.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAuth } from '@/utils/AuthContext'
 import { useOnboardingStream } from '@/hooks/useOnboardingStream'
-import { createCheckout, syncSubscription } from '@/lib/api/billing'
+import { createCheckout, syncSubscription, getSubscription } from '@/lib/api/billing'
 import { saveApiKey, triggerCliLogin } from '@/lib/api/user'
 import { PLANS, type PlanType } from '@/lib/plans'
 import { BlobBackground } from './BlobBackground'
@@ -49,12 +49,31 @@ export function OnboardingChat() {
   const stream = useOnboardingStream({ userId, onWorkspaceCreated: markWorkspaceReady })
   const templateMessages = useMemo(() => buildTemplateMessages(firstName), [firstName])
 
-  // Logo phase: hold for 2.5s then transition to template
+  // On mount: check if subscription is already active (e.g. user paid, then reloaded)
+  // If so, skip directly to 'activate' phase — don't re-show plan selection.
+  const resumeCheckedRef = useRef(false)
+  useEffect(() => {
+    if (resumeCheckedRef.current || !userId) return
+    resumeCheckedRef.current = true
+    getSubscription()
+      .then((sub) => {
+        if (sub.subscription_status === 'active') {
+          setPhase('activate')
+        }
+      })
+      .catch(() => {
+        // Not subscribed or network error — proceed with normal flow
+      })
+  }, [userId, setPhase])
+
+  // Logo phase: hold for 2.5s then transition to template (only if still on logo)
   useEffect(() => {
     if (phase !== 'logo') return
-    const timer = setTimeout(() => setPhase('template'), 2500)
+    const timer = setTimeout(() => {
+      setPhaseRaw((current) => current === 'logo' ? 'template' : current)
+    }, 2500)
     return () => clearTimeout(timer)
-  }, [phase, setPhase])
+  }, [phase])
 
   // Sequential template messages
   useEffect(() => {

--- a/xerus_web/components/onboarding/cards/PolarCheckoutOverlay.tsx
+++ b/xerus_web/components/onboarding/cards/PolarCheckoutOverlay.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
 import { ExternalLink, Loader2 } from 'lucide-react'
+import { syncSubscription } from '@/lib/api/billing'
 
 interface PolarCheckoutOverlayProps {
   checkoutUrl: string
@@ -12,7 +13,8 @@ interface PolarCheckoutOverlayProps {
 
 /**
  * Opens Polar checkout in a new tab and shows a waiting overlay.
- * Detects completion via the syncSubscription poll in OnboardingChat.
+ * Polls syncSubscription every 3s to detect when payment completes,
+ * AND detects tab close as a fallback trigger.
  */
 export function PolarCheckoutOverlay({
   checkoutUrl,
@@ -22,6 +24,7 @@ export function PolarCheckoutOverlay({
   const shouldReduceMotion = useReducedMotion()
   const tabRef = useRef<Window | null>(null)
   const openedRef = useRef(false)
+  const resolvedRef = useRef(false)
 
   useEffect(() => {
     if (openedRef.current) return
@@ -29,13 +32,34 @@ export function PolarCheckoutOverlay({
     tabRef.current = window.open(checkoutUrl, '_blank')
   }, [checkoutUrl])
 
-  // Poll to detect if user closed the tab without completing
+  // Poll syncSubscription to detect payment completion while tab is open
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      if (resolvedRef.current) return
+      try {
+        const result = await syncSubscription()
+        if (result.synced && result.subscription_status === 'active') {
+          resolvedRef.current = true
+          clearInterval(interval)
+          onSuccess()
+        }
+      } catch {
+        // Network error during poll — ignore and retry next tick
+      }
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [onSuccess])
+
+  // Fallback: detect tab close (user may close before webhook arrives)
   useEffect(() => {
     const interval = setInterval(() => {
+      if (resolvedRef.current) { clearInterval(interval); return }
       if (tabRef.current && tabRef.current.closed) {
         clearInterval(interval)
-        // Tab closed — trigger success check (the sync poll in OnboardingChat handles the rest)
-        onSuccess()
+        if (!resolvedRef.current) {
+          resolvedRef.current = true
+          onSuccess()
+        }
       }
     }, 1500)
     return () => clearInterval(interval)


### PR DESCRIPTION
﻿## Summary
- **PolarCheckoutOverlay**: Now polls syncSubscription every 3s while the checkout tab is open, detecting payment as soon as the webhook fires - not just when the user closes the tab
- **OnboardingChat**: Checks subscription status on mount. If already active (user paid then reloaded), skips directly to the activate phase instead of re-showing plan selection

## Root Cause
Server was down for 5 days (XERUS_SANDBOX_USER_ID crash). The frontend had no logic to resume from an already-active subscription on reload, and the checkout overlay had no way to detect completion while the tab was still open.

## Test plan
- [ ] Fresh user: complete checkout - overlay detects completion within 3s (no need to close tab)
- [ ] Reload during waiting for checkout - page checks subscription, finds active, skips to activate phase
- [ ] User who already paid and reloads /onboarding - immediately sees activate workforce card
- [ ] User without subscription - normal flow (logo - template - plan - checkout - activate - setup)
- [ ] Cancel checkout - overlay dismisses, can retry

Generated with [Claude Code](https://claude.com/claude-code)
