### PR TITLE
fix: agent behavior, UX issues — stop button, tab switch, queue, polling

### DIFF
--- a/xerus_backend/src/domains/execution/agent-config-resolver.ts
+++ b/xerus_backend/src/domains/execution/agent-config-resolver.ts
@@ -115,16 +115,20 @@ export async function resolveAgentIdentity(
     let moduleContent = '';
     let rulesContent = '';
     let operatingContent = '';
+    let agentMdContent = '';
+    let bootstrapContent = '';
 
     for (const base of pathSets) {
         if (!soulContent) soulContent = await tryRead(`${base}/SOUL.md`);
         if (!moduleContent) moduleContent = await tryRead(`${base}/CLAUDE.md`);
         if (!rulesContent) rulesContent = await tryRead(`${base}/RULES.md`);
         if (!operatingContent) operatingContent = await tryRead(`${base}/OPERATING.md`);
+        if (!agentMdContent) agentMdContent = await tryRead(`${base}/agent.md`);
+        if (!bootstrapContent) bootstrapContent = await tryRead(`${base}/BOOTSTRAP.md`);
         if (soulContent || moduleContent) break;
     }
 
-    if (!soulContent && !moduleContent) return '';
+    if (!soulContent && !moduleContent && !agentMdContent) return '';
 
     const sections: string[] = [
         '# AGENT IDENTITY — SUPERSEDES ALL PRIOR IDENTITY',
@@ -138,12 +142,53 @@ export async function resolveAgentIdentity(
     if (soulContent) {
         sections.push(soulContent.trim(), '');
     }
-    if (rulesContent) {
-        sections.push(rulesContent.trim(), '');
-    }
     if (operatingContent) {
         sections.push(operatingContent.trim(), '');
     }
+    if (agentMdContent) {
+        sections.push(agentMdContent.trim(), '');
+    }
+    if (rulesContent) {
+        sections.push(rulesContent.trim(), '');
+    }
+
+    // Include bootstrap checklist if not yet completed
+    if (bootstrapContent) {
+        const completedMatch = bootstrapContent.match(/completed_at:\s*(.+)/);
+        const isCompleted = completedMatch && completedMatch[1].trim() !== 'null' && completedMatch[1].trim() !== '';
+        if (!isCompleted) {
+            sections.push('== First Run ==', bootstrapContent.trim(), '');
+        }
+    }
+
+    // Inject working memory from previous sessions so the agent has continuity
+    const memoryDir = `${ws}/.memory/agents/${agentSlug}`;
+    const MAX_WORKING = 4000;
+    const MAX_EXPERTISE = 2000;
+
+    const working = await tryRead(`${memoryDir}/working.md`);
+    const workingTrimmed = working.trim();
+    if (workingTrimmed.length > 20) {
+        const lastNl = workingTrimmed.lastIndexOf('\n', MAX_WORKING);
+        const capped = lastNl > 0 ? workingTrimmed.slice(0, lastNl) : workingTrimmed.slice(0, MAX_WORKING);
+        sections.push('== Working Memory (from previous session) ==', capped, '');
+    }
+
+    const expertise = await tryRead(`${memoryDir}/expertise.md`);
+    const expertiseTrimmed = expertise.trim();
+    if (expertiseTrimmed.length > 20) {
+        const lastNl = expertiseTrimmed.lastIndexOf('\n', MAX_EXPERTISE);
+        const capped = lastNl > 0 ? expertiseTrimmed.slice(0, lastNl) : expertiseTrimmed.slice(0, MAX_EXPERTISE);
+        sections.push('== Expertise ==', capped, '');
+    }
+
+    // Workspace awareness: inject agents/index.json so the agent knows its team
+    const agentIndex = await tryRead(`${ws}/agents/index.json`);
+    if (agentIndex.trim().length > 10) {
+        sections.push('== Current Agents ==', agentIndex.trim(), '');
+    }
+
+    // Module CLAUDE.md last (reference material, lowest priority for context)
     if (moduleContent) {
         sections.push(moduleContent.trim(), '');
     }

--- a/xerus_backend/src/domains/execution/execution-pipeline.ts
+++ b/xerus_backend/src/domains/execution/execution-pipeline.ts
@@ -20,7 +20,7 @@ import {
 } from './errors';
 import { routeEventWithResilience, createResilienceState } from './event-resilience';
 import { AgentAlreadyRunningError, QueueFullError } from './queue/execution-queue.errors';
-import { sendCommand, sendMessage, streamEvents } from '../sandbox-infra/sandbox';
+import { sendMessage, streamEvents } from '../sandbox-infra/sandbox';
 import type { SessionHandle } from '../sandbox-infra/sandbox';
 import { createHealthGuard, type HealthGuard } from './execution-health-guard';
 import {
@@ -321,7 +321,10 @@ async function processEventStream(
     for await (const event of streamEvents(handle, combinedSignal, ctx.streamOffset)) {
         if (eventsProcessed === 0) clearTimeout(firstEventTimer);
         if (ctx.stream.isClosed()) {
-            await sendCommand(handle, { type: 'interrupt', agent_slug: expectedSlug });
+            // SSE stream closed (frontend disconnected). Break the event loop on the
+            // backend side. The runner process keeps running intentionally — if the
+            // user reconnects, they'll see the completed result via conversation reload.
+            // stdin-based interrupts don't work (Claude Code ignores unknown types).
             break;
         }
 

--- a/xerus_backend/src/domains/execution/execution.service.ts
+++ b/xerus_backend/src/domains/execution/execution.service.ts
@@ -75,6 +75,8 @@ interface ActiveExecution {
     handle: SessionHandle;
     agentSlug: string;
     stream: StreamSink;
+    sandboxId: string;
+    userId: string;
 }
 
 export class ExecutionService {
@@ -266,6 +268,8 @@ export class ExecutionService {
                 handle,
                 agentSlug: agentForTracking.slug,
                 stream,
+                sandboxId: ctx.sandboxId!,
+                userId: request.userId,
             });
             stream.send('progress', { phase: 'executing', message: 'Starting agent', percent: 20 });
             ctx.sessionId = await createSessionRecord(resolved, ctx);
@@ -449,10 +453,15 @@ export class ExecutionService {
             return false;
         }
 
-        // Send interrupt command to the runner process.
-        // The runner's processManager.interruptAgent() aborts the SDK query.
-        sendCommand(active.handle, { type: 'interrupt', agent_slug: active.agentSlug })
-            .catch(err => log.error('Failed to send interrupt', { error: (err as Error).message }));
+        // Kill the Daytona session to terminate the CLI process.
+        // stdin-based interrupts don't work — Claude Code's stream-json input
+        // only handles 'user' and 'control_request' types, ignoring 'interrupt'.
+        const resolved = this.resolveDeps();
+        const provider = resolved.sandboxService.getDaytonaProvider();
+        provider.getSandboxInstance(active.sandboxId)
+            .then(sandbox => sandbox.process.deleteSession(active.handle.sessionId))
+            .then(() => log.info('Cancelled: deleted runner session', { execution_id: executionId, session: active.handle.sessionId }))
+            .catch(err => log.error('Failed to delete runner session', { execution_id: executionId, error: (err as Error).message }));
 
         // Send stop event — do NOT close the stream (it belongs to the conversation, not the execution)
         if (!active.stream.isClosed()) {

--- a/xerus_backend/src/domains/execution/queue/__tests__/execution-queue.service.test.ts
+++ b/xerus_backend/src/domains/execution/queue/__tests__/execution-queue.service.test.ts
@@ -3,7 +3,7 @@
 
 import { ExecutionQueueService } from '../execution-queue.service';
 import { CreateExecutionRequest, TRIGGER_PRIORITIES, TriggerType } from '../execution-lane.types';
-import { AgentAlreadyRunningError, QueueFullError, LaneNotFoundError } from '../execution-queue.errors';
+import { QueueFullError, LaneNotFoundError } from '../execution-queue.errors';
 
 describe('ExecutionQueueService', () => {
     const TEST_USER_ID = 'test-user-001';
@@ -63,11 +63,14 @@ describe('ExecutionQueueService', () => {
             expect(pos3.position).toBe(2);
         });
 
-        it('should throw AgentAlreadyRunningError when agent is queued', () => {
+        it('should allow multiple pending messages for the same agent', () => {
             const service = new ExecutionQueueService();
-            service.enqueue(createRequest(TEST_AGENT_SLUG_1));
+            const pos1 = service.enqueue(createRequest(TEST_AGENT_SLUG_1));
+            const pos2 = service.enqueue(createRequest(TEST_AGENT_SLUG_1));
 
-            expect(() => service.enqueue(createRequest(TEST_AGENT_SLUG_1))).toThrow(AgentAlreadyRunningError);
+            expect(pos1.position).toBe(0);
+            expect(pos2.position).toBe(1);
+            expect(service.getPendingCount(TEST_USER_ID)).toBe(2);
         });
 
         it('should throw QueueFullError when queue limit reached', () => {
@@ -323,15 +326,16 @@ describe('ExecutionQueueService', () => {
             expect(service.getPendingCount(TEST_USER_ID)).toBe(1);
         });
 
-        it('should throw when trying to enqueue agent already queued (pending)', () => {
+        it('should allow multiple pending messages for same agent while running', () => {
             const service = new ExecutionQueueService();
             service.enqueue(createRequest(TEST_AGENT_SLUG_1));
             service.acquire(TEST_USER_ID);
-            // Enqueue second while running — allowed
+            // Enqueue second while running
             service.enqueue(createRequest(TEST_AGENT_SLUG_1));
-
-            // Third enqueue for same agent — rejected (already has a pending request)
-            expect(() => service.enqueue(createRequest(TEST_AGENT_SLUG_1))).toThrow(AgentAlreadyRunningError);
+            // Third enqueue for same agent — also allowed now
+            const pos = service.enqueue(createRequest(TEST_AGENT_SLUG_1));
+            expect(pos.position).toBe(1);
+            expect(service.getPendingCount(TEST_USER_ID)).toBe(2);
         });
     });
 

--- a/xerus_backend/src/domains/execution/queue/execution-queue.service.ts
+++ b/xerus_backend/src/domains/execution/queue/execution-queue.service.ts
@@ -424,20 +424,12 @@ export class ExecutionQueueService extends EventEmitter {
     // -------------------------------------------------------------------------
 
     /**
-     * Check for conflicts before adding to queue
+     * Check for conflicts before adding to queue.
+     * Multiple pending messages per agent are allowed (the frontend queues
+     * messages client-side and drains them one at a time). Only the total
+     * queue size is enforced to prevent unbounded growth.
      */
-    private checkConflicts(userId: string, agentSlug: string): ConflictCheckResult {
-        // Same agent already QUEUED (pending) — reject to prevent unbounded queue
-        // Same agent already RUNNING — allowed (caller waits for lane via waitForAgentAvailable)
-        if (this.isAgentQueued(userId, agentSlug)) {
-            return {
-                conflict: true,
-                reason: 'agent_already_running',
-                message: `Agent ${agentSlug} already has a pending request`,
-            };
-        }
-
-        // Check queue size limit
+    private checkConflicts(userId: string, _agentSlug: string): ConflictCheckResult {
         const pendingCount = this.getPendingCount(userId);
         if (pendingCount >= this.config.max_queue_size) {
             return {

--- a/xerus_backend/src/domains/execution/runner/soul-append-builder.ts
+++ b/xerus_backend/src/domains/execution/runner/soul-append-builder.ts
@@ -94,7 +94,7 @@ export function buildMemoryAppend(workspacePath: string, agentSlug: string): str
 
     const working = readFileContent(path.join(memoryDir, 'working.md'));
     const workingContent = working.trim();
-    if (workingContent.length > 80 && !workingContent.includes('No previous session state')) {
+    if (workingContent.length > 20 && !workingContent.includes('No previous session state')) {
         const lastNewline = workingContent.lastIndexOf('\n', 4000);
         const trimmed = lastNewline > 0 ? workingContent.slice(0, lastNewline) : workingContent.slice(0, 4000);
         parts.push(`== Working Memory (from previous session) ==\n${trimmed}`);

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/agent-management.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/agent-management.routes.ts
@@ -228,10 +228,23 @@ router.post('/create_agent', async (req: InternalMcpRequest, res: Response, next
         // Assign the agent to each requested channel, keeping config.json channels[],
         // index.json, channel_members, and lead_agent_slug in sync. Without this the
         // agent is invisible in every channel (frontend reads config.json channels[]).
-        const channels: string[] = Array.isArray(req.body.channels)
+        let channels: string[] = Array.isArray(req.body.channels)
             ? req.body.channels.map((ch: unknown) => String(ch)).filter((ch: string) => ch.length > 0)
             : [];
         const primaryChannel = typeof req.body.primary_channel === 'string' ? req.body.primary_channel : '';
+
+        // Safety net: if no channels provided, find the first available channel in the
+        // workspace so the agent isn't silently invisible. Prefer a general channel.
+        if (channels.length === 0 && !primaryChannel) {
+            const fallbackRows = await executeWorkspaceJsonQuery<{ slug: string }>(
+                provider, sandboxId,
+                `SELECT slug FROM channels ORDER BY CASE WHEN slug LIKE '%--general' THEN 0 ELSE 1 END, created_at ASC LIMIT 1`,
+            );
+            if (fallbackRows.length > 0) {
+                channels = [fallbackRows[0].slug];
+            }
+        }
+
         const orderedChannels = primaryChannel && !channels.includes(primaryChannel)
             ? [primaryChannel, ...channels]
             : primaryChannel

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-health.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-health.ts
@@ -10,6 +10,7 @@ import type { DaytonaProvider } from './providers/daytona.provider';
 import { personalizeWorkspace } from '../workspace/workspace-personalizer.service';
 import type { SandboxDatabase } from './sandbox.service';
 import { DEFAULT_SDK_MODEL } from '../../agents/types';
+import { executeWorkspaceQuery } from '../../conversations/workspace-db.helpers';
 
 const log = logger('WorkspaceHealth');
 
@@ -129,9 +130,16 @@ export async function syncAgentsToWorkspace(
         try {
             const contents = await sandboxFs.list(agentsDirPath);
             for (const slug of contents) {
-                if (slug === 'index.json') continue;
+                if (slug === 'index.json' || slug === '.gitkeep') continue;
+                if (slug.endsWith('.md')) continue;
                 if (agentDirConfigs.has(slug)) continue;
-                agentDirConfigs.set(slug, `${agentsDirPath}/${slug}/config.json`);
+                const configPath = `${agentsDirPath}/${slug}/config.json`;
+                try {
+                    await sandboxFs.readFile(configPath);
+                    agentDirConfigs.set(slug, configPath);
+                } catch {
+                    // No config.json — not a real agent directory
+                }
             }
         } catch {
             // This agents dir might not exist yet
@@ -168,7 +176,7 @@ export async function syncAgentsToWorkspace(
                     role: (config.role as string) || 'specialist',
                 };
             } catch {
-                agents[slug] = { name: slug, role: 'specialist' };
+                // config.json already validated in scan phase — skip broken entries
             }
         }
         if (!agents['xerus-master']) {
@@ -177,6 +185,28 @@ export async function syncAgentsToWorkspace(
         const indexPath = `${basePath}/agents/index.json`;
         const indexContent = JSON.stringify({ agents, updated_at: new Date().toISOString() }, null, 2);
         await sandboxFs.writeFile(indexPath, indexContent);
+
+        // Sync agents to workspace.db with correct role and autonomy from config.json.
+        // The scaffold-sync-hook only fires on PostToolUse Write, so system agents
+        // (xerus-master, xerus-cto) from the template clone are never registered.
+        if (_provider && _sandboxId) {
+            for (const [slug, configPath] of agentDirConfigs) {
+                try {
+                    const raw = await sandboxFs.readFile(configPath);
+                    const config = JSON.parse(raw) as Record<string, unknown>;
+                    const name = String(config.name || slug).replace(/'/g, "''");
+                    const role = String(config.role || 'specialist').replace(/'/g, "''");
+                    const autonomy = String(config.autonomy_level || 'supervised').replace(/'/g, "''");
+                    await executeWorkspaceQuery(
+                        _provider, _sandboxId,
+                        `INSERT OR REPLACE INTO agents (slug, name, adapter_type, role, autonomy_level, status)
+                         VALUES ('${slug}', '${name}', 'claudecode', '${role}', '${autonomy}', 'idle')`,
+                    );
+                } catch {
+                    // Skip agents with unreadable configs
+                }
+            }
+        }
     } catch {
         // agents/ dir might not exist yet
     }

--- a/xerus_web/components/chat/AgentDropdown.tsx
+++ b/xerus_web/components/chat/AgentDropdown.tsx
@@ -78,19 +78,19 @@ export function AgentDropdown({
   const [open, setOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
-  // Resolve pinned agents against the real agents list so their mascot config
-  // (avatarUrl from the DB) is used once loaded. Falls back to the static
-  // constant until the matching agent arrives — prevents the avatar flash.
+  // Resolve pinned agents against the real agents list so they get the real id
+  // and other metadata, but KEEP the static avatarUrl (the DB mascot config
+  // generates a generic robot icon, not the branded Xerus/CTO logo).
   const PINNED_AGENTS = useMemo(() => {
     return [XERUS_AGENT, CTO_AGENT].map((pinned) => {
       const real = agents.find((a) => a.slug === pinned.slug)
-      return real ? { ...pinned, ...real } : pinned
+      return real ? { ...pinned, ...real, avatarUrl: pinned.avatarUrl } : pinned
     })
   }, [agents])
 
   const resolvePinned = (slug: string | null | undefined, fallback: Agent): Agent => {
     const real = slug ? agents.find((a) => a.slug === slug) : undefined
-    return real ? { ...fallback, ...real } : fallback
+    return real ? { ...fallback, ...real, avatarUrl: fallback.avatarUrl } : fallback
   }
 
   // Filter agents by search, excluding pinned agents from the grouped list

--- a/xerus_web/components/chat/MessageBubble.tsx
+++ b/xerus_web/components/chat/MessageBubble.tsx
@@ -173,6 +173,11 @@ export const MessageBubble = memo(function MessageBubble({
             AI
           </span>
         )}
+        {isUser && message.isQueued && (
+          <span className="text-[10px] font-medium text-amber-500 bg-amber-500/10 rounded-full px-1.5 py-0.5 shrink-0">
+            Queued
+          </span>
+        )}
         <span className="text-[11px] text-text-muted tabular-nums shrink-0">
           {formatTime(message.timestamp)}
         </span>

--- a/xerus_web/components/chat/MessageBubble.tsx
+++ b/xerus_web/components/chat/MessageBubble.tsx
@@ -124,8 +124,8 @@ export const MessageBubble = memo(function MessageBubble({
           (message.agentName && a.name === message.agentName)
         )
       : undefined
-    if (message.agentSlug === XERUS_MASTER_SLUG) return fromList ? { ...XERUS_AGENT, ...fromList } : XERUS_AGENT
-    if (message.agentSlug === XERUS_CTO_SLUG) return fromList ? { ...CTO_AGENT, ...fromList } : CTO_AGENT
+    if (message.agentSlug === XERUS_MASTER_SLUG) return fromList ? { ...XERUS_AGENT, ...fromList, avatarUrl: XERUS_AGENT.avatarUrl } : XERUS_AGENT
+    if (message.agentSlug === XERUS_CTO_SLUG) return fromList ? { ...CTO_AGENT, ...fromList, avatarUrl: CTO_AGENT.avatarUrl } : CTO_AGENT
     return fromList ?? XERUS_AGENT
   })()
   void onViewExecution

--- a/xerus_web/components/chat/chatReducer.ts
+++ b/xerus_web/components/chat/chatReducer.ts
@@ -222,6 +222,16 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'QUEUE_MESSAGE':
       return {
         ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: `msg_${Date.now()}_queued_${state.messages.length}`,
+            role: 'user' as const,
+            content: action.content,
+            timestamp: Date.now(),
+            isQueued: true,
+          },
+        ],
         execByConversation: updateExec(state, action.convId, prev => ({
           ...prev,
           pendingMessages: [...prev.pendingMessages, action.content],

--- a/xerus_web/components/chat/types.ts
+++ b/xerus_web/components/chat/types.ts
@@ -13,6 +13,7 @@ export interface Message {
   agentName?: string
   timestamp: number
   isStreaming?: boolean
+  isQueued?: boolean
   metadata?: {
     model?: string
     tools?: string[]

--- a/xerus_web/components/chat/useChatExecution.ts
+++ b/xerus_web/components/chat/useChatExecution.ts
@@ -216,18 +216,42 @@ export function useChatExecution({ dispatch }: UseChatExecutionOptions) {
     }
     wasDisconnectedRef.current = true
     if (disconnectTimerRef.current) return
+    // 60s grace period — SSE reconnects can take time on mobile/tab switch.
+    // Don't clear streaming refs on disconnect; keep them so content survives
+    // short disconnections. Only mark execution as lost after the full timeout.
     disconnectTimerRef.current = setTimeout(() => {
       disconnectTimerRef.current = null
       const convId = getConvIdRef.current()
       if (!convId) return
+      // Commit any partial turn as an assistant message so it's not lost
+      const refs = refsByConv.current.get(convId)
+      if (refs?.turn && refs.turn.parts.length > 0) {
+        const committedTurn = commitTurn(refs.turn, refs.rawText || undefined)
+        if (committedTurn.parts.length > 0) {
+          dispatchRef.current({
+            type: 'APPEND_ASSISTANT_MESSAGE',
+            convId,
+            message: {
+              id: committedTurn.id,
+              role: 'assistant',
+              content: extractTextFromParts(committedTurn.parts),
+              agentSlug: refs.respondingAgent.agentSlug,
+              agentName: refs.respondingAgent.agentName,
+              timestamp: committedTurn.timestamp,
+              parts: committedTurn.parts,
+              writtenFiles: committedTurn.writtenFiles,
+            },
+          })
+        }
+      }
       refsByConv.current.delete(convId)
       dispatchRef.current({
         type: 'EXECUTION_FINISHED',
         convId,
         result: 'error',
-        errorMessage: 'Connection lost. Please resend your message.',
+        errorMessage: 'Connection lost. The agent may still be working — switch back to check.',
       })
-    }, 5000)
+    }, 60_000)
   }, [])
 
   // Memoize handler factories so the callbacks identity is stable.

--- a/xerus_web/components/chat/useChatState.ts
+++ b/xerus_web/components/chat/useChatState.ts
@@ -168,6 +168,22 @@ export function useChatState({ initialAgentId, conversationId, initialMessage }:
     // eslint-disable-next-line react-hooks/exhaustive-deps -- connectStream is stable via ref
   }, [state.conversationId, isAuthReady])
 
+  // ---- Reconnect + reload on tab return (visibility change) ----
+  const loadConversationDetailsRef2 = useRef(loadConversationDetails)
+  loadConversationDetailsRef2.current = loadConversationDetails
+  useEffect(() => {
+    const handler = () => {
+      if (document.visibilityState !== 'visible') return
+      const convId = state.conversationId
+      if (!convId || !isAuthReady) return
+      executionStream.connectStream(convId)
+      loadConversationDetailsRef2.current(convId)
+    }
+    document.addEventListener('visibilitychange', handler)
+    return () => document.removeEventListener('visibilitychange', handler)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs carry live values
+  }, [state.conversationId, isAuthReady, executionStream])
+
   // ---- Send message ----
   const sendMessageRef = useCallback(
     async (content: string, metadata?: { attachedFiles?: string[] }) => {


### PR DESCRIPTION
## Summary

- **Agent behavior**: `resolveAgentIdentity()` now reads agent.md, BOOTSTRAP.md, working.md, expertise.md, and agents/index.json into system prompt. Memory injection threshold lowered from 80→20 chars.
- **Avatar logos**: Pinned agents (Xerus, CTO) preserve static avatarUrl instead of DB mascot override.
- **Workspace consistency**: Filter .md files from agent scan, sync system agents to workspace.db, fallback channel assignment in create_agent MCP tool.
- **Prompt simplification**: agent.md cut 402→80 lines, BOOTSTRAP.md 15→3 steps, OPERATING.md 96→50 lines. TOOL_GUIDE.md and CLAUDE.md rewritten to enforce MCP-first state mutations.
- **Stop button**: Kill Daytona session via `sandbox.process.deleteSession()` instead of ignored stdin interrupt (`{ type: 'interrupt' }` is silently dropped by Claude Code's stream-json input).
- **Tab switch**: Increase disconnect grace period 5s→60s. Commit partial streaming turn on timeout instead of discarding. Add `visibilitychange` handler to reconnect SSE and reload messages on tab return.
- **Message queue**: Remove single-pending-per-agent restriction in ExecutionQueueService. Show queued messages as user bubbles with amber "Queued" badge.
- **Agent independence**: `visibilitychange` handler reconnects SSE + reloads conversation from workspace.db, showing completed execution results.

## Test plan

- [ ] Start agent execution, click stop — verify process is killed (not just UI reset)
- [ ] Start execution, switch tabs for 30s, return — verify streaming content preserved or completed messages loaded
- [ ] Send 3 messages while agent is running — verify all appear as user bubbles with "Queued" badge, processed sequentially
- [ ] Start execution, close tab, reopen — verify completed response appears after conversation reload
- [ ] Verify avatar logos show correct SVGs (not green robot) for Xerus and CTO agents
- [ ] Fresh onboarding: verify agent creates channels/agents via MCP tools (not sqlite3)
- [ ] `npm run typecheck` passes for both backend and frontend
- [ ] Queue tests pass (50/50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8vM55mzZ43m7KMeaS4rRD