### PR TITLE
fix: correct FK reference in migration 094

### DIFF
--- a/xerus_backend/src/database/migrations/094_digest_configs.sql
+++ b/xerus_backend/src/database/migrations/094_digest_configs.sql
@@ -2,7 +2,7 @@
 -- Stores per-user digest schedule preferences (standup + report cron schedules)
 
 CREATE TABLE IF NOT EXISTS digest_configs (
-    user_id         TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    user_id         TEXT PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
     enabled         BOOLEAN NOT NULL DEFAULT true,
     standup_cron    TEXT NOT NULL DEFAULT '0 9 * * 1-5',
     report_cron     TEXT NOT NULL DEFAULT '0 17 * * 1-5',


### PR DESCRIPTION
## Summary
- Fix `digest_configs.user_id` FK to reference `users(user_id)` instead of `users(id)`
- The table was already created correctly on NeonDB (ran with correct FK), this just fixes the migration file for future deployments

## Test plan
- [x] Migration already executed successfully on NeonDB with correct FK

🤖 Generated with [Claude Code](https://claude.com/claude-code)