### PR TITLE
feat: Paperclip-inspired MCP-first architecture redesign

### DIFF
--- a/xerus_backend/src/domains/company/channel-execution.service.ts
+++ b/xerus_backend/src/domains/company/channel-execution.service.ts
@@ -50,13 +50,17 @@ export async function triggerChannelExecution(
     agentSlug: string,
     messageContent: string,
     channelSlug: string,
+    triggerType: 'channel_message' | 'task_assigned' = 'channel_message',
 ): Promise<void> {
     // Debounce: prevent concurrent executions for the same agent+channel pair
     if (!acquireLock(userId, agentSlug, channelSlug)) {
-        log.debug('Execution already in progress for agent+channel, skipping', {
+        log.info('Execution locked for agent+channel, writing to inbox instead', {
             channel: channelSlug,
             agent: agentSlug,
+            trigger: triggerType,
         });
+        // Write to agent's inbox so it's picked up on next session start
+        await writeToAgentInbox(provider, sandboxId, agentSlug, messageContent, channelSlug, triggerType);
         return;
     }
 
@@ -88,22 +92,41 @@ export async function triggerChannelExecution(
                 userId,
                 conversationId: conversation.id,
                 context: {
-                    trigger: 'channel_message',
+                    trigger: triggerType,
                     channel_slug: channelSlug,
                 },
             },
             stream,
-            triggerType: 'channel_message',
+            triggerType,
         });
     } finally {
         releaseLock(userId, agentSlug, channelSlug);
     }
 }
 
