### PR TITLE
fix: resolve 7 onboarding E2E bugs

### DIFF
--- a/xerus_backend/src/domains/company/system-agent-assignment.service.ts
+++ b/xerus_backend/src/domains/company/system-agent-assignment.service.ts
@@ -2,6 +2,7 @@ import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona
 import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
 import {
     executeWorkspaceQuery as execWsMutate,
+    executeWorkspaceJsonQuery,
     escapeSQL,
 } from '../conversations/workspace-db.helpers';
 import { logger } from '../../utils/logger';
@@ -11,6 +12,8 @@ const log = logger('SystemAgentAssignment');
 export const SYSTEM_AGENT_SLUGS = ['xerus-master', 'xerus-cto'];
 
 const AGENT_CONFIG_PATHS = ['agents', '.claude/agents'];
+
+const AGENT_INDEX_PATH = `${SANDBOX_CONFIG.workspacePath}/agents/index.json`;
 
 
 async function readAgentConfig(
@@ -82,4 +85,173 @@ export async function addSystemAgentsToChannel(
             });
         }
     }
+}
+
+interface ChannelMetaRow {
+    slug: string;
+    domain_slug: string;
+}
+
+interface AgentIndexRecord {
+    name?: string;
+    domain?: string;
+    primary_channel?: string;
+    channels?: string[];
+    agent_type?: string;
+    [key: string]: unknown;
+}
+
+interface AgentIndexDocument {
+    agents: Record<string, AgentIndexRecord>;
+    updated_at: string;
+}
+
+async function resolveChannelDomain(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    channelSlug: string,
+): Promise<string | null> {
+    const rows = await executeWorkspaceJsonQuery<ChannelMetaRow>(
+        provider,
+        sandboxId,
+        `SELECT slug, domain_slug FROM channels WHERE slug = '${escapeSQL(channelSlug)}'`,
+    );
+    return rows.length > 0 ? rows[0].domain_slug : null;
+}
+
+async function readAgentIndexDocument(
+    provider: DaytonaProvider,
+    sandboxId: string,
+): Promise<AgentIndexDocument> {
+    try {
+        const raw = await provider.readFile(sandboxId, AGENT_INDEX_PATH);
+        const parsed = raw ? (JSON.parse(raw) as Partial<AgentIndexDocument>) : null;
+        if (parsed && parsed.agents && typeof parsed.agents === 'object') {
+            return { agents: parsed.agents, updated_at: parsed.updated_at || new Date().toISOString() };
+        }
+    } catch {
+        // index.json missing or unreadable — start a fresh document
+    }
+    return { agents: {}, updated_at: new Date().toISOString() };
+}
+
+async function writeAgentIndexDocument(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    doc: AgentIndexDocument,
+): Promise<void> {
+    doc.updated_at = new Date().toISOString();
+    await provider.writeFile(sandboxId, AGENT_INDEX_PATH, JSON.stringify(doc, null, 2));
+}
+
+/**
+ * Ensure an agent has an entry in agents/index.json. The agents list endpoint
+ * iterates index.json, so an agent created via MCP that is missing from the
+ * index is invisible on the agents page even though its row and config exist.
+ * Idempotent: preserves any existing channel data on the entry.
+ */
+export async function registerAgentInIndex(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    agentSlug: string,
+    agentName: string,
+): Promise<void> {
+    const doc = await readAgentIndexDocument(provider, sandboxId);
+    const current = doc.agents[agentSlug];
+    doc.agents[agentSlug] = {
+        ...current,
+        name: current?.name || agentName,
+        agent_type: current?.agent_type || 'private',
+    };
+    await writeAgentIndexDocument(provider, sandboxId, doc);
+}
+
+async function updateAgentIndexChannels(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    agentSlug: string,
+    agentName: string,
+    domainSlug: string | null,
+    primaryChannel: string,
+    channels: string[],
+): Promise<void> {
+    const doc = await readAgentIndexDocument(provider, sandboxId);
+    const current = doc.agents[agentSlug] || { name: agentName, agent_type: 'private' };
+    doc.agents[agentSlug] = {
+        ...current,
+        name: current.name || agentName,
+        agent_type: current.agent_type || 'private',
+        ...(domainSlug ? { domain: domainSlug } : {}),
+        primary_channel: primaryChannel,
+        channels,
+    };
+    await writeAgentIndexDocument(provider, sandboxId, doc);
+}
+
+/**
+ * Assign a single agent to a channel at the MCP/sandbox layer, keeping every
+ * source of truth in sync:
+ *   1. agents/{slug}/config.json  -> channels[] + primary_channel + domain
+ *   2. agents/index.json          -> channels[] + primary_channel (agents list reads this)
+ *   3. channel_members table      -> membership row (lead for first/primary channel)
+ *   4. channels.lead_agent_slug   -> set when the channel has no lead yet
+ *
+ * The frontend's GET /channels/:slug/agents reads config.json channels[], and
+ * the agents list reads index.json, so updating only channel_members leaves the
+ * agent invisible. This helper is the canonical fix for that drift.
+ *
+ * Fail-fast: throws if the agent's config.json cannot be found, since a created
+ * agent must always have one.
+ */
+export async function assignAgentToChannel(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    agentSlug: string,
+    channelSlug: string,
+): Promise<void> {
+    const found = await readAgentConfig(provider, sandboxId, agentSlug);
+    if (!found) {
+        throw new Error(`Agent config.json not found for ${agentSlug}; cannot assign to channel ${channelSlug}`);
+    }
+
+    const { path: configPath, config } = found;
+    const agentName = typeof config.name === 'string' ? config.name : agentSlug;
+    const channels = Array.isArray(config.channels) ? (config.channels as string[]) : [];
+
+    if (!channels.includes(channelSlug)) {
+        channels.push(channelSlug);
+    }
+
+    const existingPrimary = typeof config.primary_channel === 'string' ? config.primary_channel : '';
+    const primaryChannel = existingPrimary || channelSlug;
+
+    const domainSlug = await resolveChannelDomain(provider, sandboxId, channelSlug);
+
+    config.channels = channels;
+    config.primary_channel = primaryChannel;
+    if (domainSlug && (!config.domain || config.domain === '')) {
+        config.domain = domainSlug;
+    }
+    config.updated_at = new Date().toISOString();
+    await provider.writeFile(sandboxId, configPath, JSON.stringify(config, null, 2));
+
+    await updateAgentIndexChannels(
+        provider,
+        sandboxId,
+        agentSlug,
+        agentName,
+        domainSlug,
+        primaryChannel,
+        channels,
+    );
+
+    const role = primaryChannel === channelSlug ? 'lead' : 'member';
+    const memberSql = `INSERT OR IGNORE INTO channel_members (channel_slug, agent_slug, role) VALUES ('${escapeSQL(channelSlug)}', '${escapeSQL(agentSlug)}', '${role}')`;
+    await execWsMutate(provider, sandboxId, memberSql);
+
+    // Claim the channel lead only when it has none yet (the IS NULL guard never
+    // demotes an existing lead), so message routing (findChannelLead) can always
+    // reach an agent in the channel.
+    const setLeadSql = `UPDATE channels SET lead_agent_slug = '${escapeSQL(agentSlug)}', updated_at = '${new Date().toISOString()}' WHERE slug = '${escapeSQL(channelSlug)}' AND lead_agent_slug IS NULL`;
+    await execWsMutate(provider, sandboxId, setLeadSql);
 }

