### PR TITLE
fix: auto-scroll hijacking and misleading token counter

### DIFF
--- a/xerus_web/components/chat/MessageList.tsx
+++ b/xerus_web/components/chat/MessageList.tsx
@@ -61,11 +61,38 @@ function MessageListComponent({
   agents,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const userScrolledUpRef = useRef(false)
 
-  // Auto-scroll to bottom on new messages or streaming updates
+  // Detect when user scrolls away from bottom — pause auto-scroll
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const el = containerRef.current
+    if (!el) return
+    const onScroll = () => {
+      const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      userScrolledUpRef.current = distFromBottom > 150
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [])
+
+  // Auto-scroll only if user hasn't scrolled up. Reset on new user message.
+  useEffect(() => {
+    if (!userScrolledUpRef.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
   }, [messages, streamingTurn])
+
+  // Reset scroll lock when user sends a new message
+  const prevMsgCount = useRef(messages.length)
+  useEffect(() => {
+    const lastMsg = messages[messages.length - 1]
+    if (messages.length > prevMsgCount.current && lastMsg?.role === 'user') {
+      userScrolledUpRef.current = false
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+    prevMsgCount.current = messages.length
+  }, [messages])
 
   // Combine messages with streaming turn
   const allMessages: ChatMessageExtended[] = [...messages]
@@ -97,7 +124,7 @@ function MessageListComponent({
   }
 
   return (
-    <div data-testid="message-list" className={cn('flex-1 overflow-y-auto scrollbar-thin [contain:layout_style]', className)}>
+    <div ref={containerRef} data-testid="message-list" className={cn('flex-1 overflow-y-auto scrollbar-thin [contain:layout_style]', className)}>
       <div className="max-w-3xl mx-auto pb-4 animate-[fadeInUp_0.4s_ease-out]">
         {/* Messages — pass currentAgent only as hint for messages without their own
             agentSlug; MessageBubble prefers per-message agent resolution to preserve

--- a/xerus_web/components/chat/useChatExecution.handlers.ts
+++ b/xerus_web/components/chat/useChatExecution.handlers.ts
@@ -167,7 +167,6 @@ export function makeOnMeta(ctx: HandlerCtx) {
     if (content.model) {
       refs.tokenCount = 0
       refs.modelContextSize = modelContextSize(content.model)
-      ctx.dispatch({ type: 'SET_TOKEN_USAGE', convId, tokenUsage: { used: 0, total: refs.modelContextSize } })
     }
     if (content.agentName) {
       let turn = createStreamingTurn(content.agentSlug ?? refs.respondingAgent.agentSlug, content.agentName ?? refs.respondingAgent.agentName)

--- a/xerus_web/components/chat/useChatExecution.ts
+++ b/xerus_web/components/chat/useChatExecution.ts
@@ -57,11 +57,6 @@ export function useChatExecution({ dispatch }: UseChatExecutionOptions) {
     refs.turn = appendToken(refs.turn, refs.pendingTokenText)
     refs.pendingTokenText = ''
     dispatchRef.current({ type: 'SET_STREAMING_TURN', convId, turn: refs.turn })
-    dispatchRef.current({
-      type: 'SET_TOKEN_USAGE',
-      convId,
-      tokenUsage: { used: refs.tokenCount, total: refs.modelContextSize },
-    })
   }, [getRefs])
 
   const resetStreamContent = useCallback((convId: string, agentHint?: { agentSlug?: string; agentName?: string }) => {


### PR DESCRIPTION
## Summary

- **Auto-scroll**: Stop hijacking scroll during streaming. Only auto-scroll if user is near the bottom. If user scrolls up to read earlier content, stay there. Reset scroll lock when user sends a new message.
- **Token counter**: Remove misleading streaming token count (showed estimated `text.length/4` against 200k context window). Real token counts only available in the `done` event summary.
- **Queued label**: Add `queued` to `INFRA_NOISE` filter so it doesn't appear as a status label on agent messages.

## Test plan

- [ ] Start agent execution, scroll up during streaming — should stay where you scrolled
- [ ] Send a new message — should auto-scroll to bottom again
- [ ] Token counter "767 / 200k" should no longer appear during streaming
- [ ] "queued" status label should no longer appear on agent messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvDRY9G1855ASjmU5fGNNk