### PR TITLE
fix: auto-sync workspace template on every sandbox resume

### DIFF
--- a/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
@@ -9,6 +9,7 @@ import { installRunnerBundle } from './runner-installer';
 import { personalizeWorkspace } from '../workspace/workspace-personalizer.service';
 import { syncPipedreamMcpConfig } from '../workspace/mcp-config.service';
 import { ensureWorkspaceIntegrity, syncAgentsToWorkspace } from './workspace-health';
+import { syncWorkspaceTemplate } from './workspace-template-sync';
 import { GIT_MEMORY_CONFIG } from '../../memory/git-memory/git-memory.types';
 import type { DaytonaProvider } from './providers/daytona.provider';
 import type { SandboxFileSystem } from '../workspace/workspace.manager';
@@ -102,6 +103,25 @@ export async function runWorkspaceHealthCheck(
     };
 
     await ensureWorkspaceIntegrity(sandboxFs, userId, deps.db, cloneWorkspace, installRunner);
+
+    // Sync platform-owned template files (CLAUDE.md, hooks, rules, skills, agents)
+    // on every resume. Ensures fixes pushed to xerus-workspace reach existing sandboxes.
+    const provider = deps.getDaytonaProvider();
+    try {
+        const syncResult = await syncWorkspaceTemplate(provider, sandboxId);
+        if (syncResult.updatedPaths.length > 0) {
+            log.info('Template sync updated files', {
+                sandbox_id: sandboxId,
+                updated: syncResult.updatedPaths,
+                duration_ms: syncResult.durationMs,
+            });
+        }
+    } catch (syncErr) {
+        log.warn('Template sync failed (non-blocking)', {
+            sandbox_id: sandboxId,
+            error: (syncErr as Error).message,
+        });
+    }
 
     // Run schema migrations (init-db.sh) on every resume.
     // S3-restored databases may predate newer schema tables (e.g. file_connections).


### PR DESCRIPTION
## Summary

`syncWorkspaceTemplate()` was only called after S3 snapshot restore. Existing sandboxes never got updates pushed to the xerus-workspace repo (CLAUDE.md, hooks, rules, skills, agent prompts). Users had to recreate their sandbox to get any fix.

Now runs on every sandbox resume via `runWorkspaceHealthCheck()`. Overlays platform-owned paths only:
- `CLAUDE.md`, `.claude/skills`, `.claude/hooks`, `.claude/rules`, `.claude/commands`
- `.claude/agents` (xerus-master, xerus-cto prompt files)
- `agents/xerus-master`, `agents/xerus-cto`, `agents/index.json`
- `marketplace`, `.xerus`, `.agent/*`

User data (`drive/`, `projects/`, `.memory/`, `data/`, user-created agents) is never touched.

The sync is non-blocking — failure logs a warning but doesn't prevent sandbox resume.

## Test plan

- [ ] Push a change to xerus-workspace (e.g., edit CLAUDE.md)
- [ ] Resume an existing sandbox (pause then unpause, or send a message after idle)
- [ ] Verify the change appears in the sandbox workspace files
- [ ] Verify user-created files (drive/company.md, projects/) are not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvDRY9G1855ASjmU5fGNNk