--- a/xerus_backend/src/domains/company/task-workspace-db.service.ts
+++ b/xerus_backend/src/domains/company/task-workspace-db.service.ts
@@ -305,11 +305,15 @@ export async function listChannelDeliverables(
 // Beads JSONL → tasks sync
 // -----------------------------------------------------------------------------
 
+// Mirrors the JSONL records written by the `bd` CLI (beads). Field names match
+// the on-disk format exactly: `status` (not `state`), `issue_type`, `assignee`,
+// and `description`. The CLI also emits `body` in some versions, so both are read.
 interface BeadsIssue {
     id: string;
     title?: string;
+    description?: string;
     body?: string;
-    state?: string;
+    status?: string;
     assignee?: string;
     priority?: number;
     labels?: string[];
@@ -327,7 +331,9 @@ const BEADS_STATUS_MAP: Record<string, string> = {
     cancelled: 'cancelled',
 };
 
+// Beads priorities are 0-4 (0 = critical, 4 = backlog). See CLI_REFERENCE.md.
 const PRIORITY_MAP: Record<number, string> = {
+    0: 'critical',
     1: 'critical',
     2: 'high',
     3: 'medium',
@@ -369,8 +375,11 @@ export async function syncBeadsToTasks(
                 const issue = JSON.parse(line) as BeadsIssue;
                 if (!issue.id || !issue.title) { skipped++; continue; }
 
-                const status = BEADS_STATUS_MAP[issue.state ?? 'open'] ?? 'open';
-                const priority = PRIORITY_MAP[issue.priority ?? 3] ?? 'medium';
+                const status = BEADS_STATUS_MAP[issue.status ?? 'open'] ?? 'open';
+                const priority = issue.priority !== undefined
+                    ? (PRIORITY_MAP[issue.priority] ?? 'medium')
+                    : 'medium';
+                const description = issue.description ?? issue.body ?? null;
                 const now = new Date().toISOString();
                 const issueProject = issue.project ?? projectSlug;
 
@@ -380,7 +389,7 @@ export async function syncBeadsToTasks(
                         '${escapeSQL(issue.id)}',
                         '${escapeSQL(issueProject)}',
                         '${escapeSQL(issue.title)}',
-                        ${issue.body ? `'${escapeSQL(issue.body)}'` : 'NULL'},
+                        ${description !== null ? `'${escapeSQL(description)}'` : 'NULL'},
                         '${status}',
                         '${priority}',
                         ${issue.assignee ? `'${escapeSQL(issue.assignee)}'` : 'NULL'},

--- a/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
+++ b/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
@@ -60,6 +60,10 @@ function resolveModelAlias(model: string): 'sonnet' | 'opus' | 'haiku' | 'inheri
     return 'inherit';
 }
 
+// Agent configs live under either `agents/{slug}` or `.claude/agents/{slug}`.
+// Try `agents/` first, fall back to `.claude/agents/`.
+const AGENT_CONFIG_DIRS = ['agents', '.claude/agents'] as const;
+
 export class AgentConfigLoader {
     private readonly workspacePath: string;
     private readonly emitter: StdoutEmitter;
@@ -69,11 +73,22 @@ export class AgentConfigLoader {
         this.emitter = emitter;
     }
 
-    loadConfig(agentSlug: string): AgentConfig | null {
-        const agentDir = path.join(this.workspacePath, 'agents', agentSlug);
-        const configPath = path.join(agentDir, 'config.json');
+    // Resolve an agent's directory by checking `agents/{slug}` then `.claude/agents/{slug}`.
+    // Returns the first directory containing config.json, or null if none exists.
+    private resolveAgentDir(agentSlug: string): string | null {
+        for (const dir of AGENT_CONFIG_DIRS) {
+            const agentDir = path.join(this.workspacePath, dir, agentSlug);
+            if (fs.existsSync(path.join(agentDir, 'config.json'))) {
+                return agentDir;
+            }
+        }
+        return null;
+    }
 
-        if (!fs.existsSync(configPath)) return null;
+    loadConfig(agentSlug: string): AgentConfig | null {
+        const agentDir = this.resolveAgentDir(agentSlug);
+        if (!agentDir) return null;
+        const configPath = path.join(agentDir, 'config.json');
 
         try {
             const raw = fs.readFileSync(configPath, 'utf-8');
@@ -193,9 +208,9 @@ export class AgentConfigLoader {
     }
 
     buildChannelScopedDefinitions(agentSlug: string): Record<string, SubagentDefinition> {
-        const agentDir = path.join(this.workspacePath, 'agents', agentSlug);
+        const agentDir = this.resolveAgentDir(agentSlug);
+        if (!agentDir) return {};
         const configPath = path.join(agentDir, 'config.json');
-        if (!fs.existsSync(configPath)) return {};
 
         let agentChannels: string[];
         try {
@@ -218,8 +233,9 @@ export class AgentConfigLoader {
         for (const slug of allSlugs) {
             if (slug === agentSlug) continue;
 
-            const otherConfigPath = path.join(this.workspacePath, 'agents', slug, 'config.json');
-            if (!fs.existsSync(otherConfigPath)) continue;
+            const otherDir = this.resolveAgentDir(slug);
+            if (!otherDir) continue;
+            const otherConfigPath = path.join(otherDir, 'config.json');
 
             try {
                 const raw = fs.readFileSync(otherConfigPath, 'utf-8');
@@ -242,9 +258,9 @@ export class AgentConfigLoader {
     }
 
     private readAgentAsDefinition(slug: string): SubagentDefinition | null {
-        const agentDir = path.join(this.workspacePath, 'agents', slug);
+        const agentDir = this.resolveAgentDir(slug);
+        if (!agentDir) return null;
         const configPath = path.join(agentDir, 'config.json');
-        if (!fs.existsSync(configPath)) return null;
 
         try {
             const raw = fs.readFileSync(configPath, 'utf-8');
@@ -269,27 +285,33 @@ export class AgentConfigLoader {
     }
 
     private listAgentSlugs(): string[] {
-        const agentsDir = path.join(this.workspacePath, 'agents');
-        if (!fs.existsSync(agentsDir)) return [];
+        const slugs = new Set<string>();
 
-        const indexPath = path.join(agentsDir, 'index.json');
+        for (const dir of AGENT_CONFIG_DIRS) {
+            const agentsDir = path.join(this.workspacePath, dir);
+            if (!fs.existsSync(agentsDir)) continue;
 
-        if (fs.existsSync(indexPath)) {
-            try {
-                const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as Record<string, unknown>;
-                const agents = (index.agents || {}) as Record<string, unknown>;
-                return Object.keys(agents);
-            } catch (error) {
-                throw new AgentConfigLoadError(
-                    'agents/index.json',
-                    error instanceof Error ? error.message : String(error),
-                );
+            const indexPath = path.join(agentsDir, 'index.json');
+            if (fs.existsSync(indexPath)) {
+                try {
+                    const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as Record<string, unknown>;
+                    const agents = (index.agents || {}) as Record<string, unknown>;
+                    for (const slug of Object.keys(agents)) slugs.add(slug);
+                    continue;
+                } catch (error) {
+                    throw new AgentConfigLoadError(
+                        `${dir}/index.json`,
+                        error instanceof Error ? error.message : String(error),
+                    );
+                }
+            }
+
+            for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+                if (entry.isDirectory()) slugs.add(entry.name);
             }
         }
 
-        return fs.readdirSync(agentsDir, { withFileTypes: true })
-            .filter(d => d.isDirectory())
-            .map(d => d.name);
+        return [...slugs];
     }
 
     private resolveAgentCwd(agentSlug: string, config: Record<string, unknown>): string {
@@ -316,6 +338,7 @@ export class AgentConfigLoader {
             }
         }
 
-        return path.join(this.workspacePath, 'agents', agentSlug);
+        return this.resolveAgentDir(agentSlug)
+            ?? path.join(this.workspacePath, 'agents', agentSlug);
     }
 }

--- a/xerus_backend/src/domains/execution/runner/mcp-server.ts
+++ b/xerus_backend/src/domains/execution/runner/mcp-server.ts
@@ -372,6 +372,8 @@ export const TOOLS = [
                 tool_slugs: { type: 'array', items: { type: 'string' }, description: 'Pipedream app slugs to assign' },
                 skill_slugs: { type: 'array', items: { type: 'string' }, description: 'Skill slugs to install on the agent' },
                 kb_collection_ids: { type: 'array', items: { type: 'string' }, description: 'KB collections to assign' },
+                channels: { type: 'array', items: { type: 'string' }, description: 'Channel slugs to add the agent to so it is visible in those channels. Without this the agent is created but appears in no channel.' },
+                primary_channel: { type: 'string', description: 'Slug of the agent primary channel (made the channel lead if the channel has none). Defaults to the first entry of channels.' },
             },
             required: ['name', 'description', 'system_prompt'],
         },

--- a/xerus_backend/src/domains/execution/session-record.ts
+++ b/xerus_backend/src/domains/execution/session-record.ts
@@ -177,14 +177,21 @@ export async function updateSessionRecord(
     }
 
     // Post-execution syncs: bridge agent-created data to workspace.db for frontend visibility.
-    // Non-critical — fire and forget so session completion isn't blocked.
     if (ctx.sandboxId) {
         const provider = deps.sandboxService.getDaytonaProvider();
 
-        syncBeadsToTasks(provider, ctx.sandboxId).catch(err =>
-            log.warn('Post-execution beads sync failed', { error: (err as Error).message }),
-        );
+        // Beads tasks must be synced before the pipeline emits `done`, because the
+        // frontend task board fetches /tasks immediately on completion. A fire-and-forget
+        // sync races that fetch and leaves the board empty until the next reload.
+        // Failure is non-critical — log and continue so session completion isn't blocked.
+        try {
+            const result = await syncBeadsToTasks(provider, ctx.sandboxId);
+            log.debug('Post-execution beads sync complete', { synced: result.synced, skipped: result.skipped });
+        } catch (err) {
+            log.warn('Post-execution beads sync failed', { error: (err as Error).message });
+        }
 
+        // Posts and deliverables surface in feeds that poll independently — fire and forget.
         syncPostsJsonlToChannelMessages(provider, ctx.sandboxId).catch(err =>
             log.warn('Post-execution posts sync failed', { error: (err as Error).message }),
         );

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/agent-management.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/agent-management.routes.ts
@@ -11,6 +11,8 @@ import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service
 import { buildScaffoldFilesFromRow } from '../../sandbox-infra/scaffold/scaffold-payload.service';
 import { SANDBOX_CONFIG } from '../../sandbox-infra/sandbox/sandbox.config';
 import { workspaceSSEBroadcaster } from '../../drive';
+import { assignAgentToChannel, registerAgentInIndex } from '../../company/system-agent-assignment.service';
+import { writeScaffoldFilesToSandbox } from './sandbox-file-writer';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_RESULTS = 100;
@@ -30,27 +32,6 @@ function getSandboxService(): SandboxService {
         throw new Error('Agent management routes dependencies not initialized');
     }
     return _sandboxService;
-}
-
-async function writeScaffoldFilesToSandbox(
-    provider: ReturnType<typeof getDaytonaProvider>,
-    sandboxId: string,
-    files: Array<{ path: string; content: string }>,
-): Promise<void> {
-    const basePath = SANDBOX_CONFIG.workspacePath;
-    const HEREDOC = 'XERUS_SCAFFOLD_EOF_9c1a';
-    for (const file of files) {
-        if (file.content.includes(HEREDOC)) {
-            throw new Error(`Scaffold file content for ${file.path} contains reserved heredoc delimiter`);
-        }
-        const fullPath = `${basePath}/${file.path}`;
-        const dirPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
-        const writeCmd = `mkdir -p ${dirPath} && cat > ${fullPath} << '${HEREDOC}'\n${file.content}\n${HEREDOC}`;
-        const { exitCode } = await provider.executeCommand(sandboxId, writeCmd);
-        if (exitCode !== 0) {
-            throw new Error(`Failed to write scaffold file ${file.path} to sandbox (exit ${exitCode})`);
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +135,45 @@ router.post('/create_agent', async (req: InternalMcpRequest, res: Response, next
         const model = model_id || 'claude-sonnet';
         const configJson = escapeSQL(JSON.stringify({ model, system_prompt, description }));
 
+        // Idempotent creation: if an agent with this slug already exists, return it
+        // instead of erroring or re-scaffolding. Prevents duplicate-agent attempts
+        // from the agent calling create_agent twice with the same name/slug.
+        const existingAgentRows = await executeWorkspaceJsonQuery<WorkspaceAgentRow>(
+            provider, sandboxId,
+            `SELECT slug, name, adapter_type, role, autonomy_level, status, config, marketplace_ref, installed_at, updated_at
+             FROM agents WHERE slug = '${escapeSQL(agentSlug)}'`,
+        );
+        if (existingAgentRows.length > 0) {
+            const existing = existingAgentRows[0];
+            let existingDescription = description;
+            if (existing.config) {
+                try {
+                    const parsed = JSON.parse(existing.config) as { description?: string; model?: string };
+                    if (typeof parsed.description === 'string') {
+                        existingDescription = parsed.description;
+                    }
+                } catch {
+                    // config not JSON — fall back to request description
+                }
+            }
+            const existingResult: McpToolResult = {
+                success: true,
+                data: {
+                    agent: {
+                        slug: existing.slug,
+                        name: existing.name,
+                        description: existingDescription,
+                        model_id: model,
+                        autonomy_level: existing.autonomy_level,
+                        status: existing.status,
+                        installed_at: existing.installed_at,
+                    },
+                },
+            };
+            res.json(existingResult);
+            return;
+        }
+
         const sql = `
             INSERT INTO agents (slug, name, adapter_type, role, autonomy_level, status, config)
             VALUES ('${escapeSQL(agentSlug)}', '${escapeSQL(name)}', 'claudecode', NULL, '${escapeSQL(autonomy)}', 'idle', '${configJson}');
@@ -167,7 +187,9 @@ router.post('/create_agent', async (req: InternalMcpRequest, res: Response, next
             throw new BadRequestError(`Agent with slug "${agentSlug}" already exists`);
         }
 
-        // Write scaffold files (config.json, SOUL.md, STATUS.md, etc.) to sandbox filesystem
+        // Write scaffold files (config.json, SOUL.md, STATUS.md, etc.) to sandbox filesystem.
+        // Channels are left empty here; assignAgentToChannel is the single writer of
+        // channel state (config.json channels[], index.json, channel_members, lead).
         const scaffoldFiles = buildScaffoldFilesFromRow(
             {
                 name,
@@ -178,7 +200,7 @@ router.post('/create_agent', async (req: InternalMcpRequest, res: Response, next
                 personality_type: null,
                 domain: null,
                 primary_channel: null,
-                channels: Array.isArray(req.body.channels) ? req.body.channels : [],
+                channels: [],
                 slug: agentSlug,
             },
             agentSlug,
@@ -198,19 +220,25 @@ router.post('/create_agent', async (req: InternalMcpRequest, res: Response, next
             throw new Error(`Failed to write agent.md for ${agentSlug} (exit ${promptExitCode})`);
         }
 
-        // Auto-populate channel_members for channels listed in the agent's config
-        const channels: string[] = Array.isArray(req.body.channels) ? req.body.channels : [];
-        if (channels.length > 0) {
-            const memberInserts = channels.map((ch: string) =>
-                `INSERT OR IGNORE INTO channel_members (channel_slug, agent_slug, role) VALUES ('${escapeSQL(String(ch))}', '${escapeSQL(agentSlug)}', 'member')`,
-            );
-            const leadUpdates = channels.map((ch: string) =>
-                `UPDATE channels SET lead_agent_slug = '${escapeSQL(agentSlug)}' WHERE slug = '${escapeSQL(String(ch))}' AND lead_agent_slug IS NULL`,
-            );
-            await executeWorkspaceQuery(
-                provider, sandboxId,
-                `BEGIN;\n${memberInserts.join(';\n')};\n${leadUpdates.join(';\n')};\nCOMMIT;`,
-            );
+        // Register the agent in agents/index.json so it appears on the agents list
+        // (the list endpoint iterates index.json). assignAgentToChannel updates the
+        // same entry with channel data when channels are provided.
+        await registerAgentInIndex(provider, sandboxId, agentSlug, name);
+
+        // Assign the agent to each requested channel, keeping config.json channels[],
+        // index.json, channel_members, and lead_agent_slug in sync. Without this the
+        // agent is invisible in every channel (frontend reads config.json channels[]).
+        const channels: string[] = Array.isArray(req.body.channels)
+            ? req.body.channels.map((ch: unknown) => String(ch)).filter((ch: string) => ch.length > 0)
+            : [];
+        const primaryChannel = typeof req.body.primary_channel === 'string' ? req.body.primary_channel : '';
+        const orderedChannels = primaryChannel && !channels.includes(primaryChannel)
+            ? [primaryChannel, ...channels]
+            : primaryChannel
+                ? [primaryChannel, ...channels.filter((ch) => ch !== primaryChannel)]
+                : channels;
+        for (const channelSlug of orderedChannels) {
+            await assignAgentToChannel(provider, sandboxId, agentSlug, channelSlug);
         }
 
         const row = rows[0];
@@ -309,6 +337,10 @@ router.post('/clone_agent', async (req: InternalMcpRequest, res: Response, next:
             [],
         );
         await writeScaffoldFilesToSandbox(provider, sandboxId, scaffoldFiles);
+
+        // Register the clone in agents/index.json so it appears on the agents list
+        // (the list endpoint iterates index.json).
+        await registerAgentInIndex(provider, sandboxId, cloneSlug, name);
 
         const row = rows[0];
         const mcpResult: McpToolResult = {

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/channel-task.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/channel-task.routes.ts
@@ -11,7 +11,7 @@ import { requireRunningSandbox, getDaytonaProvider } from '../../sandbox-infra/s
 import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service';
 import { workspaceSSEBroadcaster } from '../../drive';
 import { scaffoldChannel } from '../../company/workspace-scaffold.service';
-import { addSystemAgentsToChannel } from '../../company/system-agent-assignment.service';
+import { addSystemAgentsToChannel, assignAgentToChannel } from '../../company/system-agent-assignment.service';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -73,8 +73,8 @@ router.post('/create_channel', async (req: InternalMcpRequest, res: Response, ne
             throw new BadRequestError('name is required');
         }
 
-        const channelSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-        if (!SLUG_PATTERN.test(channelSlug)) {
+        const bareSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+        if (!SLUG_PATTERN.test(bareSlug)) {
             throw new BadRequestError(`Invalid channel name: ${name}. Slug must match ${SLUG_PATTERN}`);
         }
 
@@ -84,6 +84,34 @@ router.post('/create_channel', async (req: InternalMcpRequest, res: Response, ne
 
         // Ensure the domain exists (use project_id as domain_slug, default to 'default')
         const domainSlug = project_id || 'default';
+        const channelSlug = `${domainSlug}--${bareSlug}`;
+
+        // Idempotent creation: if a channel with this slug already exists, return it
+        // instead of erroring or re-scaffolding. Prevents duplicate-channel attempts
+        // from the agent calling create_channel twice with the same name.
+        const existingChannelRows = await executeWorkspaceJsonQuery<ChannelRow>(
+            provider, sandboxId,
+            `SELECT slug, name, domain_slug, lead_agent_slug, description, created_at FROM channels WHERE slug = '${escapeSQL(channelSlug)}'`,
+        );
+        if (existingChannelRows.length > 0) {
+            const existing = existingChannelRows[0];
+            const existingResult: McpToolResult = {
+                success: true,
+                data: {
+                    channel: {
+                        slug: existing.slug,
+                        name: existing.name,
+                        description: existing.description || '',
+                        domain_slug: existing.domain_slug,
+                        lead_agent_slug: existing.lead_agent_slug || null,
+                        agent_ids: agent_ids || [],
+                        created_at: existing.created_at,
+                    },
+                },
+            };
+            res.json(existingResult);
+            return;
+        }
 
         // Determine lead agent (first in agent_ids list, if provided)
         const leadAgent = Array.isArray(agent_ids) && agent_ids.length > 0
@@ -176,22 +204,37 @@ router.post('/add_to_channel', async (req: InternalMcpRequest, res: Response, ne
         const provider = getDaytonaProvider(sandboxService);
 
         // agent_id is treated as slug in workspace.db
-        const agentSlug = escapeSQL(String(agent_id));
+        const agentSlugRaw = String(agent_id);
         const agentRows = await executeWorkspaceJsonQuery<AgentRow>(
             provider, sandboxId,
-            `SELECT slug, name FROM agents WHERE slug = '${agentSlug}'`,
+            `SELECT slug, name FROM agents WHERE slug = '${escapeSQL(agentSlugRaw)}'`,
         );
 
         if (agentRows.length === 0) {
             throw new BadRequestError(`Agent not found: ${agent_id}`);
         }
 
-        const memberRole = role || 'member';
-        const sql = `INSERT INTO channel_members (channel_slug, agent_slug, role)
-                     VALUES ('${escapeSQL(channel_id)}', '${agentSlug}', '${escapeSQL(memberRole)}')
-                     ON CONFLICT(channel_slug, agent_slug) DO UPDATE SET role = '${escapeSQL(memberRole)}'`;
+        // Sync every source of truth: config.json channels[], index.json, the
+        // channel_members row, and lead_agent_slug. Updating only channel_members
+        // leaves the agent invisible in the channel (frontend reads config.json).
+        await assignAgentToChannel(provider, sandboxId, agentSlugRaw, channel_id);
 
-        await executeWorkspaceQuery(provider, sandboxId, sql);
+        // Honor an explicit role override (e.g. promoting to lead). The helper
+        // assigns 'lead' only for the agent's primary channel, so apply the
+        // caller's role here when supplied.
+        const memberRole = typeof role === 'string' && role.length > 0 ? role : null;
+        if (memberRole) {
+            await executeWorkspaceQuery(
+                provider, sandboxId,
+                `UPDATE channel_members SET role = '${escapeSQL(memberRole)}' WHERE channel_slug = '${escapeSQL(channel_id)}' AND agent_slug = '${escapeSQL(agentSlugRaw)}'`,
+            );
+            if (memberRole === 'lead') {
+                await executeWorkspaceQuery(
+                    provider, sandboxId,
+                    `UPDATE channels SET lead_agent_slug = '${escapeSQL(agentSlugRaw)}', updated_at = '${new Date().toISOString()}' WHERE slug = '${escapeSQL(channel_id)}'`,
+                );
+            }
+        }
 
         const mcpResult: McpToolResult = {
             success: true,
@@ -199,7 +242,7 @@ router.post('/add_to_channel', async (req: InternalMcpRequest, res: Response, ne
                 added: true,
                 channel_id,
                 agent_slug: agentRows[0].slug,
-                role: memberRole,
+                role: memberRole || 'member',
             },
         };
 
@@ -248,6 +291,37 @@ router.post('/create_task', async (req: InternalMcpRequest, res: Response, next:
                 }
                 // If still not found, use as-is — the insert will fail with a clear error downstream
             }
+        }
+
+        // Idempotent creation: if a task with the same title already exists in this
+        // channel, return it instead of inserting a duplicate. Task IDs are generated
+        // per-call, so without this check repeated create_task calls always duplicate.
+        const existingTaskRows = await executeWorkspaceJsonQuery<TaskRow>(
+            provider, sandboxId,
+            `SELECT id, project_slug, title, description, status, priority, assigned_agent, created_at
+             FROM tasks WHERE project_slug = '${escapeSQL(normalizedChannelId)}' AND title = '${escapeSQL(title)}' LIMIT 1`,
+        );
+        if (existingTaskRows.length > 0) {
+            const existing = existingTaskRows[0];
+            const existingResult: McpToolResult = {
+                success: true,
+                data: {
+                    task: {
+                        id: existing.id,
+                        channel_id,
+                        title: existing.title,
+                        description: existing.description || '',
+                        assigned_agent_ids: existing.assigned_agent ? [existing.assigned_agent] : [],
+                        priority: existing.priority,
+                        subtasks: subtasks || [],
+                        status: existing.status,
+                        created_by: userId,
+                        created_at: existing.created_at,
+                    },
+                },
+            };
+            res.json(existingResult);
+            return;
         }
 
         const taskId = `task-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/sandbox-file-writer.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/sandbox-file-writer.ts
@@ -1,0 +1,23 @@
+import { SANDBOX_CONFIG } from '../../sandbox-infra/sandbox/sandbox.config';
+import type { DaytonaProvider } from '../../sandbox-infra/sandbox/providers/daytona.provider';
+
+export async function writeScaffoldFilesToSandbox(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    files: Array<{ path: string; content: string }>,
+): Promise<void> {
+    const basePath = SANDBOX_CONFIG.workspacePath;
+    const HEREDOC = 'XERUS_SCAFFOLD_EOF_9c1a';
+    for (const file of files) {
+        if (file.content.includes(HEREDOC)) {
+            throw new Error(`Scaffold file content for ${file.path} contains reserved heredoc delimiter`);
+        }
+        const fullPath = `${basePath}/${file.path}`;
+        const dirPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
+        const writeCmd = `mkdir -p ${dirPath} && cat > ${fullPath} << '${HEREDOC}'\n${file.content}\n${HEREDOC}`;
+        const { exitCode } = await provider.executeCommand(sandboxId, writeCmd);
+        if (exitCode !== 0) {
+            throw new Error(`Failed to write scaffold file ${file.path} to sandbox (exit ${exitCode})`);
+        }
+    }
+}

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/skill-management.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/skill-management.routes.ts
@@ -131,6 +131,46 @@ router.post('/create_skill', async (req: InternalMcpRequest, res: Response, next
         const descEscaped = escapeSQL(description);
         const skillPath = `.claude/skills/${skillSlug}/SKILL.md`;
 
+        // Idempotent creation: if a skill with this slug already exists, return it
+        // instead of erroring or overwriting. Prevents duplicate-skill attempts from
+        // the agent calling create_skill twice with the same name.
+        const existingSkillRows = await executeWorkspaceJsonQuery<SkillRow>(
+            provider, sandboxId,
+            `SELECT slug, name, version, source, source_ref, description, categories, installed_at, updated_at
+             FROM skills WHERE slug = '${escapeSQL(skillSlug)}'`,
+        );
+        if (existingSkillRows.length > 0) {
+            const existing = existingSkillRows[0];
+            let existingCategory = cat;
+            if (existing.categories) {
+                try {
+                    const parsed = JSON.parse(existing.categories) as string[];
+                    if (Array.isArray(parsed) && typeof parsed[0] === 'string') {
+                        existingCategory = parsed[0];
+                    }
+                } catch {
+                    // categories not JSON — fall back to request category
+                }
+            }
+            const existingResult: McpToolResult = {
+                success: true,
+                data: {
+                    skill: {
+                        slug: existing.slug,
+                        name: existing.name,
+                        description: existing.description || description,
+                        category: existingCategory,
+                        agent_id: agent_id || null,
+                        user_id: userId,
+                        path: existing.source_ref || skillPath,
+                        created_at: existing.installed_at || new Date().toISOString(),
+                    },
+                },
+            };
+            res.json(existingResult);
+            return;
+        }
+
         const sql = `
             INSERT INTO skills (slug, name, version, source, source_ref, description, categories)
             VALUES ('${escapeSQL(skillSlug)}', '${escapeSQL(name)}', '1.0.0', 'local', '${escapeSQL(skillPath)}', '${descEscaped}', '${categoriesJson}');

--- a/xerus_backend/src/domains/platform-tools/platform/tools/schedule.tools.ts
+++ b/xerus_backend/src/domains/platform-tools/platform/tools/schedule.tools.ts
@@ -197,6 +197,16 @@ export class ScheduleService {
     ): Promise<CreateScheduleResult> {
         await ensureScheduleConfigColumn(this.provider, sandboxId);
 
+        // Idempotent creation: schedules.name is UNIQUE. If a schedule with this name
+        // already exists, return it instead of letting the INSERT fail. Prevents
+        // duplicate-schedule attempts from the agent calling create_schedule twice.
+        const existingSql = `SELECT * FROM schedules WHERE name = '${escapeSQL(input.name)}' LIMIT 1;`;
+        const existingResult = await this.provider.executeCommand(sandboxId, buildSqliteCommand(existingSql));
+        const existingRows = parseJsonResult<ScheduleEntry>(existingResult.result);
+        if (existingRows[0]) {
+            return { schedule: existingRows[0] };
+        }
+
         const id = randomUUID();
         const now = Math.floor(Date.now() / 1000);
         const adapterType = input.adapter_type ?? 'claudecode';

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/runner-session.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/runner-session.ts
@@ -60,12 +60,16 @@ export async function getOrCreateRunnerSession(
         const envChanged = !envVarsEqual(existing.envVars, envVars);
         const convChanged = conversationId != null && existing.conversationId != null
             && existing.conversationId !== conversationId;
-        if (envChanged || convChanged) {
+        const modelChanged = model != null && existing.model != null
+            && existing.model !== model;
+        if (envChanged || convChanged || modelChanged) {
             log.info('Session invalidated, restarting', {
                 agent_slug: slug, user_id: userId,
-                reason: envChanged ? 'env_changed' : 'conversation_changed',
+                reason: envChanged ? 'env_changed' : modelChanged ? 'model_changed' : 'conversation_changed',
                 old_conv: existing.conversationId?.slice(0, 8),
                 new_conv: conversationId?.slice(0, 8),
+                old_model: existing.model,
+                new_model: model,
             });
             session.agentSessions.delete(slug);
         } else {
@@ -128,7 +132,7 @@ export async function getOrCreateRunnerSession(
     handle.lastUsedAt = Date.now();
 
     // Cache in per-agent map
-    session.agentSessions.set(slug, { handle, envVars: { ...envVars }, conversationId });
+    session.agentSessions.set(slug, { handle, envVars: { ...envVars }, conversationId, model });
 
     // Also set legacy handle for backward compat
     session.runnerHandle = handle;

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox.types.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox.types.ts
@@ -29,6 +29,7 @@ export interface AgentSessionEntry {
     handle: SessionHandle;
     envVars: Record<string, string>;
     conversationId?: string;
+    model?: string;
 }
 
 // In-memory sandbox session

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-health.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-health.ts
@@ -13,6 +13,10 @@ import { DEFAULT_SDK_MODEL } from '../../agents/types';
 
 const log = logger('WorkspaceHealth');
 
+// Agent configs live under either `agents/` or `.claude/agents/`.
+// Scan both, with `agents/` taking priority on slug collisions.
+const AGENT_CONFIG_DIRS = ['agents', '.claude/agents'] as const;
+
 // Critical files that must exist for a workspace to be functional.
 // If any are missing, the workspace needs volume restore or reinitialization.
 const CRITICAL_FILES = [
@@ -116,15 +120,27 @@ export async function syncAgentsToWorkspace(
     const basePath = SANDBOX_CONFIG.workspacePath;
 
     // Fix stale model in ALL agent configs (S3 restore may bring back old values).
-    // Scan all agent dirs on disk — xerus-master and other
-    // platform agents come from the workspace template.
-    const agentsDirPath = `${basePath}/agents`;
+    // Scan all agent dirs on disk — agents live under either `agents/` or
+    // `.claude/agents/`. xerus-master and other platform agents come from the
+    // workspace template. Dedupe by slug, with `agents/` taking priority.
+    const agentDirConfigs = new Map<string, string>();
+    for (const dir of AGENT_CONFIG_DIRS) {
+        const agentsDirPath = `${basePath}/${dir}`;
+        try {
+            const contents = await sandboxFs.list(agentsDirPath);
+            for (const slug of contents) {
+                if (slug === 'index.json') continue;
+                if (agentDirConfigs.has(slug)) continue;
+                agentDirConfigs.set(slug, `${agentsDirPath}/${slug}/config.json`);
+            }
+        } catch {
+            // This agents dir might not exist yet
+        }
+    }
+
     let modelFixCount = 0;
     try {
-        const agentDirContents = await sandboxFs.list(agentsDirPath);
-        const agentDirs = agentDirContents.filter(name => name !== 'index.json');
-        for (const slug of agentDirs) {
-            const configPath = `${agentsDirPath}/${slug}/config.json`;
+        for (const configPath of agentDirConfigs.values()) {
             try {
                 const raw = await sandboxFs.readFile(configPath);
                 const config = JSON.parse(raw) as Record<string, unknown>;
@@ -143,8 +159,7 @@ export async function syncAgentsToWorkspace(
         // Build agents/index.json from filesystem (workspace.db is source of truth,
         // but index.json is a convenience file for the runner)
         const agents: Record<string, { name: string; role: string }> = {};
-        for (const slug of agentDirs) {
-            const configPath = `${agentsDirPath}/${slug}/config.json`;
+        for (const [slug, configPath] of agentDirConfigs) {
             try {
                 const raw = await sandboxFs.readFile(configPath);
                 const config = JSON.parse(raw) as Record<string, unknown>;

--- a/xerus_web/components/chat/AgentDropdown.tsx
+++ b/xerus_web/components/chat/AgentDropdown.tsx
@@ -78,7 +78,20 @@ export function AgentDropdown({
   const [open, setOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
-  const PINNED_AGENTS = [XERUS_AGENT, CTO_AGENT]
+  // Resolve pinned agents against the real agents list so their mascot config
+  // (avatarUrl from the DB) is used once loaded. Falls back to the static
+  // constant until the matching agent arrives — prevents the avatar flash.
+  const PINNED_AGENTS = useMemo(() => {
+    return [XERUS_AGENT, CTO_AGENT].map((pinned) => {
+      const real = agents.find((a) => a.slug === pinned.slug)
+      return real ? { ...pinned, ...real } : pinned
+    })
+  }, [agents])
+
+  const resolvePinned = (slug: string | null | undefined, fallback: Agent): Agent => {
+    const real = slug ? agents.find((a) => a.slug === slug) : undefined
+    return real ? { ...fallback, ...real } : fallback
+  }
 
   // Filter agents by search, excluding pinned agents from the grouped list
   const filteredAgents = useMemo(() => {
@@ -124,8 +137,8 @@ export function AgentDropdown({
         >
           {(() => {
             const raw = selectedAgent ?? XERUS_AGENT
-            const display = raw.slug === XERUS_MASTER_SLUG ? { ...raw, ...XERUS_AGENT, id: raw.id || XERUS_AGENT.id }
-              : raw.slug === XERUS_CTO_SLUG ? { ...raw, ...CTO_AGENT, id: raw.id || CTO_AGENT.id }
+            const display = raw.slug === XERUS_MASTER_SLUG ? { ...resolvePinned(XERUS_MASTER_SLUG, XERUS_AGENT), id: raw.id || XERUS_AGENT.id }
+              : raw.slug === XERUS_CTO_SLUG ? { ...resolvePinned(XERUS_CTO_SLUG, CTO_AGENT), id: raw.id || CTO_AGENT.id }
               : raw
             return (
               <div className="flex items-center gap-2 overflow-hidden">

--- a/xerus_web/components/chat/MessageBubble.tsx
+++ b/xerus_web/components/chat/MessageBubble.tsx
@@ -115,16 +115,18 @@ export const MessageBubble = memo(function MessageBubble({
   // actually produced by a specific agent. Fall back to the canonical XERUS_AGENT
   // so the header always renders with a real agent identity (no hardcoded logos).
   const resolvedAgent: Agent = agent ?? (() => {
-    // System agents use their static definitions (correct SVG avatars)
-    if (message.agentSlug === XERUS_MASTER_SLUG) return XERUS_AGENT
-    if (message.agentSlug === XERUS_CTO_SLUG) return CTO_AGENT
-    if (agents && (message.agentSlug || message.agentName)) {
-      return agents.find((a) =>
-        (message.agentSlug && a.slug === message.agentSlug) ||
-        (message.agentName && a.name === message.agentName)
-      ) ?? XERUS_AGENT
-    }
-    return XERUS_AGENT
+    // Prefer the real agent from the list (carries the mascot config avatarUrl
+    // from the DB). Merge over the static constant so system agents keep their
+    // canonical name/id while gaining the real avatar once loaded.
+    const fromList = agents && (message.agentSlug || message.agentName)
+      ? agents.find((a) =>
+          (message.agentSlug && a.slug === message.agentSlug) ||
+          (message.agentName && a.name === message.agentName)
+        )
+      : undefined
+    if (message.agentSlug === XERUS_MASTER_SLUG) return fromList ? { ...XERUS_AGENT, ...fromList } : XERUS_AGENT
+    if (message.agentSlug === XERUS_CTO_SLUG) return fromList ? { ...CTO_AGENT, ...fromList } : CTO_AGENT
+    return fromList ?? XERUS_AGENT
   })()
   void onViewExecution
 


### PR DESCRIPTION
## Summary

- **Bug 5 (P0)**: Channel slug format — `create_channel` now produces `domain--slug` instead of bare slugs
- **Bug 4 (P0)**: Task board empty — beads-to-tasks sync is now awaited (not fire-and-forget), fixed field name mismatch (`state`→`status`, added `description` field)
- **Bug 1 (P1)**: Stale model in session cache — runner session cache tracks model and invalidates on change
- **Bug 3 (P1)**: Agent path inconsistency — `AgentConfigLoader` and `syncAgentsToWorkspace` now check both `agents/` and `.claude/agents/`
- **Bug 6 (P1)**: Agent-created agents not in channels — new `assignAgentToChannel` helper updates all 4 sources of truth (config.json `channels[]`, `index.json`, `channel_members`, `lead_agent_slug`)
- **Bug 7 (P2)**: No duplicate checks — `create_channel`, `create_task`, `create_agent`, `create_skill` are now idempotent (return existing on duplicate)
- **Bug 2 (P3)**: Mascot image flash — `AgentDropdown` and `MessageBubble` resolve pinned agents against real DB data

## Changes

**15 files** changed (+535/-108):

| Area | Files | Bugs Fixed |
|------|-------|------------|
| Session cache | `runner-session.ts`, `sandbox.types.ts` | Bug 1 |
| Agent config | `agent-config-loader.ts`, `workspace-health.ts` | Bug 3 |
| MCP endpoints | `channel-task.routes.ts`, `agent-management.routes.ts`, `skill-management.routes.ts` | Bug 5, 6, 7 |
| Agent assignment | `system-agent-assignment.service.ts` (new helpers) | Bug 6 |
| Task sync | `session-record.ts`, `task-workspace-db.service.ts` | Bug 4 |
| Tool schema | `mcp-server.ts` | Bug 6 |
| Frontend | `AgentDropdown.tsx`, `MessageBubble.tsx` | Bug 2 |
| Extract | `sandbox-file-writer.ts` (new) | File size |

## Test plan

- [ ] Typecheck passes (`npx tsc --noEmit` — verified clean)
- [ ] Lint passes (`npx eslint` — verified clean)
- [ ] Create a new user account and verify onboarding flow
- [ ] Verify task board shows agent-created tasks after execution
- [ ] Change agent model and verify session picks up new model
- [ ] Create duplicate channel/task/agent — verify idempotent return
- [ ] Verify agent avatars use mascot config, no SVG flash
- [ ] Verify agents appear in channels after creation via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8vM55mzZ43m7KMeaS4rRD