### PR TITLE
fix: prevent template sync from clobbering MCP server bundle

### DIFF
--- a/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
+++ b/xerus_backend/src/domains/execution/runner/agent-config-loader.ts
@@ -161,9 +161,12 @@ export class AgentConfigLoader {
                 system_prompt = { type: 'preset' as const, preset: 'claude_code' as const, append };
             }
 
-            // Auto-inject platform MCP server for master orchestrator.
-            // The 'stdio' marker is resolved to an in-process SDK MCP server
-            // by ProcessManager.resolveMcpServers() at execution time.
+            // Platform MCP tools are NOT served through this config. The CLI
+            // inside the sandbox discovers them natively via the workspace
+            // .mcp.json (enforced by mcp-config.service.ts), which points the
+            // 'platform' server at .xerus/runner/mcp-server.js (uploaded by
+            // runner-installer.ts). This marker only mirrors that setup for
+            // consumers of AgentConfig.mcp_servers.
             const baseMcpServers = parsed.mcp_servers as Record<string, unknown> | undefined;
             const mcp_servers = isMaster
                 ? { ...baseMcpServers, 'platform': { type: 'stdio' } }

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/__tests__/workspace-template-sync.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/__tests__/workspace-template-sync.test.ts
@@ -1,0 +1,43 @@
+// Workspace Template Sync Tests
+// Guards the platform overlay path list against re-introducing paths that
+// clobber backend-owned sandbox artifacts.
+
+import { listPlatformOverlayPaths } from '../workspace-template-sync';
+
+describe('PLATFORM_OVERLAY_PATHS', () => {
+    // Backend-owned artifacts inside the sandbox that do NOT exist in the
+    // xerus-workspace template. Directory overlays are rm -rf + copy, so any
+    // overlay path covering these destroys them on every resume:
+    // - .xerus/runner/mcp-server.js  — uploaded by runner-installer.ts from
+    //   dist/runner-bundle (the 39 platform MCP tools)
+    // - .xerus/runner/node_modules   — pre-installed by the sandbox snapshot
+    //   (@modelcontextprotocol/sdk, rrule)
+    const BACKEND_OWNED_PATHS = [
+        '.xerus/runner/mcp-server.js',
+        '.xerus/runner/node_modules',
+        '.xerus/runner/package.json',
+    ];
+
+    it('never overlays .xerus or .xerus/runner as whole directories', () => {
+        const paths = listPlatformOverlayPaths();
+        expect(paths).not.toContain('.xerus');
+        expect(paths).not.toContain('.xerus/runner');
+    });
+
+    it('never overlays a path that covers backend-owned runner artifacts', () => {
+        const paths = listPlatformOverlayPaths();
+        for (const backendPath of BACKEND_OWNED_PATHS) {
+            const covering = paths.filter(
+                p => p === backendPath || backendPath.startsWith(`${p}/`),
+            );
+            expect(covering).toEqual([]);
+        }
+    });
+
+    it('still syncs template-owned .xerus content', () => {
+        const paths = listPlatformOverlayPaths();
+        expect(paths).toContain('.xerus/ipc');
+        expect(paths).toContain('.xerus/templates');
+        expect(paths).toContain('.xerus/runner/scheduler.ts');
+    });
+});

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/runner-installer.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/runner-installer.ts
@@ -61,13 +61,16 @@ export async function installRunnerBundle(
     const sandboxFs = await provider.createFileSystem(sandboxId);
     await sandboxFs.mkdir(runnerDir);
 
-    // Upload MCP server bundle (backend-coupled tools)
-    if (fs.existsSync(MCP_BUNDLE_PATH)) {
-        const mcpContent = fs.readFileSync(MCP_BUNDLE_PATH, 'utf-8');
-        await sandboxFs.writeFile(`${runnerDir}/mcp-server.js`, mcpContent);
-    } else {
-        log.error('MCP server bundle not found — platform tools will be unavailable. Run: npm run bundle:runner', { path: MCP_BUNDLE_PATH });
+    // Upload MCP server bundle (backend-coupled tools).
+    // Fail-fast: a sandbox without the platform MCP server silently degrades
+    // agents to raw sqlite3/filesystem writes — better to fail setup loudly.
+    if (!fs.existsSync(MCP_BUNDLE_PATH)) {
+        throw new Error(
+            `MCP server bundle not found at ${MCP_BUNDLE_PATH} — platform tools cannot be served. Run: npm run build:runner`,
+        );
     }
+    const mcpContent = fs.readFileSync(MCP_BUNDLE_PATH, 'utf-8');
+    await sandboxFs.writeFile(`${runnerDir}/mcp-server.js`, mcpContent);
 
     // Verify node_modules exists for pre-installed snapshots.
     // If snapshot is broken (e.g., Dockerfile build failed), deps won't be there.

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
@@ -64,8 +64,9 @@ export async function runAgentSync(
 }
 
 /**
- * Sync Pipedream MCP servers into .mcp.json based on user's connected accounts.
- * Adds entries for connected apps, removes entries for disconnected apps.
+ * Sync MCP servers into .mcp.json: enforces canonical static platform entries
+ * (platform, ipc — including legacy-name migration) and syncs Pipedream entries
+ * from the user's connected accounts.
  * Called at workspace create and resume so agents always have up-to-date MCP tools.
  */
 export async function runMcpConfigSync(
@@ -76,13 +77,14 @@ export async function runMcpConfigSync(
     const sandboxFs = await deps.getSandboxFs(sandboxId);
     const mcpJsonPath = `${SANDBOX_CONFIG.workspacePath}/.mcp.json`;
     const result = await syncPipedreamMcpConfig(sandboxFs, mcpJsonPath, userId, deps.db);
-    if (result.added.length > 0 || result.removed.length > 0) {
+    if (result.added.length > 0 || result.removed.length > 0 || result.normalized.length > 0) {
         log.info('MCP config synced', {
             sandbox_id: sandboxId,
             added: result.added.length,
             added_servers: result.added.join(', ') || 'none',
             removed: result.removed.length,
             removed_servers: result.removed.join(', ') || 'none',
+            normalized_servers: result.normalized.join(', ') || 'none',
             total: result.total,
         });
     }
@@ -122,6 +124,15 @@ export async function runWorkspaceHealthCheck(
             error: (syncErr as Error).message,
         });
     }
+
+    // Re-install the runner bundle on every resume, AFTER template sync.
+    // The bundle (.xerus/runner/mcp-server.js) is backend-owned and must track
+    // the deployed backend version — without this, sandboxes created before a
+    // backend deploy run a stale platform MCP server forever, and any sandbox
+    // whose bundle was lost (e.g. the pre-fix template sync replaced it with
+    // the template stub) never recovers. Cheap: one file upload; npm install
+    // only runs when node_modules is missing.
+    await runRunnerInstall(sandboxId, deps);
 
     // Run schema migrations (init-db.sh) on every resume.
     // S3-restored databases may predate newer schema tables (e.g. file_connections).

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-template-sync.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/workspace-template-sync.ts
@@ -21,9 +21,26 @@ const VALID_GIT_URL_PATTERN = /^https:\/\/[a-zA-Z0-9._-]+\/[a-zA-Z0-9_./-]+\.git
 // removed). Files are replaced as-is. .claude/settings.json is intentionally
 // excluded — it carries personalized env vars and is owned by
 // workspace-personalizer.service.ts.
+//
+// .xerus MUST NOT be overlaid as a whole directory: directory overlays do
+// `rm -rf` + copy, and .xerus/runner contains backend-owned artifacts that do
+// not exist in the template — mcp-server.js (uploaded by runner-installer.ts
+// from dist/runner-bundle) and node_modules (pre-installed by the sandbox
+// snapshot). Blanket-syncing .xerus destroys the platform MCP server on every
+// resume. Template-owned .xerus content is enumerated explicitly instead;
+// new template files under .xerus must be added here to sync.
 const PLATFORM_OVERLAY_PATHS: ReadonlyArray<string> = [
     'CLAUDE.md',
-    '.xerus',
+    '.xerus/ipc',
+    '.xerus/templates',
+    '.xerus/manifest.yaml',
+    '.xerus/version.json',
+    '.xerus/runner/adapters',
+    '.xerus/runner/db.ts',
+    '.xerus/runner/index.ts',
+    '.xerus/runner/scheduler.ts',
+    '.xerus/runner/session-manager.ts',
+    '.xerus/runner/sync-agents-md.py',
     '.claude/skills',
     '.claude/hooks',
     '.claude/rules',

--- a/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/mcp-config.service.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/__tests__/mcp-config.service.test.ts
@@ -1,0 +1,171 @@
+// MCP Config Service Tests
+// Tests for syncPipedreamMcpConfig — static platform server enforcement
+// (canonical entries, legacy-name migration) and Pipedream account sync.
+
+import { syncPipedreamMcpConfig } from '../mcp-config.service';
+import type { SandboxFileSystem } from '../workspace.manager';
+
+const MCP_JSON_PATH = '/workspace/.mcp.json';
+
+const CANONICAL_PLATFORM = { command: 'node', args: ['.xerus/runner/mcp-server.js'], env: {} };
+const CANONICAL_IPC = { command: 'python3', args: ['.xerus/ipc/claude_ipc_server.py'], env: {} };
+
+// In-memory filesystem for testing (no mocks - real data structure)
+function createInMemoryFs(): SandboxFileSystem & { files: Map<string, string>; writeCount: number } {
+    const files = new Map<string, string>();
+
+    const fs = {
+        files,
+        writeCount: 0,
+        async mkdir(): Promise<void> {},
+        async writeFile(path: string, content: string): Promise<void> {
+            fs.writeCount += 1;
+            files.set(path, content);
+        },
+        async readFile(path: string): Promise<string> {
+            const content = files.get(path);
+            if (content === undefined) {
+                throw new Error(`File not found: ${path}`);
+            }
+            return content;
+        },
+        async exists(path: string): Promise<boolean> {
+            return files.has(path);
+        },
+        async rm(path: string): Promise<void> {
+            files.delete(path);
+        },
+        async list(): Promise<string[]> {
+            return [];
+        },
+    };
+    return fs;
+}
+
+// In-memory database returning the given connected app slugs (no mocks)
+function createDb(appSlugs: string[]) {
+    return {
+        async query<T>(): Promise<{ rows: T[] }> {
+            return { rows: appSlugs.map(app_slug => ({ app_slug })) as T[] };
+        },
+    };
+}
+
+function readServers(fs: { files: Map<string, string> }): Record<string, { command?: string; args?: string[]; url?: string }> {
+    const raw = fs.files.get(MCP_JSON_PATH);
+    if (raw === undefined) throw new Error('.mcp.json was not written');
+    return (JSON.parse(raw) as { mcpServers: Record<string, { command?: string; args?: string[]; url?: string }> }).mcpServers;
+}
+
+describe('syncPipedreamMcpConfig — static server enforcement', () => {
+    it('renames legacy xerus-platform entry to canonical platform', async () => {
+        const fs = createInMemoryFs();
+        fs.files.set(MCP_JSON_PATH, JSON.stringify({
+            mcpServers: {
+                'xerus-platform': CANONICAL_PLATFORM,
+                ipc: CANONICAL_IPC,
+            },
+        }));
+
+        const result = await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb([]));
+
+        expect(result.normalized).toContain('xerus-platform');
+        expect(result.normalized).toContain('platform');
+        const servers = readServers(fs);
+        expect(servers['xerus-platform']).toBeUndefined();
+        expect(servers['platform']).toEqual(CANONICAL_PLATFORM);
+        expect(servers['ipc']).toEqual(CANONICAL_IPC);
+    });
+
+    it('adds missing static entries when .mcp.json lacks them', async () => {
+        const fs = createInMemoryFs();
+        fs.files.set(MCP_JSON_PATH, JSON.stringify({ mcpServers: {} }));
+
+        const result = await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb([]));
+
+        expect(result.normalized).toEqual(expect.arrayContaining(['platform', 'ipc']));
+        const servers = readServers(fs);
+        expect(servers['platform']).toEqual(CANONICAL_PLATFORM);
+        expect(servers['ipc']).toEqual(CANONICAL_IPC);
+    });
+
+    it('creates .mcp.json with static entries when the file is missing', async () => {
+        const fs = createInMemoryFs();
+
+        const result = await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb([]));
+
+        expect(result.normalized).toEqual(expect.arrayContaining(['platform', 'ipc']));
+        const servers = readServers(fs);
+        expect(servers['platform']).toEqual(CANONICAL_PLATFORM);
+        expect(servers['ipc']).toEqual(CANONICAL_IPC);
+    });
+
+    it('repairs a platform entry whose command/args drifted', async () => {
+        const fs = createInMemoryFs();
+        fs.files.set(MCP_JSON_PATH, JSON.stringify({
+            mcpServers: {
+                platform: { command: 'node', args: ['some/other/path.js'], env: {} },
+                ipc: CANONICAL_IPC,
+            },
+        }));
+
+        const result = await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb([]));
+
+        expect(result.normalized).toEqual(['platform']);
+        expect(readServers(fs)['platform']).toEqual(CANONICAL_PLATFORM);
+    });
+
+    it('does not write when config is already canonical (idempotent)', async () => {
+        const fs = createInMemoryFs();
+        fs.files.set(MCP_JSON_PATH, JSON.stringify({
+            mcpServers: { platform: CANONICAL_PLATFORM, ipc: CANONICAL_IPC },
+        }));
+
+        const result = await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb([]));
+
+        expect(result.normalized).toEqual([]);
+        expect(result.added).toEqual([]);
+        expect(result.removed).toEqual([]);
+        expect(fs.writeCount).toBe(0);
+    });
+
+    it('preserves user-defined non-platform entries', async () => {
+        const custom = { command: 'npx', args: ['-y', 'some-custom-server'] };
+        const fs = createInMemoryFs();
+        fs.files.set(MCP_JSON_PATH, JSON.stringify({
+            mcpServers: { 'my-custom': custom, 'xerus-platform': CANONICAL_PLATFORM },
+        }));
+
+        await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb([]));
+
+        const servers = readServers(fs);
+        expect(servers['my-custom']).toEqual(custom);
+        expect(servers['platform']).toEqual(CANONICAL_PLATFORM);
+    });
+});
+
+describe('syncPipedreamMcpConfig — Pipedream account sync', () => {
+    // Same base URL resolution as the service (env-dependent)
+    const PIPEDREAM_BASE = process.env.PIPEDREAM_MCP_URL || 'https://mcp.pipedream.com';
+
+    it('adds entries for connected apps and removes stale Pipedream entries', async () => {
+        const fs = createInMemoryFs();
+        fs.files.set(MCP_JSON_PATH, JSON.stringify({
+            mcpServers: {
+                platform: CANONICAL_PLATFORM,
+                ipc: CANONICAL_IPC,
+                slack: { type: 'sse', url: `${PIPEDREAM_BASE}/user-1/slack` },
+            },
+        }));
+
+        const result = await syncPipedreamMcpConfig(fs, MCP_JSON_PATH, 'user-1', createDb(['gmail']));
+
+        expect(result.added).toEqual(['gmail']);
+        expect(result.removed).toEqual(['slack']);
+        const servers = readServers(fs);
+        expect(servers['gmail']).toEqual({ type: 'sse', url: `${PIPEDREAM_BASE}/user-1/gmail` });
+        expect(servers['slack']).toBeUndefined();
+        expect(servers['platform']).toEqual(CANONICAL_PLATFORM);
+        expect(servers['ipc']).toEqual(CANONICAL_IPC);
+    });
+});

