### PR TITLE
fix: resolve 6 onboarding issues breaking new user flow

### DIFF
--- a/xerus_backend/src/domains/conversations/workspace-db.service.ts
+++ b/xerus_backend/src/domains/conversations/workspace-db.service.ts
@@ -134,21 +134,23 @@ export async function getConversationWithMessages(
 
     const messages: ConversationMessageRow[] = [];
     for (const row of rows) {
-        // User message
-        messages.push({
-            id: row.id * 2,
-            conversation_id: row.conversation_id,
-            session_id: row.session_id,
-            role: 'user',
-            content: row.user_message,
-            execution_id: row.session_id,
-            created_at: row.created_at,
-            input_tokens: null,
-            output_tokens: null,
-            credits_used: null,
-            thinking: null,
-            message_metadata: null,
-        });
+        // User message (skip empty — e.g. system-seeded welcome messages)
+        if (row.user_message) {
+            messages.push({
+                id: row.id * 2,
+                conversation_id: row.conversation_id,
+                session_id: row.session_id,
+                role: 'user',
+                content: row.user_message,
+                execution_id: row.session_id,
+                created_at: row.created_at,
+                input_tokens: null,
+                output_tokens: null,
+                credits_used: null,
+                thinking: null,
+                message_metadata: null,
+            });
+        }
         // Assistant response (if present)
         if (row.agent_response) {
             // Parse message_metadata from JSON string to object for frontend consumption

--- a/xerus_backend/src/domains/execution/sdk/sdk.config.ts
+++ b/xerus_backend/src/domains/execution/sdk/sdk.config.ts
@@ -92,6 +92,9 @@ export function buildSDKEnvironment(
         // ANTHROPIC_AUTH_TOKEN is no longer recognized by the CLI.
         ANTHROPIC_API_KEY: apiKey,
         XERUS_WORKSPACE_ROOT: process.env.XERUS_WORKSPACE_ROOT || '/home/daytona',
+        // Platform MCP server needs these to reach the backend from inside the sandbox
+        XERUS_BACKEND_URL: process.env.API_BASE_URL || 'https://api.xerus.ai/api/v1',
+        XERUS_BACKEND_TOKEN: process.env.XERUS_INTERNAL_API_TOKEN || '',
     };
 
     // Inject user's BYOK keys if available.

--- a/xerus_backend/src/domains/onboarding/onboarding.routes.ts
+++ b/xerus_backend/src/domains/onboarding/onboarding.routes.ts
@@ -10,8 +10,9 @@ import { authenticateFirebaseToken } from '../../middleware/auth';
 import { UnauthorizedError, BadRequestError } from '../../utils/errors';
 import { query } from '../../database/connection';
 import type { SandboxService } from '../sandbox-infra';
-import { createDomain, createChannel, createChannelMessage } from '../company/company-workspace-db.service';
-import { createConversation } from '../conversations/workspace-db.service';
+import { createDomain, createChannel } from '../company/company-workspace-db.service';
+import { createConversation, writeChatExecution, incrementConversationMessageCount } from '../conversations/workspace-db.service';
+import { addSystemAgentsToChannel } from '../company/system-agent-assignment.service';
 import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
 import { sanitizeSlug } from '../../shared/slugify';
 import { logger } from '../../utils/logger';
@@ -150,7 +151,12 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
         const channelDir = `${domainDir}/channels/general`;
         await provider.executeCommand(sandboxId, `mkdir -p ${shellEscapePath(channelDir)}`);
 
-        // Conversation + welcome message are best-effort: the agents table may
+        // 4. Assign system agents (xerus-master, xerus-cto) to the channel
+        // Mirrors company.routes.ts project creation flow. Uses INSERT OR IGNORE
+        // on agents table, so it's safe even before syncAgentsToWorkspace runs.
+        await addSystemAgentsToChannel(provider, sandboxId, generalSlug);
+
+        // 5. Conversation + welcome message are best-effort: the agents table may
         // not be populated yet (syncAgentsToWorkspace runs after workspace setup),
         // so the FK on conversations.agent_slug can fail. Domain + channel are the
         // critical deliverables — don't let a conversation FK failure block onboarding.
@@ -162,11 +168,12 @@ router.post('/handoff', auth, async (req: AuthenticatedRequest, res: Response, n
             );
             conversationId = conversation.id;
 
-            await createChannelMessage(
-                provider, sandboxId,
-                generalSlug, 'agent', 'xerus-master',
-                welcomeMessage, 'post', {},
+            // Write welcome as a chat_execution so it appears on /chat (not /inbox)
+            await writeChatExecution(
+                provider, sandboxId, conversationId,
+                null, '', welcomeMessage, 0, null, null,
             );
+            await incrementConversationMessageCount(provider, sandboxId, conversationId);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             if (msg.includes('FOREIGN KEY') || msg.includes('constraint')) {

--- a/xerus_backend/src/domains/skills/errors.ts
+++ b/xerus_backend/src/domains/skills/errors.ts
@@ -70,3 +70,10 @@ export class SkillSecretInvalidValueError extends SkillError {
         super(`Invalid value for "${key}": ${reason}`, 422, 'SKILL_SECRET_INVALID_VALUE');
     }
 }
+
+export class SandboxNotReadyError extends Error {
+    constructor(userId: string) {
+        super(`No running sandbox for user ${userId}`);
+        this.name = 'SandboxNotReadyError';
+    }
+}

--- a/xerus_backend/src/domains/skills/repository.ts
+++ b/xerus_backend/src/domains/skills/repository.ts
@@ -16,6 +16,7 @@ import type {
     UpdateSkillDTO,
 } from './types';
 import type { SkillWorkspaceService } from './workspace.service';
+import { SandboxNotReadyError } from './errors';
 import { slugify } from '../../shared/slugify';
 import { generatePuzzleConfig } from './skill-avatar';
 
@@ -72,7 +73,13 @@ export class SkillRepository {
 
     async listInstalled(userId: string): Promise<Skill[]> {
         const ws = this.requireWorkspace();
-        const entries = await ws.batchReadInstalled(userId);
+        let entries;
+        try {
+            entries = await ws.batchReadInstalled(userId);
+        } catch (err) {
+            if (err instanceof SandboxNotReadyError) return [];
+            throw err;
+        }
         const skills: Skill[] = [];
         for (const entry of entries) {
             if (entry.type === 'config') {
@@ -336,7 +343,13 @@ export class SkillRepository {
 
     private async listMarketplaceSkillsAll(userId: string): Promise<Skill[]> {
         const ws = this.requireWorkspace();
-        const entries = await ws.batchReadMarketplace(userId);
+        let entries;
+        try {
+            entries = await ws.batchReadMarketplace(userId);
+        } catch (err) {
+            if (err instanceof SandboxNotReadyError) return [];
+            throw err;
+        }
         const skills: Skill[] = [];
         for (const entry of entries) {
             if (entry.type === 'xerushub') {

--- a/xerus_backend/src/domains/skills/workspace.service.ts
+++ b/xerus_backend/src/domains/skills/workspace.service.ts
@@ -8,6 +8,7 @@ import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona
 import type { SandboxFileSystem } from '../sandbox-infra/workspace/workspace.manager';
 import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
 import { SkillInstallScope, SKILL_SLUG_PATTERN } from './types';
+import { SandboxNotReadyError } from './errors';
 import { shellEscapePath } from '../../utils/shell-safety';
 import { logger } from '../../utils/logger';
 
@@ -308,7 +309,7 @@ export class SkillWorkspaceService {
     private async resolveProvider(userId: string): Promise<{ provider: DaytonaProvider; sandboxId: string }> {
         const status = await this.sandboxService.getSandboxStatus(userId);
         if (status.status !== 'running' || !status.sandboxId) {
-            throw new Error(`No running sandbox for user ${userId}`);
+            throw new SandboxNotReadyError(userId);
         }
         const provider = this.sandboxService.getProvider() as DaytonaProvider;
         return { provider, sandboxId: status.sandboxId };

--- a/xerus_web/hooks/useOnboardingStream.ts
+++ b/xerus_web/hooks/useOnboardingStream.ts
@@ -10,8 +10,8 @@ interface UseOnboardingStreamOptions {
 
 interface OnboardingHandoffResult {
   workspace: { id: string; slug: string; name: string }
-  domain: { id: string; slug: string; name: string }
-  channel: { id: string; slug: string; name: string }
+  domain: { slug: string; name: string }
+  channel: { slug: string; name: string }
 }
 
 interface UseOnboardingStreamReturn {
@@ -91,7 +91,7 @@ export function useOnboardingStream({ userId, onWorkspaceCreated }: UseOnboardin
 
       const data = await res.json()
       const result = data.data
-      if (!result?.workspace?.id || !result?.domain?.id || !result?.channel?.id) {
+      if (!result?.workspace?.id || !result?.domain?.slug || !result?.channel?.slug) {
         throw new Error('Invalid handoff response: missing workspace, domain, or channel')
       }
       return result as OnboardingHandoffResult


### PR DESCRIPTION
## Summary
- **Issue 1 (P0)**: Frontend handoff validation checked `domain.id`/`channel.id` but backend returns slug-based PKs — fixed to check `.slug`
- **Issue 2 (P1)**: `GET /skills` threw 500 when sandbox not provisioned — added `SandboxNotReadyError`, read paths return `[]` gracefully
- **Issue 3 (P1)**: Welcome message written to `channel_messages` (shows on `/inbox`) — now writes to `chat_executions` (shows on `/chat`)
- **Issue 4 (P1)**: Onboarding skipped `addSystemAgentsToChannel()` — added it after channel creation, matching `company.routes.ts` pattern
- **Issue 5 (P0)**: `buildSDKEnvironment()` never exported `XERUS_BACKEND_URL`/`XERUS_BACKEND_TOKEN` — all 38 platform MCP tools were broken inside sandbox

## Root Cause
The onboarding handoff route was a thinner copy of the normal project creation flow (`POST /company/domains`) missing several critical steps: agent-channel assignment, correct response shape, welcome message in the right table, and SDK environment vars for MCP tools.

## Files Changed
| File | Change |
|------|--------|
| `xerus_web/hooks/useOnboardingStream.ts` | Check `.slug` not `.id` for domain/channel |
| `xerus_backend/.../skills/errors.ts` | Added `SandboxNotReadyError` |
| `xerus_backend/.../skills/workspace.service.ts` | Throw typed error |
| `xerus_backend/.../skills/repository.ts` | Catch `SandboxNotReadyError` in read paths |
| `xerus_backend/.../onboarding/onboarding.routes.ts` | Add agent assignment, fix welcome msg target |
| `xerus_backend/.../conversations/workspace-db.service.ts` | Skip empty user_message rows |
| `xerus_backend/.../execution/sdk/sdk.config.ts` | Add backend URL + token to SDK env |

## Test plan
- [ ] Fresh signup at app.xerus.ai — handoff should succeed (no 500)
- [ ] Skills page loads without error (empty list if sandbox still provisioning)
- [ ] Welcome message appears on `/chat` page, not `/inbox` Activity
- [ ] `#General` channel shows xerus-master as assigned agent
- [ ] Agent can use `mcp__platform__search_tools` to find Pipedream apps
- [ ] Verify typecheck passes: `npm run typecheck` (both backend + frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8vM55mzZ43m7KMeaS4rRD