### PR TITLE
feat: AskUserQuestion HITL bridge for headless sandbox

### DIFF
--- a/xerus_backend/src/domains/execution/cli-stream-router.ts
+++ b/xerus_backend/src/domains/execution/cli-stream-router.ts
@@ -104,6 +104,25 @@ export async function handleCliStreamEvent(
                                         ctx.stream.send('tool_call' as StreamEventType, { toolName, arguments: args, callId });
                                     }
                                 }
+
+                                // AskUserQuestion HITL bridge: emit guidance event so the
+                                // frontend renders the question UI. The PreToolUse hook in
+                                // the sandbox blocks tool execution until the user responds.
+                                if (toolName === 'AskUserQuestion' && Object.keys(args).length > 0) {
+                                    const questions = args.questions as Array<{ question?: string; options?: Array<{ label: string }> }> | undefined;
+                                    const firstQ = questions?.[0];
+                                    ctx.stream.send('guidance' as StreamEventType, {
+                                        question: firstQ?.question || 'The agent has a question for you',
+                                        options: firstQ?.options?.map((o: { label: string }) => o.label),
+                                        pause_id: callId,
+                                        scenario: 'ask_user',
+                                        tool_name: 'AskUserQuestion',
+                                        agent_slug: ctx.agent?.slug,
+                                        execution_id: ctx.sessionId,
+                                        ui_hint: 'question',
+                                    });
+                                    log.info('AskUserQuestion guidance emitted', { call_id: callId, agent: ctx.agent?.slug });
+                                }
                                 break;
                             }
                             case 'tool_result': {

--- a/xerus_backend/src/domains/execution/execution.service.ts
+++ b/xerus_backend/src/domains/execution/execution.service.ts
@@ -430,6 +430,10 @@ export class ExecutionService {
     /**
      * Send HITL response to runner for a paused execution.
      * Called by POST /:id/respond route after DB state is updated.
+     *
+     * For AskUserQuestion: also writes a response file to /tmp/xerus-hitl/{pauseId}.response
+     * in the sandbox. The PreToolUse hook is blocking on this file and will unblock
+     * when it appears, allowing the tool execution to proceed.
      */
     async respondToHitl(executionId: string, pauseId: string, approved: boolean, feedback?: string): Promise<boolean> {
         const active = this.activeExecutions.get(executionId);
@@ -443,6 +447,17 @@ export class ExecutionService {
             approved,
             feedback,
         });
+
+        // Write response file for AskUserQuestion PreToolUse hook (which blocks on this file)
+        const resolved = this.resolveDeps();
+        const provider = resolved.sandboxService.getDaytonaProvider();
+        const responseContent = JSON.stringify({ approved, feedback: feedback || '', timestamp: new Date().toISOString() });
+        provider.getSandboxInstance(active.sandboxId)
+            .then(sandbox => sandbox.fs.uploadFile(
+                Buffer.from(responseContent, 'utf-8'),
+                `/tmp/xerus-hitl/${pauseId}.response`,
+            ))
+            .catch(err => log.warn('Failed to write HITL response file', { error: (err as Error).message }));
 
         return true;
     }


### PR DESCRIPTION
## Summary

- **cli-stream-router.ts**: When a `tool_use` block for `AskUserQuestion` arrives, emit a `guidance` SSE event with the question/options data so the frontend renders the interactive question UI
- **execution.service.ts**: `respondToHitl()` now writes a response file to `/tmp/xerus-hitl/{pauseId}.response` in the sandbox, unblocking the PreToolUse hook that's waiting for the user's answer
- **xerus-workspace** (already pushed): PreToolUse hook intercepts `AskUserQuestion`, blocks execution by polling for response file, times out after 5 minutes

### Root cause
Claude Code runs with `--dangerously-skip-permissions` in the sandbox. When `AskUserQuestion` is called, it auto-resolves in headless mode (no terminal to show the question). The agent gets an empty response and loops trying to ask again.

### Flow
1. Model calls `AskUserQuestion` → `assistant` message with `tool_use` block
2. `cli-stream-router.ts` sees `name: 'AskUserQuestion'` → emits `guidance` SSE event
3. PreToolUse hook blocks on `/tmp/xerus-hitl/{callId}.response`
4. Frontend shows guidance UI → user responds → `POST /execute/:id/respond`
5. Backend writes response file to sandbox → hook unblocks → tool executes

## Test plan

- [ ] Agent calls AskUserQuestion → frontend shows guidance question UI (not just "Asked a question" chip)
- [ ] User clicks a response option → agent receives the answer and continues
- [ ] 5-minute timeout → agent gets "timed out" error and can proceed differently
- [ ] Non-AskUserQuestion tools still work normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvDRY9G1855ASjmU5fGNNk