--- a/xerus_backend/src/domains/sandbox-infra/workspace/mcp-config.service.ts
+++ b/xerus_backend/src/domains/sandbox-infra/workspace/mcp-config.service.ts
@@ -29,8 +29,27 @@ export interface McpConfigDatabase {
 export interface McpSyncResult {
     added: string[];
     removed: string[];
+    normalized: string[];
     total: number;
 }
+
+// -----------------------------------------------------------------------------
+// Static platform servers
+// -----------------------------------------------------------------------------
+
+// Canonical static (stdio) MCP servers owned by the platform. The template's
+// .mcp.json seeds these at clone time; sync re-enforces them so sandboxes
+// created from older templates converge without manual intervention.
+// Tool names derive from the server key (mcp__<server>__<tool>), so a stale
+// key breaks every prompt and allowlist that references mcp__platform__*.
+const STATIC_MCP_SERVERS: Record<string, McpServerEntry> = {
+    platform: { command: 'node', args: ['.xerus/runner/mcp-server.js'], env: {} },
+    ipc: { command: 'python3', args: ['.xerus/ipc/claude_ipc_server.py'], env: {} },
+};
+
+// Server keys used for static servers in older template versions.
+// Renamed entries are removed and replaced by their canonical key.
+const LEGACY_STATIC_SERVER_NAMES: ReadonlyArray<string> = ['xerus-platform'];
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -59,6 +78,12 @@ function buildPipedreamEntry(userId: string, appSlug: string): McpServerEntry {
 }
 
 function readMcpConfig(raw: string): McpConfigDocument {
+    // Empty file ≡ missing file: nothing to preserve, start fresh so static
+    // server enforcement can seed it. Malformed non-empty JSON still throws
+    // (fail-fast — never silently discard a config we cannot parse).
+    if (raw.trim() === '') {
+        return { mcpServers: {} };
+    }
     const parsed = JSON.parse(raw) as Partial<McpConfigDocument>;
     return {
         mcpServers: parsed.mcpServers && typeof parsed.mcpServers === 'object'
@@ -67,15 +92,47 @@ function readMcpConfig(raw: string): McpConfigDocument {
     };
 }
 
+/**
+ * Enforce canonical static server entries in-place.
+ * - Drops legacy-named entries (e.g. 'xerus-platform' from older templates).
+ * - Adds missing canonical entries and repairs entries whose command/args drifted.
+ * Returns the list of server keys that changed.
+ */
+function normalizeStaticServers(doc: McpConfigDocument): string[] {
+    const changed: string[] = [];
+
+    for (const legacyName of LEGACY_STATIC_SERVER_NAMES) {
+        if (doc.mcpServers[legacyName]) {
+            delete doc.mcpServers[legacyName];
+            changed.push(legacyName);
+        }
+    }
+
+    for (const [name, canonical] of Object.entries(STATIC_MCP_SERVERS)) {
+        const existing = doc.mcpServers[name];
+        const matches = existing
+            && existing.command === canonical.command
+            && JSON.stringify(existing.args) === JSON.stringify(canonical.args);
+        if (!matches) {
+            doc.mcpServers[name] = { ...canonical };
+            changed.push(name);
+        }
+    }
+
+    return changed;
+}
+
 // -----------------------------------------------------------------------------
 // Core Sync Logic
 // -----------------------------------------------------------------------------
 
 /**
- * Sync Pipedream MCP servers into .mcp.json.
- * - Adds entries for connected accounts not yet present.
- * - Removes entries for disconnected accounts.
- * - Preserves static (non-Pipedream) entries untouched.
+ * Sync MCP servers into .mcp.json.
+ * - Enforces canonical static platform entries (platform, ipc), including
+ *   renaming legacy keys from older workspace templates.
+ * - Adds Pipedream entries for connected accounts not yet present.
+ * - Removes Pipedream entries for disconnected accounts.
+ * - Preserves other user-defined entries untouched.
  *
  * Idempotent: safe to call repeatedly. Only writes if changes detected.
  */
@@ -104,7 +161,10 @@ export async function syncPipedreamMcpConfig(
     const added: string[] = [];
     const removed: string[] = [];
 
-    // 3. Add MCP servers for connected apps not yet in config
+    // 3. Enforce canonical static platform servers (self-heals stale/legacy entries)
+    const normalized = normalizeStaticServers(doc);
+
+    // 4. Add MCP servers for connected apps not yet in config
     for (const appSlug of connectedApps) {
         if (!doc.mcpServers[appSlug]) {
             doc.mcpServers[appSlug] = buildPipedreamEntry(userId, appSlug);
@@ -112,7 +172,7 @@ export async function syncPipedreamMcpConfig(
         }
     }
 
-    // 4. Remove stale Pipedream entries (disconnected accounts)
+    // 5. Remove stale Pipedream entries (disconnected accounts)
     for (const [key, entry] of Object.entries(doc.mcpServers)) {
         if (isPipedreamEntry(entry) && !connectedApps.has(key)) {
             delete doc.mcpServers[key];
@@ -120,13 +180,13 @@ export async function syncPipedreamMcpConfig(
         }
     }
 
-    // 5. Write back only if changed
-    if (added.length > 0 || removed.length > 0) {
+    // 6. Write back only if changed
+    if (added.length > 0 || removed.length > 0 || normalized.length > 0) {
         await sandboxFs.writeFile(mcpJsonPath, JSON.stringify(doc, null, 2) + '\n');
     }
 
     const pipedreamCount = Object.values(doc.mcpServers).filter(isPipedreamEntry).length;
-    return { added, removed, total: pipedreamCount };
+    return { added, removed, normalized, total: pipedreamCount };
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Root cause**: Workspace template sync replaced `.xerus/runner/` (the real 39-tool MCP server bundle) with a 734-byte stub on every sandbox resume, permanently breaking platform tool access for agents
- **Fix**: Replace blanket `.xerus` overlay with explicit file entries, re-install runner bundle in health check, enforce canonical MCP server names, fail-fast on missing bundle
- **Impact**: Agents fell back to raw sqlite3/bash instead of using create_task, update_task, and 37 other platform tools

## Changes (7 files, +330/-22)
- `workspace-template-sync.ts`: Replace `.xerus` blanket overlay with explicit file-level entries excluding runner bundle
- `sandbox-setup.ts`: Re-run `installRunnerBundle` after template sync in health check
- `runner-installer.ts`: Fail-fast when bundle missing (was silent log), fix script name `bundle:runner` → `build:runner`
- `mcp-config.service.ts`: Enforce canonical static MCP servers (platform, ipc), migrate legacy `xerus-platform` name
- `agent-config-loader.ts`: Clean up misleading `resolveMcpServers()` comment
- 2 new test files for template sync exclusions and MCP config normalization

## Test plan
- [ ] Run new tests: `npx jest workspace-template-sync mcp-config.service --no-coverage`
- [ ] Deploy to staging, resume a sandbox, verify `.xerus/runner/mcp-server.js` is the real bundle (not 734-byte stub)
- [ ] Trigger agent chat, verify agent uses `create_task` MCP tool (not raw sqlite3)
- [ ] Run `/api-test prod` to verify no regression
- [ ] Verify `.mcp.json` has `platform` (not `xerus-platform`) server entry after resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCxWRZz5sJhC7cvK8wdTU2