+async function writeToAgentInbox(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    agentSlug: string,
+    content: string,
+    channelSlug: string,
+    trigger: string,
+): Promise<void> {
+    const ws = SANDBOX_CONFIG.workspacePath;
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const inboxDir = `${ws}/agents/${sanitizeSlug(agentSlug)}/inbox`;
+    const filename = `${ts}-${trigger}.json`;
+    const entry = JSON.stringify({ trigger, channel: channelSlug, content, created_at: new Date().toISOString() });
+    const cmd = `mkdir -p ${shellEscapePath(inboxDir)} && printf '%s\\n' ${shellEscape(entry)} > ${shellEscapePath(`${inboxDir}/${filename}`)}`;
+    await provider.executeCommand(sandboxId, cmd).catch(err => {
+        log.warn('Failed to write to agent inbox', { agent: agentSlug, error: (err as Error).message });
+    });
+}
+
 /**
- * Append a message entry to the channel's posts.jsonl file on sandbox.
- * This is the agent IPC (inter-process communication) dual-write -- agents
- * read posts.jsonl via ChannelWatcher to discover new messages.
+ * @deprecated Posts.jsonl is being replaced by workspace.db channel_messages.
+ * This dual-write is kept as a transition — agents with old prompts still
+ * read posts.jsonl. Remove once all agents read from workspace.db.
  */
 export async function syncMessageToSandbox(
     sandboxService: SandboxService,

--- a/xerus_backend/src/domains/company/company.routes.ts
+++ b/xerus_backend/src/domains/company/company.routes.ts
@@ -453,7 +453,7 @@ router.get('/channels/:channelId/messages', auth, async (req: AuthenticatedReque
             throw new UnauthorizedError();
         }
 
-        const channelId = sanitizeSlug(req.params.channelId);
+        let channelId = sanitizeSlug(req.params.channelId);
         const limit = Math.min(parseInt(req.query.limit as string, 10) || 50, 100);
         const offset = parseInt(req.query.offset as string, 10) || 0;
 
@@ -463,6 +463,16 @@ router.get('/channels/:channelId/messages', auth, async (req: AuthenticatedReque
         const { sandboxService } = companyDeps;
         const sandboxId = await requireRunningSandbox(sandboxService, userId);
         const provider = getDaytonaProvider(sandboxService);
+
+        // Normalize bare slugs to domain--channel format
+        if (!channelId.includes('--')) {
+            const safeCh = channelId.replace(/'/g, "''");
+            const lookupSql = `SELECT slug FROM channels WHERE slug LIKE '%--${safeCh}' OR slug = '${safeCh}' LIMIT 1`;
+            const channelRows = await execWsQuery<{ slug: string }>(provider, sandboxId, lookupSql);
+            if (channelRows.length > 0) {
+                channelId = channelRows[0].slug;
+            }
+        }
 
         // Verify channel exists in workspace DB
         const channelInfo = await getChannelWithDomain(provider, sandboxId, channelId);

--- a/xerus_backend/src/domains/execution/agent-config-resolver.ts
+++ b/xerus_backend/src/domains/execution/agent-config-resolver.ts
@@ -80,6 +80,83 @@ export async function resolveAdapterType(
 }
 
 // -----------------------------------------------------------------------------
+// Platform Rules (injected into every agent's system prompt)
+// -----------------------------------------------------------------------------
+
+const XERUS_MASTER_SLUG = 'xerus-master';
+
+const ORCHESTRATOR_TOOLS = [
+    'create_agent', 'clone_agent', 'update_agent', 'delete_agent',
+    'create_channel', 'add_to_channel', 'create_task',
+    'upload_kb', 'assign_kb',
+    'create_skill', 'install_skill', 'uninstall_skill',
+    'connect_tool', 'register_trigger', 'deregister_trigger',
+    'create_schedule', 'update_schedule', 'delete_schedule',
+].map(t => `mcp__platform__${t}`);
+
+const COMMON_TOOLS = [
+    'search_agents', 'list_agents', 'search_kb',
+    'query_memory', 'write_memory', 'analyze_memory_patterns',
+    'search_outputs', 'send_notification',
+    'get_status', 'get_billing_status',
+    'search_skills', 'search_tools', 'list_domains',
+    'list_triggers', 'list_schedules',
+    'pause_execution', 'resume_execution', 'get_session_state',
+    'complete_session', 'cancel_execution',
+].map(t => `mcp__platform__${t}`);
+
+export function buildPlatformRules(agentSlug: string): string {
+    const isOrchestrator = agentSlug === XERUS_MASTER_SLUG;
+    const tools = isOrchestrator
+        ? [...ORCHESTRATOR_TOOLS, ...COMMON_TOOLS]
+        : COMMON_TOOLS;
+
+    const lines = [
+        '== Platform Rules ==',
+        '',
+        'GOLDEN RULE: MCP tools for anything the USER sees. Filesystem for your own work.',
+        '',
+        'UI-VISIBLE (always use MCP tools):',
+        '  Tasks      → mcp__platform__create_task',
+        '  Channels   → mcp__platform__create_channel',
+        '  Agents     → mcp__platform__create_agent',
+        '  Notify     → mcp__platform__send_notification',
+        '  Activity is AUTOMATIC — every MCP mutation logs an activity entry.',
+        '',
+        'AGENT-INTERNAL (use filesystem):',
+        '  Research, scratch files  → scratch/',
+        '  Deliverables (files)     → output/deliverables/',
+        '  Working memory           → .memory/agents/{your-slug}/working.md',
+        '  Personal subtasks        → beads (only you see these)',
+        '',
+        'NEVER:',
+        '  sqlite3 data/workspace.db "INSERT/UPDATE..."  — bypasses activity logging + SSE',
+        '  Write to output/posts.jsonl                   — deprecated',
+        '  Create agents/channels/tasks via filesystem    — use MCP tools',
+        '',
+        `Your MCP tools: ${tools.join(', ')}`,
+        '',
+    ];
+
+    if (isOrchestrator) {
+        lines.push(
+            'You are the ORCHESTRATOR. You can create agents, channels, tasks, skills.',
+            'Delegate to agents in their channels. Max delegation depth: 3, concurrent: 5.',
+            '',
+        );
+    } else {
+        lines.push(
+            'You are an AGENT. Work within your assigned channel.',
+            'You cannot create agents or modify workspace structure.',
+            'Max delegation depth: 1, concurrent: 2.',
+            '',
+        );
+    }
+
+    return lines.join('\n');
+}
+
+// -----------------------------------------------------------------------------
 // Agent Identity Resolution
 // -----------------------------------------------------------------------------
 
@@ -187,6 +264,9 @@ export async function resolveAgentIdentity(
     if (agentIndex.trim().length > 10) {
         sections.push('== Current Agents ==', agentIndex.trim(), '');
     }
+
+    // Platform rules: concise MCP-first guidance injected for every agent
+    sections.push(buildPlatformRules(agentSlug));
 
     // Module CLAUDE.md last (reference material, lowest priority for context)
     if (moduleContent) {

--- a/xerus_backend/src/domains/execution/queue/execution-lane.types.ts
+++ b/xerus_backend/src/domains/execution/queue/execution-lane.types.ts
@@ -12,6 +12,7 @@ export const TRIGGER_PRIORITIES = {
     user_message: 1, // Highest - user is waiting
     channel_message: 1, // Same priority as user_message - human sent in channel
     mention: 2, // User-initiated via @mention
+    task_assigned: 2, // Task assigned to agent - auto-wakeup
     team: 3, // Another agent delegated
     schedule: 4, // Scheduled trigger
     heartbeat: 5, // Lowest - proactive check

--- a/xerus_backend/src/domains/execution/session-record.ts
+++ b/xerus_backend/src/domains/execution/session-record.ts
@@ -191,7 +191,8 @@ export async function updateSessionRecord(
             log.warn('Post-execution beads sync failed', { error: (err as Error).message });
         }
 
-        // Posts and deliverables surface in feeds that poll independently — fire and forget.
+        // DEPRECATED: posts.jsonl sync is now redundant — MCP mutations auto-log activity.
+        // Kept as safety net for agents still writing to posts.jsonl with old prompts.
         syncPostsJsonlToChannelMessages(provider, ctx.sandboxId).catch(err =>
             log.warn('Post-execution posts sync failed', { error: (err as Error).message }),
         );

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/activity-logger.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/activity-logger.ts
@@ -1,0 +1,36 @@
+import { escapeSQL, executeWorkspaceQuery } from '../../conversations/workspace-db.helpers';
+import type { DaytonaProvider } from '../../sandbox-infra/sandbox/providers/daytona.provider';
+import { logger } from '../../../utils/logger';
+
+const log = logger('activity-logger');
+
+const DEFAULT_SENDER = 'xerus-master';
+
+interface ActivityParams {
+    channelSlug: string;
+    agentSlug?: string;
+    action: string;
+    summary: string;
+}
+
+export async function logMcpActivity(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    params: ActivityParams,
+): Promise<void> {
+    const sender = params.agentSlug || DEFAULT_SENDER;
+    const metadata = JSON.stringify({ action: params.action, auto_logged: true });
+
+    const sql = `INSERT INTO channel_messages (channel_slug, agent_slug, content, message_type, metadata)
+        VALUES ('${escapeSQL(params.channelSlug)}', '${escapeSQL(sender)}', '${escapeSQL(params.summary)}', 'system', '${escapeSQL(metadata)}')`;
+
+    try {
+        await executeWorkspaceQuery(provider, sandboxId, sql);
+    } catch (err) {
+        log.warn('Activity log failed (non-blocking)', {
+            channel: params.channelSlug,
+            action: params.action,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+}

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/agent-management.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/agent-management.routes.ts
@@ -13,6 +13,7 @@ import { SANDBOX_CONFIG } from '../../sandbox-infra/sandbox/sandbox.config';
 import { workspaceSSEBroadcaster } from '../../drive';
 import { assignAgentToChannel, registerAgentInIndex } from '../../company/system-agent-assignment.service';
 import { writeScaffoldFilesToSandbox } from './sandbox-file-writer';
+import { logMcpActivity } from './activity-logger';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_RESULTS = 100;
@@ -63,6 +64,18 @@ function formatAgentListResult(rows: WorkspaceAgentRow[]): McpToolResult {
             total: rows.length,
         },
     };
+}
+
+async function findAgentChannel(
+    provider: ReturnType<typeof getDaytonaProvider>,
+    sandboxId: string,
+    agentSlug: string,
+): Promise<string | null> {
+    const rows = await executeWorkspaceJsonQuery<{ channel_slug: string }>(
+        provider, sandboxId,
+        `SELECT channel_slug FROM channel_members WHERE agent_slug = '${escapeSQL(agentSlug)}' LIMIT 1`,
+    );
+    return rows.length > 0 ? rows[0].channel_slug : null;
 }
 
 const router = Router();
@@ -275,6 +288,15 @@ router.post('/create_agent', async (req: InternalMcpRequest, res: Response, next
             timestamp: new Date().toISOString(),
         });
 
+        const createdChannelRows = await findAgentChannel(provider, sandboxId, agentSlug);
+        if (createdChannelRows) {
+            await logMcpActivity(provider, sandboxId, {
+                channelSlug: createdChannelRows,
+                action: 'agent_created',
+                summary: `Agent "${name}" (@${agentSlug}) created`,
+            });
+        }
+
         res.json(mcpResult);
     } catch (error) {
         next(error);
@@ -374,6 +396,15 @@ router.post('/clone_agent', async (req: InternalMcpRequest, res: Response, next:
             type: 'file_changed', path: `agents/${cloneSlug}/config.json`, action: 'created',
             timestamp: new Date().toISOString(),
         });
+
+        const cloneChannel = await findAgentChannel(provider, sandboxId, source.slug);
+        if (cloneChannel) {
+            await logMcpActivity(provider, sandboxId, {
+                channelSlug: cloneChannel,
+                action: 'agent_cloned',
+                summary: `Agent "${name}" (@${cloneSlug}) cloned from @${source.slug}`,
+            });
+        }
 
         res.json(mcpResult);
     } catch (error) {
@@ -479,6 +510,9 @@ router.post('/delete_agent', async (req: InternalMcpRequest, res: Response, next
             throw new BadRequestError('Agent not found or access denied');
         }
 
+        // Query channel membership BEFORE delete (cascade removes rows)
+        const deleteChannel = await findAgentChannel(provider, sandboxId, slug);
+
         // workspace.db agents table has ON DELETE CASCADE for related tables
         await executeWorkspaceQuery(
             provider, sandboxId,
@@ -497,6 +531,14 @@ router.post('/delete_agent', async (req: InternalMcpRequest, res: Response, next
             type: 'file_changed', path: `agents/${existing[0].slug}`, action: 'deleted',
             timestamp: new Date().toISOString(),
         });
+
+        if (deleteChannel) {
+            await logMcpActivity(provider, sandboxId, {
+                channelSlug: deleteChannel,
+                action: 'agent_deleted',
+                summary: `Agent @${existing[0].slug} removed`,
+            });
+        }
 
         res.json(mcpResult);
     } catch (error) {

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/channel-task.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/channel-task.routes.ts
@@ -12,7 +12,10 @@ import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service
 import { workspaceSSEBroadcaster } from '../../drive';
 import { scaffoldChannel } from '../../company/workspace-scaffold.service';
 import { addSystemAgentsToChannel, assignAgentToChannel } from '../../company/system-agent-assignment.service';
+import { logMcpActivity } from './activity-logger';
+import { logger } from '../../../utils/logger';
 
+const log = logger('channel-task-routes');
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 // ---------------------------------------------------------------------------
@@ -180,6 +183,12 @@ router.post('/create_channel', async (req: InternalMcpRequest, res: Response, ne
             timestamp: new Date().toISOString(),
         });
 
+        await logMcpActivity(provider, sandboxId, {
+            channelSlug,
+            action: 'channel_created',
+            summary: `Channel "${name}" created in ${domainSlug}`,
+        });
+
         res.json(mcpResult);
     } catch (error) {
         next(error);
@@ -245,6 +254,12 @@ router.post('/add_to_channel', async (req: InternalMcpRequest, res: Response, ne
                 role: memberRole || 'member',
             },
         };
+
+        await logMcpActivity(provider, sandboxId, {
+            channelSlug: channel_id,
+            action: 'agent_added_to_channel',
+            summary: `@${agentRows[0].slug} added to #${channel_id} as ${memberRole || 'member'}`,
+        });
 
         res.json(mcpResult);
     } catch (error) {
@@ -380,6 +395,59 @@ router.post('/create_task', async (req: InternalMcpRequest, res: Response, next:
             type: 'file_changed', path: `tasks/${taskId}`, action: 'created',
             timestamp: new Date().toISOString(),
         });
+
+        const assignedLabel = Array.isArray(assigned_agent_ids) && assigned_agent_ids.length > 0
+            ? ` and assigned to @${assigned_agent_ids[0]}`
+            : '';
+        await logMcpActivity(provider, sandboxId, {
+            channelSlug: normalizedChannelId,
+            action: 'task_created',
+            summary: `Task "${title}" created${assignedLabel}`,
+        });
+
+        // Agent wakeup: if task is assigned, trigger execution for the assigned agent
+        if (Array.isArray(assigned_agent_ids) && assigned_agent_ids.length > 0) {
+            const assignedSlug = String(assigned_agent_ids[0]);
+            const taskPrompt = [
+                `You have been assigned a new task:`,
+                ``,
+                `**Title**: ${title}`,
+                description ? `**Description**: ${description}` : '',
+                `**Priority**: ${taskPriority}`,
+                `**Task ID**: ${taskId}`,
+                `**Channel**: ${channel_id}`,
+                ``,
+                `Work on this task now.`,
+            ].filter(Boolean).join('\n');
+
+            try {
+                const { triggerChannelExecution } = await import('../../company/channel-execution.service');
+                const { getExecutionService } = await import('../../execution/execution.routes');
+                const execService = getExecutionService();
+                triggerChannelExecution(
+                    execService,
+                    provider,
+                    sandboxId,
+                    userId,
+                    assignedSlug,
+                    taskPrompt,
+                    normalizedChannelId,
+                    'task_assigned',
+                ).catch(err => {
+                    log.warn('Task-assigned wakeup failed (non-blocking)', {
+                        agent: assignedSlug,
+                        task: taskId,
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                });
+            } catch (err) {
+                log.warn('Task-assigned wakeup skipped (service not ready)', {
+                    agent: assignedSlug,
+                    task: taskId,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            }
+        }
 
         res.json(mcpResult);
     } catch (error) {

--- a/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/channel-claude-md.template.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/channel-claude-md.template.test.ts
@@ -42,8 +42,6 @@ describe('generateChannelClaudeMd', () => {
 
     it('should include channel directory structure', () => {
         const result = generateChannelClaudeMd(DEFAULT_PARAMS);
-        expect(result).toContain('.beads/issues.jsonl');
-        expect(result).toContain('output/posts.jsonl');
         expect(result).toContain('output/deliverables/');
         expect(result).toContain('scratch/');
     });

--- a/xerus_backend/src/domains/sandbox-infra/workspace/channel-claude-md.template.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/channel-claude-md.template.ts
@@ -84,8 +84,6 @@ export function generateChannelClaudeMd(params: ChannelClaudeMdParams): string {
 
     sections.push('## Channel Directories');
     sections.push('');
-    sections.push('- `.beads/issues.jsonl` -- Task board');
-    sections.push('- `output/posts.jsonl` -- Channel posts');
     sections.push('- `output/deliverables/` -- Published files');
     sections.push('- `scratch/` -- Temporary working files');
     sections.push('- `data/` -- Channel data');
@@ -120,9 +118,9 @@ export function generateChannelClaudeMd(params: ChannelClaudeMdParams): string {
     sections.push('## Standup Protocol');
     sections.push('');
     sections.push('When prompted or at session start:');
-    sections.push('1. Read .memory/agents/{your-slug}/working.md');
+    sections.push('1. Your working memory is already in your system prompt');
     sections.push('2. Summarize: completed, planned, blockers');
-    sections.push('3. Post to output/posts.jsonl');
+    sections.push('3. Use `mcp__platform__send_notification` to share updates');
     sections.push('');
 
     if (channelPriorities && channelPriorities.length > 0) {

--- a/xerus_backend/src/domains/sandbox-infra/workspace/operating-md.template.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/operating-md.template.ts
@@ -2,6 +2,9 @@
 // Generates OPERATING.md that teaches agents HOW to operate autonomously.
 // Placed at /workspace/agents/{slug}/OPERATING.md
 // Kept under 800 tokens to respect context budget.
+// NOTE: working.md, expertise.md, agents/index.json, and platform rules
+// are already injected into the system prompt by resolveAgentIdentity().
+// Do NOT tell agents to re-read them here.
 
 // -----------------------------------------------------------------------------
 // Types
@@ -57,22 +60,24 @@ export function generateOperatingMd(params: OperatingMdParams): string {
     sections.push(buildBehaviorSection(params));
     sections.push('');
 
-    // Context Gathering
-    sections.push('## Context Gathering');
+    // Session Start Protocol
+    sections.push('## Session Start');
     sections.push('');
-    sections.push('1. Read `' + memBase + '/agents/' + params.agentSlug + '/working.md` (last session state)');
-    sections.push('2. Read `.beads/issues.jsonl` (task board)');
-    sections.push('3. Read `' + memBase + '/agents/' + params.agentSlug + '/expertise.md` (capabilities)');
+    sections.push('Your working memory, expertise, team roster, and platform rules are already in your system prompt.');
+    sections.push('Do NOT re-read working.md, expertise.md, or agents/index.json — they are already injected.');
+    sections.push('');
+    sections.push('1. Handle the user\'s message immediately');
+    sections.push('2. Read files only when the current task requires them');
+    sections.push('3. Check `agents/' + params.agentSlug + '/inbox/` for coordination messages');
     if (params.channelSlug) {
-        sections.push('4. Read channel CLAUDE.md for mission/priorities');
+        sections.push('4. If channel lead: check for handoffs in `.channel/state/handoffs/`');
     }
-    sections.push('Use Explore subagent for reading >5 files.');
     sections.push('');
 
     // Delegation
     sections.push('## Delegation');
     sections.push('');
-    sections.push('You have SDK-native subagent types via the Task tool:');
+    sections.push('SDK-native subagent types via the Task tool:');
     sections.push('| Type | Purpose |');
     sections.push('|------|---------|');
     sections.push('| Explore | Read-only context gathering |');
@@ -86,18 +91,20 @@ export function generateOperatingMd(params: OperatingMdParams): string {
     sections.push('## Skills First');
     sections.push('');
     sections.push('Before implementing from scratch:');
-    sections.push("1. Search installed skills: `Glob('**/.claude/skills/*/SKILL.md')` (finds both channel and global skills)");
+    sections.push("1. Search installed skills: `Glob('**/.claude/skills/*/SKILL.md')`");
     sections.push('2. If matching skill exists, follow its framework');
     sections.push('');
 
-    // Plan-First Workflow
-    sections.push('## Plan-First Workflow');
+    // Output Rules
+    sections.push('## Output Rules');
     sections.push('');
-    sections.push('For tasks with >3 steps:');
-    sections.push('1. Gather context (Explore subagent)');
-    sections.push('2. Create plan');
-    sections.push('3. Execute step by step');
-    sections.push('4. Verify (general-purpose subagent)');
+    sections.push('Follow the "Platform Rules" section in your system prompt.');
+    sections.push('- Tasks → `mcp__platform__create_task` (NEVER beads for team-visible tasks)');
+    sections.push('- Activity → automatic (every MCP mutation creates an activity entry)');
+    sections.push('- Deliverables → write file to `output/deliverables/`, register via MCP if needed');
+    sections.push('- Status updates → `mcp__platform__send_notification`');
+    sections.push('- Personal subtasks → beads (only you see these)');
+    sections.push('- Notify user → `mcp__platform__send_notification`');
     sections.push('');
 
     // Memory Efficiency
@@ -116,41 +123,14 @@ export function generateOperatingMd(params: OperatingMdParams): string {
     sections.push('2. Address issues before marking complete');
     sections.push('');
 
-    // Session Start Protocol
-    sections.push('## Session Start');
-    sections.push('');
-    sections.push('1. Read `' + memBase + '/agents/' + params.agentSlug + '/.task-context.md` (your assignment)');
-    sections.push('2. If BLOCKED: output blocked message, end session');
-    sections.push('3. If READY: execute the task described, nothing else');
-    sections.push('4. If IDLE: read HEARTBEAT.md for proactive tasks, then read working.md');
-    sections.push('5. Check `agents/' + params.agentSlug + '/inbox/` for coordination messages');
-    if (params.channelSlug) {
-        sections.push('6. If channel lead: check `.channel/state/handoffs/` for recent handoff from previous shift');
-    }
-    sections.push('');
-
     // Channel Lead Duties
     if (params.channelSlug) {
         sections.push('## If Channel Lead');
         sections.push('');
-        sections.push('- On first session of the day: TeamCreate with all channel_members');
         sections.push('- Distribute tasks to teammates via TaskCreate');
         sections.push('- Monitor teammate progress via SendMessage');
-        sections.push('- Run daily standup: collect updates from each agent, post summary');
         sections.push('');
     }
-
-    // Communication
-    sections.push('## Communication');
-    sections.push('');
-    sections.push('- Post updates to `output/posts.jsonl` in your channel');
-    sections.push('- For agent-to-agent: use coordination message with `target_agent` in metadata');
-    sections.push('- For escalation: set `metadata.requires_approval: true`');
-    if (params.channelSlug && params.domainSlug) {
-        sections.push('- For cross-channel: post to target channel\'s `output/posts.jsonl`');
-    }
-    sections.push('- When blocked: write to `agents/xerus-master/inbox/`');
-    sections.push('');
 
     // Before Session End
     sections.push('## Before Session End');

--- a/xerus_backend/src/domains/skills/routes.ts
+++ b/xerus_backend/src/domains/skills/routes.ts
@@ -65,21 +65,20 @@ function normalizeChannelId(channelId: string): string {
         if (!domain || !channel) {
             throw new SkillValidationError([{ field: 'channel_id', message: 'channel_id must be in "domain--channel" or "domain/channel" format' }]);
         }
-        if (!SLUG_PATTERN.test(domain) || !SLUG_PATTERN.test(channel)) {
-            throw new SkillValidationError([{ field: 'channel_id', message: `Invalid slug segment in channel_id` }]);
-        }
         return `${domain}/${channel}`;
     }
-    const parts = channelId.split('/');
-    if (parts.length !== 2 || !parts[0] || !parts[1]) {
-        throw new SkillValidationError([{ field: 'channel_id', message: 'channel_id must be in "domain--channel" or "domain/channel" format' }]);
-    }
-    for (const part of parts) {
-        if (!SLUG_PATTERN.test(part)) {
-            throw new SkillValidationError([{ field: 'channel_id', message: `Invalid slug segment in channel_id` }]);
+    if (channelId.includes('/')) {
+        const parts = channelId.split('/');
+        if (parts.length !== 2 || !parts[0] || !parts[1]) {
+            throw new SkillValidationError([{ field: 'channel_id', message: 'channel_id must be in "domain--channel" or "domain/channel" format' }]);
         }
+        return channelId;
     }
-    return channelId;
+    // Bare slug (e.g. "general") — treat as default domain
+    if (channelId && SLUG_PATTERN.test(channelId)) {
+        return `default/${channelId}`;
+    }
+    throw new SkillValidationError([{ field: 'channel_id', message: 'channel_id must be in "domain--channel" or "domain/channel" format' }]);
 }
 
 // GET /api/v1/skills - Unified: all skills with is_installed flag + categories

--- a/xerus_web/hooks/useChannelData.ts
+++ b/xerus_web/hooks/useChannelData.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 import useSWR from 'swr'
 import { apiGet, apiPost, apiPatch } from '@/lib/api/client'
 import { toast } from '@/lib/toast'
@@ -153,57 +153,50 @@ interface UseChannelTasksReturn {
   refetch: () => void
 }
 
+const TASK_POLL_INTERVAL_MS = 10_000
+
+const fetchChannelTasks = async ([, id]: readonly [string, string]): Promise<KanbanTask[]> => {
+  const result = await apiGet<{ data?: { tasks: KanbanTask[] }; tasks?: KanbanTask[] }>(
+    `/channels/${id}/tasks`,
+  )
+  const payload = result.data ?? result
+  return payload.tasks ?? []
+}
+
 export function useChannelTasks(channelId: string): UseChannelTasksReturn {
-  const [tasks, setTasks] = useState<KanbanTask[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const channelIdRef = useRef(channelId)
-  const inFlightRef = useRef(false)
+  const swrKey = channelId ? (['channel-tasks', channelId] as const) : null
 
-  const fetchTasks = useCallback(async (signal?: AbortSignal) => {
-    if (!channelId) return
-    if (inFlightRef.current) return
-    inFlightRef.current = true
-    setIsLoading(true)
-    setError(null)
-    try {
-      const result = await apiGet<{ data?: { tasks: KanbanTask[] }; tasks?: KanbanTask[] }>(
-        `/channels/${channelId}/tasks`,
-        signal ? { signal } : undefined,
-      )
-      if (signal?.aborted || channelIdRef.current !== channelId) return
-      const payload = result.data ?? result
-      setTasks(payload.tasks ?? [])
-    } catch (err) {
-      if (signal?.aborted || (err instanceof Error && err.name === 'AbortError')) return
-      setError(err instanceof Error ? err.message : 'Failed to fetch tasks')
-    } finally {
-      inFlightRef.current = false
-      if (!signal?.aborted && channelIdRef.current === channelId) {
-        setIsLoading(false)
-      }
-    }
-  }, [channelId])
+  const { data, isLoading, error: swrError, mutate } = useSWR<KanbanTask[]>(
+    swrKey,
+    fetchChannelTasks,
+    {
+      refreshInterval: TASK_POLL_INTERVAL_MS,
+      refreshWhenHidden: false,
+      onErrorRetry: (_err, _key, _config, revalidate, { retryCount }) => {
+        const delay = Math.min(POLL_MAX_BACKOFF_MS, TASK_POLL_INTERVAL_MS * 2 ** retryCount)
+        setTimeout(() => revalidate({ retryCount }), delay)
+      },
+    },
+  )
 
-  useEffect(() => {
-    channelIdRef.current = channelId
-    inFlightRef.current = false
-    const controller = new AbortController()
-    fetchTasks(controller.signal)
-    return () => controller.abort()
-  }, [channelId, fetchTasks])
+  const tasks = data ?? []
+  const error = swrError instanceof Error ? swrError.message : (swrError ? 'Failed to fetch tasks' : null)
 
   const updateTaskStatus = useCallback(async (taskId: string, newStatus: string) => {
-    const previous = tasks
-    setTasks(prev => prev.map(t => (t.id === taskId ? { ...t, status: newStatus } : t)))
-    try {
-      await apiPost(`/tasks/${taskId}/status`, { status: newStatus })
-    } catch (err) {
-      setTasks(previous)
+    await mutate(
+      async (current) => {
+        await apiPost(`/tasks/${taskId}/status`, { status: newStatus })
+        return (current ?? []).map(t => (t.id === taskId ? { ...t, status: newStatus } : t))
+      },
+      {
+        optimisticData: (current) => (current ?? []).map(t => (t.id === taskId ? { ...t, status: newStatus } : t)),
+        rollbackOnError: true,
+        revalidate: false,
+      },
+    ).catch(() => {
       toast.error("Couldn't update that task -- reverting", { description: 'Your changes could not be saved. The task has been restored.' })
-      throw err
-    }
-  }, [tasks])
+    })
+  }, [mutate])
 
   const createTaskFn = useCallback(async (chId: string, payload: CreateTaskPayload): Promise<KanbanTask | null> => {
     try {
@@ -213,14 +206,14 @@ export function useChannelTasks(channelId: string): UseChannelTasksReturn {
       )
       const saved = result.data?.task ?? result.task ?? null
       if (saved) {
-        setTasks(prev => [saved, ...prev])
+        await mutate((current) => [saved, ...(current ?? [])], { revalidate: false })
       }
       return saved
     } catch {
       toast.error("Couldn't create that task", { description: 'Please try again.' })
       return null
     }
-  }, [])
+  }, [mutate])
 
   const updateTaskFn = useCallback(async (taskId: string, payload: UpdateTaskPayload): Promise<KanbanTask | null> => {
     try {
@@ -230,14 +223,14 @@ export function useChannelTasks(channelId: string): UseChannelTasksReturn {
       )
       const updated = result.data?.task ?? result.task ?? null
       if (updated) {
-        setTasks(prev => prev.map(t => (t.id === taskId ? updated : t)))
+        await mutate((current) => (current ?? []).map(t => (t.id === taskId ? updated : t)), { revalidate: false })
       }
       return updated
     } catch {
       toast.error("Couldn't update that task", { description: 'Please try again.' })
       return null
     }
-  }, [])
+  }, [mutate])
 
   const getTaskFn = useCallback(async (taskId: string): Promise<KanbanTask | null> => {
     try {
@@ -250,6 +243,8 @@ export function useChannelTasks(channelId: string): UseChannelTasksReturn {
     }
   }, [])
 
+  const refetch = useCallback(() => { mutate() }, [mutate])
+
   return {
     tasks,
     isLoading,
@@ -258,7 +253,7 @@ export function useChannelTasks(channelId: string): UseChannelTasksReturn {
     createTask: createTaskFn,
     updateTask: updateTaskFn,
     getTask: getTaskFn,
-    refetch: fetchTasks,
+    refetch,
   }
 }
 
@@ -273,45 +268,38 @@ interface UseChannelDeliverablesReturn {
   refetch: () => void
 }
 
+const DELIVERABLE_POLL_INTERVAL_MS = 15_000
+
+const fetchChannelDeliverables = async ([, id]: readonly [string, string]): Promise<Deliverable[]> => {
+  const raw = await apiGet<{ data?: { deliverables: Deliverable[] }; deliverables?: Deliverable[] }>(
+    `/channels/${id}/deliverables`,
+  )
+  const payload = raw.data ?? raw
+  return payload.deliverables ?? []
+}
+
 export function useChannelDeliverables(channelId: string): UseChannelDeliverablesReturn {
-  const [deliverables, setDeliverables] = useState<Deliverable[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const channelIdRef = useRef(channelId)
-  const inFlightRef = useRef(false)
+  const swrKey = channelId ? (['channel-deliverables', channelId] as const) : null
 
-  const fetchDeliverables = useCallback(async (signal?: AbortSignal) => {
-    if (!channelId) return
-    if (inFlightRef.current) return
-    inFlightRef.current = true
-    setIsLoading(true)
-    setError(null)
-    try {
-      const raw = await apiGet<{ data?: { deliverables: Deliverable[] }; deliverables?: Deliverable[] }>(
-        `/channels/${channelId}/deliverables`,
-        signal ? { signal } : undefined,
-      )
-      if (signal?.aborted || channelIdRef.current !== channelId) return
-      const payload = raw.data ?? raw
-      setDeliverables(payload.deliverables ?? [])
-    } catch (err) {
-      if (signal?.aborted || (err instanceof Error && err.name === 'AbortError')) return
-      setError(err instanceof Error ? err.message : 'Failed to fetch deliverables')
-    } finally {
-      inFlightRef.current = false
-      if (!signal?.aborted && channelIdRef.current === channelId) {
-        setIsLoading(false)
-      }
-    }
-  }, [channelId])
+  const { data, isLoading, error: swrError, mutate } = useSWR<Deliverable[]>(
+    swrKey,
+    fetchChannelDeliverables,
+    {
+      refreshInterval: DELIVERABLE_POLL_INTERVAL_MS,
+      refreshWhenHidden: false,
+      onErrorRetry: (_err, _key, _config, revalidate, { retryCount }) => {
+        const delay = Math.min(POLL_MAX_BACKOFF_MS, DELIVERABLE_POLL_INTERVAL_MS * 2 ** retryCount)
+        setTimeout(() => revalidate({ retryCount }), delay)
+      },
+    },
+  )
 
-  useEffect(() => {
-    channelIdRef.current = channelId
-    inFlightRef.current = false
-    const controller = new AbortController()
-    fetchDeliverables(controller.signal)
-    return () => controller.abort()
-  }, [channelId, fetchDeliverables])
+  const refetch = useCallback(() => { mutate() }, [mutate])
 
-  return { deliverables, isLoading, error, refetch: fetchDeliverables }
+  return {
+    deliverables: data ?? [],
+    isLoading,
+    error: swrError instanceof Error ? swrError.message : (swrError ? 'Failed to fetch deliverables' : null),
+    refetch,
+  }
 }


### PR DESCRIPTION
## Summary

- **Dynamic prompt injection**: `buildPlatformRules()` injects role-aware MCP-first rules into every agent's system prompt. Agents get the golden rule, full tool list, and anti-patterns before their first action. No more reading 1000 lines of contradictory rule files.
- **Auto activity logging**: Every MCP mutation (create_task, create_channel, create_agent, add_to_channel, clone_agent, delete_agent) auto-inserts a `channel_messages` row. Activity tab shows agent work without agents manually writing to posts.jsonl.
- **Agent wakeup on task assignment**: `create_task` with `assigned_agent_ids` triggers `triggerChannelExecution()` with `task_assigned` priority. Agents wake autonomously when work arrives. Inbox fallback when agent is busy.
- **Frontend SWR polling**: Tasks (10s), deliverables (15s), messages (8s) now all poll via SWR instead of one-shot fetch.
- **Template cleanup**: operating-md, channel-claude-md, scaffold templates all updated to MCP-first. posts.jsonl references removed from agent-facing prompts.
- **Bug fixes from review**: activity-logger AUTOINCREMENT id fix, sync throw catch in wakeup, bare channel slug normalization in skills + messages endpoints.

## Test plan

- [ ] Deploy and send a message to xerus-master — verify agent doesn't read 10 files at startup
- [ ] Ask xerus-master to create a task with assigned agent — verify task appears on UI task board within 10s
- [ ] Check Activity tab — verify auto-logged "Task created" message appears
- [ ] Verify assigned agent wakes up automatically (check execution logs)
- [ ] Navigate to /inbox channel tabs — verify no skill validation error
- [ ] Switch tabs (Tasks, Activity, Deliverables) — verify data loads
- [ ] Run typecheck in both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvDRY9G1855ASjmU5fGNNk