### PR TITLE
Pipedream tool webhooks, wake-daemon scheduling, company business data, drive scan

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -4,6 +4,16 @@
 E2E_BASE_URL=http://localhost:3005
 E2E_API_URL=http://localhost:5001/api/v1
 
+# Internal schedule-fire endpoint (seam.api.test.ts).
+# E2E_INTERNAL_URL is optional — defaults to E2E_API_URL with /api/v1 stripped + /internal/v1.
+# XERUS_INTERNAL_API_TOKEN must match xerus_backend/.env (loaded automatically by playwright.config).
+E2E_INTERNAL_URL=http://localhost:5001/internal/v1
+XERUS_INTERNAL_API_TOKEN=
+
+# Set to 1 to run the full seam chain (real Daytona sandbox + real agent run).
+# Leave unset for the deterministic fire-endpoint contract only.
+E2E_RUN_SEAM=
+
 # Test user (must exist in Firebase + Neon DB)
 E2E_TEST_USER_EMAIL=
 E2E_TEST_USER_UID=

--- a/e2e/api/seam.api.test.ts
+++ b/e2e/api/seam.api.test.ts
@@ -1,0 +1,379 @@
+// Seam E2E test — the platform release gate (plan Task 1.3).
+//
+// Walks the landing-page sentence end-to-end:
+//   schedule fires -> POST /internal/v1/schedules/fire -> executionService.startExecution
+//     -> execution_sessions row (Neon)         (e)
+//     -> channel_messages row from the agent   (a)
+//     -> task board mutation                   (b)
+//     -> deliverable file in the workspace     (c)
+//     -> workspace.db inbox_items row          (d)
+//
+// Two layers, both real services / no mocks (CLAUDE.md):
+//
+//   1. "Fire endpoint contract" — deterministic. Exercises Task S.1's internal
+//      endpoint directly: auth (timing-safe token compare), field validation,
+//      and (schedule_id, scheduled_for) idempotency. Runs in CI without a
+//      Daytona sandbox because the endpoint returns 200 synchronously and the
+//      async startExecution rejection is swallowed by the handler. This is the
+//      gate that always runs.
+//
+//   2. "Full seam chain" — opt-in via E2E_RUN_SEAM=1, requires a real running
+//      sandbox + a real agent (staging Daytona). Fires the endpoint for a real
+//      agent and asserts all five artifacts land. Skips cleanly when the
+//      sandbox is unavailable so local `test:api` runs stay green.
+
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { getFirebaseIdToken, authHeader } from '../shared/auth'
+import { db } from '../shared/db'
+import { CONFIG } from '../shared/config'
+import { unwrap } from '../shared/api-helpers'
+
+const API = CONFIG.apiURL
+const FIRE_URL = `${CONFIG.internal.url}/schedules/fire`
+const INTERNAL_TOKEN = CONFIG.internal.token
+
+// A slug that intentionally matches no agent. The endpoint fires
+// startExecution asynchronously; with a non-existent agent it fails fast at
+// loadAgent (no LLM run, no cost) while the HTTP contract stays deterministic.
+const SENTINEL_AGENT = '__e2e_seam_probe_agent__'
+
+interface FireResponse {
+  success: boolean
+  execution_id?: string
+  duplicate?: boolean
+  error?: string
+}
+
+function validFireBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const now = new Date().toISOString()
+  return {
+    schedule_id: `e2e-sched-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    agent_slug: SENTINEL_AGENT,
+    prompt: '[E2E seam probe] no-op — agent does not exist',
+    scheduled_for: now,
+    user_id: CONFIG.testUser.uid,
+    ...overrides,
+  }
+}
+
+async function fire(
+  request: APIRequestContext,
+  body: Record<string, unknown>,
+  token: string | null = INTERNAL_TOKEN,
+): Promise<{ status: number; body: FireResponse }> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token !== null) headers.Authorization = `Bearer ${token}`
+  const resp = await request.post(FIRE_URL, { headers, data: body })
+  return { status: resp.status(), body: (await resp.json()) as FireResponse }
+}
+
+// -----------------------------------------------------------------------------
+// Layer 1 — Fire endpoint contract (Task S.1). Deterministic, no sandbox needed.
+// -----------------------------------------------------------------------------
+
+test.describe('Seam: internal schedule-fire endpoint contract', () => {
+  test('rejects a request with no bearer token → 401', async ({ request }) => {
+    const { status, body } = await fire(request, validFireBody(), null)
+    expect(status).toBe(401)
+    expect(body.success).toBe(false)
+  })
+
+  test('rejects a request with a wrong token → 401', async ({ request }) => {
+    const { status, body } = await fire(request, validFireBody(), 'not-the-real-token')
+    expect(status).toBe(401)
+    expect(body.success).toBe(false)
+  })
+
+  test('rejects missing required fields → 400', async ({ request }) => {
+    if (!INTERNAL_TOKEN) {
+      test.skip(true, 'XERUS_INTERNAL_API_TOKEN not set — cannot pass auth to reach validation')
+      return
+    }
+    const requiredFields = ['schedule_id', 'agent_slug', 'prompt', 'user_id', 'scheduled_for']
+    for (const field of requiredFields) {
+      const body = validFireBody()
+      delete body[field]
+      const { status, body: resBody } = await fire(request, body)
+      expect(status, `omitting ${field} should be rejected`).toBe(400)
+      expect(resBody.success).toBe(false)
+      expect(resBody.error, `error should name ${field}`).toContain(field)
+    }
+  })
+
+  test('accepts a valid fire → 200 with a fresh execution_id', async ({ request }) => {
+    if (!INTERNAL_TOKEN) {
+      test.skip(true, 'XERUS_INTERNAL_API_TOKEN not set')
+      return
+    }
+    const { status, body } = await fire(request, validFireBody())
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.execution_id).toBeTruthy()
+    expect(body.duplicate).toBe(false)
+  })
+
+  test('is idempotent on (schedule_id, scheduled_for) → duplicate returns the same execution', async ({ request }) => {
+    if (!INTERNAL_TOKEN) {
+      test.skip(true, 'XERUS_INTERNAL_API_TOKEN not set')
+      return
+    }
+    const body = validFireBody()
+
+    const first = await fire(request, body)
+    expect(first.status).toBe(200)
+    expect(first.body.duplicate).toBe(false)
+    const executionId = first.body.execution_id
+    expect(executionId).toBeTruthy()
+
+    // Same (schedule_id, scheduled_for) → must NOT start a second execution.
+    const second = await fire(request, body)
+    expect(second.status).toBe(200)
+    expect(second.body.duplicate).toBe(true)
+    expect(second.body.execution_id).toBe(executionId)
+
+    // A different scheduled_for is a distinct occurrence → new execution id.
+    const nextOccurrence = await fire(request, {
+      ...body,
+      scheduled_for: new Date(Date.now() + 60_000).toISOString(),
+    })
+    expect(nextOccurrence.status).toBe(200)
+    expect(nextOccurrence.body.duplicate).toBe(false)
+    expect(nextOccurrence.body.execution_id).not.toBe(executionId)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Layer 2 — Full seam chain. Opt-in (E2E_RUN_SEAM=1) + real sandbox required.
+// -----------------------------------------------------------------------------
+
+const RUN_SEAM = process.env.E2E_RUN_SEAM === '1'
+
+// The scheduled run's prompt: instruct the agent to touch every seam so the
+// five artifacts are produced. Todos are authoritative — the agent must not
+// stop until all four outputs exist.
+const SEAM_PROMPT = [
+  '[E2E seam gate] Perform ALL of the following now, in order, then stop:',
+  '1. Post a short status message to your primary channel announcing you have started this scheduled run.',
+  '2. Create one task on the company board titled "E2E seam gate deliverable".',
+  '3. Produce a deliverable file named "e2e-seam-report.md" with a one-paragraph summary of this run.',
+  '4. Send an inbox notification to the user confirming the run is complete.',
+  'Do not ask the user for anything. Complete every step before ending.',
+].join('\n')
+
+const SEAM_TIMEOUT_MS = 8 * 60_000
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+interface ScheduleSessionRow {
+  id: string
+  status: string
+  trigger_type: string
+  agent_slug: string
+  [key: string]: unknown
+}
+
+test.describe('Seam: full chain (schedule → channel message + task + deliverable + inbox + session)', () => {
+  test.skip(!RUN_SEAM, 'Set E2E_RUN_SEAM=1 with a staging Daytona sandbox to run the full seam gate')
+
+  test.setTimeout(SEAM_TIMEOUT_MS + 60_000)
+
+  let token: string
+  let headers: Record<string, string>
+
+  test.beforeAll(async () => {
+    if (!INTERNAL_TOKEN) throw new Error('XERUS_INTERNAL_API_TOKEN required for the full seam gate')
+    token = await getFirebaseIdToken()
+    headers = authHeader(token)
+  })
+
+  test('a scheduled fire produces all five seam artifacts', async ({ request }) => {
+    const uid = CONFIG.testUser.uid
+
+    // Pick a real, non-system agent to run the schedule.
+    const agents = await db.findAll<{ slug: string; agent_type?: string; is_system?: boolean }>(
+      'agent_registry',
+      { user_id: uid },
+    )
+    const agent = agents.find((a) => a.slug !== 'xerus-master' && a.agent_type !== 'system' && a.is_system !== true)
+      ?? agents[0]
+    if (!agent) {
+      test.skip(true, 'Test user has no agents — cannot run the seam gate')
+      return
+    }
+    const agentSlug = agent.slug
+
+    // Create the schedule via the platform tool route. A 503 here means no
+    // running sandbox is available — skip rather than fail a local run.
+    const scheduledFor = new Date(Date.now() + 60_000)
+    const createResp = await request.post(`${API}/execute/schedules`, {
+      headers,
+      data: {
+        agent_slug: agentSlug,
+        name: `e2e-seam-gate-${Date.now()}`,
+        prompt: SEAM_PROMPT,
+        rrule: 'FREQ=MINUTELY;INTERVAL=1',
+      },
+    })
+    if (createResp.status() === 503) {
+      test.skip(true, 'Sandbox unavailable (503) — full seam gate needs a running staging sandbox')
+      return
+    }
+    expect(createResp.status(), 'schedule create').toBe(201)
+    const created = await unwrap<{ schedule: { id: string } }>(createResp)
+    const scheduleId = created.schedule.id
+
+    // Baselines so we assert deltas rather than absolute counts (the workspace
+    // may already contain items from earlier runs).
+    const baseline = await captureBaseline(request, headers, agentSlug)
+    const fireStartIso = new Date(Date.now() - 2_000).toISOString()
+
+    try {
+      // Fire the schedule directly through the internal endpoint — exactly what
+      // the in-sandbox 9to5 daemon does when an occurrence comes due.
+      const { status, body } = await fire(request, {
+        schedule_id: scheduleId,
+        agent_slug: agentSlug,
+        prompt: SEAM_PROMPT,
+        scheduled_for: scheduledFor.toISOString(),
+        user_id: uid,
+      })
+      expect(status, 'fire accepted').toBe(200)
+      expect(body.success).toBe(true)
+      const executionId = body.execution_id
+      expect(executionId).toBeTruthy()
+
+      // (e) obs / execution_sessions row — the schedule-triggered session in Neon.
+      const session = await pollScheduleSession(uid, agentSlug, fireStartIso, SEAM_TIMEOUT_MS)
+      expect(session, 'schedule-triggered execution_sessions row').toBeTruthy()
+      expect(session!.trigger_type).toBe('schedule')
+      expect(['completed', 'running', 'failed']).toContain(session!.status)
+      // A failed run cannot have produced downstream artifacts — surface it loudly.
+      expect(session!.status, 'scheduled run must not fail').not.toBe('failed')
+
+      // Give post-execution workspace.db syncs a moment to land.
+      await sleep(5_000)
+
+      // (b) task board mutation.
+      const tasksAfter = await countTasks(request, headers)
+      expect(tasksAfter, 'task board grew').toBeGreaterThan(baseline.tasks)
+
+      // (d) workspace.db inbox_items row.
+      const inboxAfter = await countInbox(request, headers)
+      expect(inboxAfter, 'inbox item written').toBeGreaterThan(baseline.inbox)
+
+      // (a) channel_messages row from the agent + (c) deliverable file.
+      const { agentMessages, deliverables } = await scanChannels(request, headers, agentSlug)
+      expect(agentMessages, 'channel message from the agent').toBeGreaterThan(baseline.agentMessages)
+      expect(deliverables, 'deliverable produced').toBeGreaterThan(baseline.deliverables)
+    } finally {
+      await request.delete(`${API}/execute/schedules/${scheduleId}`, { headers }).catch(() => {})
+    }
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Full-seam helpers
+// -----------------------------------------------------------------------------
+
+interface Baseline {
+  tasks: number
+  inbox: number
+  agentMessages: number
+  deliverables: number
+}
+
+async function captureBaseline(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  agentSlug: string,
+): Promise<Baseline> {
+  const [tasks, inbox, channels] = await Promise.all([
+    countTasks(request, headers),
+    countInbox(request, headers),
+    scanChannels(request, headers, agentSlug),
+  ])
+  return { tasks, inbox, agentMessages: channels.agentMessages, deliverables: channels.deliverables }
+}
+
+async function countTasks(request: APIRequestContext, headers: Record<string, string>): Promise<number> {
+  const resp = await request.get(`${API}/tasks?limit=100`, { headers })
+  if (resp.status() !== 200) return 0
+  const data = await unwrap<{ tasks: unknown[] }>(resp)
+  return data.tasks?.length ?? 0
+}
+
+async function countInbox(request: APIRequestContext, headers: Record<string, string>): Promise<number> {
+  const resp = await request.get(`${API}/inbox?limit=100`, { headers })
+  if (resp.status() !== 200) return 0
+  const data = await unwrap<{ items: unknown[]; total: number }>(resp)
+  return data.total ?? data.items?.length ?? 0
+}
+
+// Walk every domain/channel and count (a) messages authored by the agent and
+// (c) deliverables. Channel discovery mirrors what the Inbox/Channels UI does.
+async function scanChannels(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  agentSlug: string,
+): Promise<{ agentMessages: number; deliverables: number }> {
+  const domainsResp = await request.get(`${API}/company/domains`, { headers })
+  if (domainsResp.status() !== 200) return { agentMessages: 0, deliverables: 0 }
+  const { domains } = await unwrap<{ domains: Array<{ channels: Array<{ id: string }> }> }>(domainsResp)
+
+  const channelIds = domains.flatMap((d) => d.channels.map((c) => c.id))
+  let agentMessages = 0
+  let deliverables = 0
+
+  for (const channelId of channelIds) {
+    const encoded = encodeURIComponent(channelId)
+
+    const msgResp = await request.get(`${API}/company/channels/${encoded}/messages?limit=100`, { headers })
+    if (msgResp.status() === 200) {
+      const { messages } = await unwrap<{ messages: Array<{ sender_slug: string; sender_type: string }> }>(msgResp)
+      agentMessages += messages.filter((m) => m.sender_type !== 'human' && m.sender_slug === agentSlug).length
+    }
+
+    const delResp = await request.get(`${API}/company/channels/${encoded}/deliverables?limit=100`, { headers })
+    if (delResp.status() === 200) {
+      const { deliverables: rows } = await unwrap<{ deliverables: unknown[] }>(delResp)
+      deliverables += rows?.length ?? 0
+    }
+  }
+
+  return { agentMessages, deliverables }
+}
+
+// Poll Neon for the schedule-triggered execution_sessions row created by this fire.
+async function pollScheduleSession(
+  userId: string,
+  agentSlug: string,
+  sinceIso: string,
+  timeoutMs: number,
+): Promise<ScheduleSessionRow | null> {
+  const deadline = Date.now() + timeoutMs
+  let latest: ScheduleSessionRow | null = null
+
+  while (Date.now() < deadline) {
+    const rows = await db.query<ScheduleSessionRow>(
+      `SELECT es.id, es.status, es.trigger_type, es.agent_slug
+       FROM execution_sessions es
+       JOIN workspaces w ON es.workspace_id::text = w.id::text
+       WHERE w.user_id = $1
+         AND es.agent_slug = $2
+         AND es.trigger_type = 'schedule'
+         AND es.created_at >= $3
+       ORDER BY es.created_at DESC
+       LIMIT 1`,
+      [userId, agentSlug, sinceIso],
+    )
+    if (rows.length > 0) {
+      latest = rows[0]
+      // Terminal states end the poll; a 'running' row keeps polling until it settles.
+      if (latest.status === 'completed' || latest.status === 'failed') return latest
+    }
+    await sleep(5_000)
+  }
+  return latest
+}

--- a/e2e/shared/config.ts
+++ b/e2e/shared/config.ts
@@ -2,9 +2,21 @@ import path from 'path'
 
 const BACKEND_DIR = path.resolve(__dirname, '../../xerus_backend')
 
+const API_URL = process.env.E2E_API_URL || 'http://localhost:5001/api/v1'
+
 export const CONFIG = {
   baseURL: process.env.E2E_BASE_URL || 'http://localhost:3002',
-  apiURL: process.env.E2E_API_URL || 'http://localhost:5001/api/v1',
+  apiURL: API_URL,
+
+  // Internal (sandbox-to-backend) API. The 9to5 schedule daemon POSTs
+  // /internal/v1/schedules/fire here with the shared internal token.
+  // Derived from apiURL by stripping the /api/v1 suffix unless overridden.
+  internal: {
+    url:
+      process.env.E2E_INTERNAL_URL ||
+      API_URL.replace(/\/api\/v1\/?$/, '') + '/internal/v1',
+    token: process.env.XERUS_INTERNAL_API_TOKEN || '',
+  },
 
   testUser: {
     email: process.env.E2E_TEST_USER_EMAIL || '',

--- a/xerus_backend/.env.example
+++ b/xerus_backend/.env.example
@@ -92,6 +92,10 @@ ALLOWED_ORIGINS=http://localhost:3002
 
 # Webhooks
 WEBHOOK_BASE_URL=http://localhost:3001/api/v1/webhooks
+# Pipedream Connect project webhook signing key. Used to verify the x-pd-signature
+# HMAC on POST /api/v1/tools/webhook/connected (account connection events) and on
+# trigger event webhooks. Copy it from the Pipedream project webhook settings.
+# Required: the connection webhook fail-fasts (500) rather than skip verification.
 PIPEDREAM_WEBHOOK_SECRET=
 
 # API

--- a/xerus_backend/package.json
+++ b/xerus_backend/package.json
@@ -9,6 +9,7 @@
     "test": "jest --runInBand --forceExit",
     "test:watch": "jest --watch --runInBand",
     "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",
     "sync-apps": "ts-node --transpile-only src/scripts/syncPipedreamApps.ts",
     "build:runner": "ts-node --transpile-only scripts/bundle-runner.ts",

--- a/xerus_backend/src/database/migrations/095_sandbox_wake_schedule.sql
+++ b/xerus_backend/src/database/migrations/095_sandbox_wake_schedule.sql
@@ -1,0 +1,14 @@
+-- Migration: 095_sandbox_wake_schedule.sql
+-- Alarm clock table: one row per sandbox with the earliest due schedule time.
+-- The wake-daemon scans this table (indexed on next_wake_at) to wake sleeping
+-- sandboxes before their schedules are due.
+
+CREATE TABLE IF NOT EXISTS sandbox_wake_schedule (
+    sandbox_id   TEXT PRIMARY KEY,
+    user_id      TEXT NOT NULL,
+    next_wake_at TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_wake_next ON sandbox_wake_schedule (next_wake_at)
+    WHERE next_wake_at IS NOT NULL;

--- a/xerus_backend/src/database/migrations/096_relax_memory_search_index_constraints.sql
+++ b/xerus_backend/src/database/migrations/096_relax_memory_search_index_constraints.sql
@@ -1,0 +1,40 @@
+-- Migration: 096_relax_memory_search_index_constraints.sql
+-- Description: Relax memory_search_index scope/memory_type CHECK constraints so
+--   they accept the v2 hierarchical memory model. Migration 028 created these
+--   constraints for the v1 flat model only, so every v2 write emitted by the live
+--   indexing path (inferMemoryScope / inferMemoryType) was silently rejected,
+--   leaving memory_search_index empty. Widen both to cover all values any code
+--   path can emit (v2 model + legacy values still produced by inference).
+-- Depends: 028_git_memory_search_index.sql
+-- Reference: src/domains/memory/memory.types.ts (MEMORY_SCOPES, MEMORY_TYPES)
+--            src/domains/memory/git-memory/memory-path-inference.ts
+
+-- ===== 1. RELAX scope CHECK =====
+-- v2 scopes: company, project, channel, agent, user, entity, topic
+-- Legacy value 'workspace' retained for backward compatibility (harmless — nothing
+-- emits it now, but keeping it avoids rejecting any pre-existing rows).
+ALTER TABLE memory_search_index DROP CONSTRAINT IF EXISTS msi_scope_check;
+ALTER TABLE memory_search_index
+    ADD CONSTRAINT msi_scope_check CHECK (
+        scope IN (
+            'workspace', 'company', 'project', 'channel', 'agent', 'user', 'entity', 'topic'
+        )
+    );
+
+-- ===== 2. RELAX memory_type CHECK =====
+-- v2 types (memory.types.ts MEMORY_TYPES): working, expertise, context, learnings,
+-- patterns, decisions, standup, vision, preferences, entity, topic.
+-- Legacy types still produced by inferMemoryType and the DRM path: episodic,
+-- semantic, procedural, action_history.
+ALTER TABLE memory_search_index DROP CONSTRAINT IF EXISTS msi_memory_type_check;
+ALTER TABLE memory_search_index
+    ADD CONSTRAINT msi_memory_type_check CHECK (
+        memory_type IN (
+            'working', 'expertise', 'context', 'learnings', 'patterns',
+            'decisions', 'standup', 'vision', 'preferences', 'entity', 'topic',
+            'episodic', 'semantic', 'procedural', 'action_history'
+        )
+    );
+
+COMMENT ON COLUMN memory_search_index.memory_type IS 'v2 hierarchical memory type (working, expertise, context, learnings, patterns, decisions, standup, vision, preferences, entity, topic) plus legacy episodic/semantic/procedural/action_history';
+COMMENT ON COLUMN memory_search_index.scope IS 'v2 scope: workspace, company, project, channel, agent, user, entity, topic';

--- a/xerus_backend/src/domains/agents/manifest-validator.ts
+++ b/xerus_backend/src/domains/agents/manifest-validator.ts
@@ -1,0 +1,98 @@
+// Workspace Manifest Validator
+// Validates agents/{slug}/config.json and agent.md frontmatter.
+// Used by scaffold-sync-hook, agent-install route, and CI.
+
+import { logger } from '../../utils/logger';
+
+const log = logger('ManifestValidator');
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const VALID_ROLES = ['creative', 'technical', 'analytical', 'operational', 'specialist', 'lead', 'user', 'system'];
+const VALID_AUTONOMY_LEVELS = ['manual', 'supervised', 'autonomous'];
+const VALID_ADAPTER_TYPES = ['claudecode', 'codex'];
+
+export interface AgentConfig {
+    slug: string;
+    name: string;
+    description?: string;
+    role?: string;
+    model?: string;
+    ai_model?: string;
+    adapter_type?: string;
+    autonomy_level?: string;
+    domain?: string;
+    primary_channel?: string;
+    channels?: string[];
+    tools?: string[];
+    heartbeat_cron?: string;
+    mascot?: string;
+}
+
+export interface ValidationError {
+    field: string;
+    message: string;
+}
+
+export function validateAgentConfig(config: unknown, slug?: string): ValidationError[] {
+    const errors: ValidationError[] = [];
+
+    if (!config || typeof config !== 'object') {
+        return [{ field: 'root', message: 'Config must be a JSON object' }];
+    }
+
+    const c = config as Record<string, unknown>;
+
+    if (!c.slug || typeof c.slug !== 'string') {
+        errors.push({ field: 'slug', message: 'slug is required and must be a string' });
+    } else if (!SLUG_PATTERN.test(c.slug)) {
+        errors.push({ field: 'slug', message: `slug "${c.slug}" must match ${SLUG_PATTERN}` });
+    } else if (slug && c.slug !== slug) {
+        errors.push({ field: 'slug', message: `slug "${c.slug}" does not match directory name "${slug}"` });
+    }
+
+    if (!c.name || typeof c.name !== 'string') {
+        errors.push({ field: 'name', message: 'name is required and must be a string' });
+    }
+
+    if (c.role && typeof c.role === 'string' && !VALID_ROLES.includes(c.role)) {
+        errors.push({ field: 'role', message: `role "${c.role}" must be one of: ${VALID_ROLES.join(', ')}` });
+    }
+
+    if (c.autonomy_level && typeof c.autonomy_level === 'string' && !VALID_AUTONOMY_LEVELS.includes(c.autonomy_level)) {
+        errors.push({ field: 'autonomy_level', message: `autonomy_level "${c.autonomy_level}" must be one of: ${VALID_AUTONOMY_LEVELS.join(', ')}` });
+    }
+
+    if (c.adapter_type && typeof c.adapter_type === 'string' && !VALID_ADAPTER_TYPES.includes(c.adapter_type)) {
+        errors.push({ field: 'adapter_type', message: `adapter_type "${c.adapter_type}" must be one of: ${VALID_ADAPTER_TYPES.join(', ')}` });
+    }
+
+    if (c.channels && !Array.isArray(c.channels)) {
+        errors.push({ field: 'channels', message: 'channels must be an array' });
+    }
+
+    if (c.tools && !Array.isArray(c.tools)) {
+        errors.push({ field: 'tools', message: 'tools must be an array' });
+    }
+
+    return errors;
+}
+
+export function validateAgentConfigJson(jsonStr: string, slug?: string): ValidationError[] {
+    try {
+        const parsed = JSON.parse(jsonStr) as unknown;
+        return validateAgentConfig(parsed, slug);
+    } catch (err) {
+        return [{ field: 'root', message: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}` }];
+    }
+}
+
+export function logValidationResult(slug: string, errors: ValidationError[]): void {
+    if (errors.length === 0) {
+        log.debug('Agent config valid', { slug });
+    } else {
+        log.warn('Agent config validation failed', {
+            slug,
+            errors: errors.map(e => `${e.field}: ${e.message}`),
+        });
+    }
+}

--- a/xerus_backend/src/domains/company/__tests__/company-business-db.test.ts
+++ b/xerus_backend/src/domains/company/__tests__/company-business-db.test.ts
@@ -1,0 +1,144 @@
+// Company Business DB Tests
+// Validates the read surface for company.db business tables (topics,
+// research_reports, prospects) exposed via company-business-db.service.ts:
+// - Limit/offset clamping (bounds the sandbox SQLite scan)
+// - SQL builders target the correct tables, columns, ordering, and pagination
+// - Missing-table classification (fresh company.db before schema load = empty)
+//
+// These validate the deterministic query-construction layer without a sandbox,
+// matching the approach in channel-behavior.test.ts. End-to-end verification
+// against a live Daytona sandbox is covered separately (requires a real sandbox).
+
+import {
+    clampLimit,
+    clampOffset,
+    buildListTopicsSql,
+    buildListResearchReportsSql,
+    buildListProspectsSql,
+    isMissingTableError,
+    DEFAULT_BUSINESS_LIMIT,
+    MAX_BUSINESS_LIMIT,
+} from '../company-business-db.service';
+
+// ---------------------------------------------------------------------------
+// 1. Limit / Offset clamping
+// ---------------------------------------------------------------------------
+
+describe('clampLimit', () => {
+    it('returns the value when within bounds', () => {
+        expect(clampLimit(25)).toBe(25);
+    });
+
+    it('caps at MAX_BUSINESS_LIMIT', () => {
+        expect(clampLimit(MAX_BUSINESS_LIMIT + 500)).toBe(MAX_BUSINESS_LIMIT);
+    });
+
+    it('defaults when zero or negative', () => {
+        expect(clampLimit(0)).toBe(DEFAULT_BUSINESS_LIMIT);
+        expect(clampLimit(-10)).toBe(DEFAULT_BUSINESS_LIMIT);
+    });
+
+    it('defaults on NaN (unparseable query param)', () => {
+        expect(clampLimit(Number.NaN)).toBe(DEFAULT_BUSINESS_LIMIT);
+    });
+
+    it('floors fractional values', () => {
+        expect(clampLimit(10.9)).toBe(10);
+    });
+});
+
+describe('clampOffset', () => {
+    it('returns the value when positive', () => {
+        expect(clampOffset(40)).toBe(40);
+    });
+
+    it('returns 0 for negative or NaN', () => {
+        expect(clampOffset(-5)).toBe(0);
+        expect(clampOffset(Number.NaN)).toBe(0);
+    });
+
+    it('floors fractional values', () => {
+        expect(clampOffset(12.7)).toBe(12);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. SQL builders
+// ---------------------------------------------------------------------------
+
+describe('buildListTopicsSql', () => {
+    const sql = buildListTopicsSql(30, 0);
+
+    it('selects from the topics table', () => {
+        expect(sql).toMatch(/FROM\s+topics/);
+    });
+
+    it('selects the schema columns', () => {
+        for (const col of ['name', 'relevance_score', 'trend_direction', 'research_count', 'source_agent']) {
+            expect(sql).toContain(col);
+        }
+    });
+
+    it('orders by relevance then recency', () => {
+        expect(sql).toMatch(/ORDER BY relevance_score DESC, updated_at DESC/);
+    });
+
+    it('applies clamped LIMIT and OFFSET', () => {
+        expect(buildListTopicsSql(9999, 5)).toContain(`LIMIT ${MAX_BUSINESS_LIMIT} OFFSET 5`);
+    });
+});
+
+describe('buildListResearchReportsSql', () => {
+    const sql = buildListResearchReportsSql(30, 0);
+
+    it('selects from research_reports', () => {
+        expect(sql).toMatch(/FROM\s+research_reports/);
+    });
+
+    it('selects the schema columns', () => {
+        for (const col of ['topic', 'source_skill', 'source_agent', 'key_findings', 'summary', 'sheet_url']) {
+            expect(sql).toContain(col);
+        }
+    });
+
+    it('orders by newest first', () => {
+        expect(sql).toMatch(/ORDER BY created_at DESC/);
+    });
+});
+
+describe('buildListProspectsSql', () => {
+    const sql = buildListProspectsSql(30, 0);
+
+    it('selects from prospects', () => {
+        expect(sql).toMatch(/FROM\s+prospects/);
+    });
+
+    it('selects the schema columns', () => {
+        for (const col of ['name', 'type', 'status', 'relevance_score', 'source_agent', 'notes']) {
+            expect(sql).toContain(col);
+        }
+    });
+
+    it('orders by relevance then recency', () => {
+        expect(sql).toMatch(/ORDER BY relevance_score DESC, updated_at DESC/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Missing-table classification
+// ---------------------------------------------------------------------------
+
+describe('isMissingTableError', () => {
+    it('is true for sqlite "no such table" errors', () => {
+        expect(isMissingTableError(new Error('SQLite returned invalid JSON: Error: no such table: topics'))).toBe(true);
+    });
+
+    it('is true when passed a raw string', () => {
+        expect(isMissingTableError('Parse error near line 1: no such table: prospects')).toBe(true);
+    });
+
+    it('is false for unrelated errors', () => {
+        expect(isMissingTableError(new Error('database is locked'))).toBe(false);
+        expect(isMissingTableError(new Error('Sandbox provider does not support executeCommand'))).toBe(false);
+    });
+});

--- a/xerus_backend/src/domains/company/company-business-db.service.ts
+++ b/xerus_backend/src/domains/company/company-business-db.service.ts
@@ -1,0 +1,182 @@
+// Company Business DB Service
+// Read surface for company.db (SQLite on the sandbox) — the structured layer of
+// the workspace's 3-layer data model (Google Sheets -> company.db -> .memory/entities/).
+// Agents write business data here via the data-steward protocol; this service reads
+// it back so the UI can surface topics, research reports, and prospects.
+//
+// Distinct from company-workspace-db.service.ts, which reads workspace.db
+// (operational: domains, channels, messages). This service is read-only.
+// Schema: xerus-workspace/data/schema.sql
+
+import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona.provider';
+import { COMPANY_DB_PATH, executeSandboxDbJsonQuery } from '../conversations/workspace-db.helpers';
+
+// -----------------------------------------------------------------------------
+// Types (mirror schema.sql — topics / research_reports / prospects)
+// -----------------------------------------------------------------------------
+
+export interface TopicRow {
+    id: number;
+    name: string;
+    description: string | null;
+    relevance_score: number | null;
+    trend_direction: string | null;
+    research_count: number;
+    last_researched_at: string | null;
+    source_agent: string;
+    entity_path: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface ResearchReportRow {
+    id: number;
+    topic: string;
+    source_skill: string;
+    source_agent: string;
+    key_findings: string | null;
+    summary: string | null;
+    sheet_url: string | null;
+    raw_data_path: string | null;
+    created_at: string;
+}
+
+export interface ProspectRow {
+    id: number;
+    name: string;
+    type: string;
+    status: string;
+    relevance_score: number | null;
+    source_agent: string;
+    source_url: string | null;
+    notes: string | null;
+    entity_path: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface CompanyBusinessData {
+    topics: TopicRow[];
+    research_reports: ResearchReportRow[];
+    prospects: ProspectRow[];
+}
+
+// -----------------------------------------------------------------------------
+// Pagination bounds — cap the sandbox SQLite scan and JSON payload size
+// -----------------------------------------------------------------------------
+
+export const DEFAULT_BUSINESS_LIMIT = 50;
+export const MAX_BUSINESS_LIMIT = 200;
+
+export function clampLimit(limit: number): number {
+    if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_BUSINESS_LIMIT;
+    return Math.min(Math.floor(limit), MAX_BUSINESS_LIMIT);
+}
+
+export function clampOffset(offset: number): number {
+    if (!Number.isFinite(offset) || offset <= 0) return 0;
+    return Math.floor(offset);
+}
+
+// -----------------------------------------------------------------------------
+// SQL builders (pure) — numeric limit/offset only, so no interpolation risk
+// -----------------------------------------------------------------------------
+
+export function buildListTopicsSql(limit: number, offset: number): string {
+    return `
+        SELECT id, name, description, relevance_score, trend_direction, research_count,
+               last_researched_at, source_agent, entity_path, created_at, updated_at
+        FROM topics
+        ORDER BY relevance_score DESC, updated_at DESC
+        LIMIT ${clampLimit(limit)} OFFSET ${clampOffset(offset)}
+    `;
+}
+
+export function buildListResearchReportsSql(limit: number, offset: number): string {
+    return `
+        SELECT id, topic, source_skill, source_agent, key_findings, summary,
+               sheet_url, raw_data_path, created_at
+        FROM research_reports
+        ORDER BY created_at DESC
+        LIMIT ${clampLimit(limit)} OFFSET ${clampOffset(offset)}
+    `;
+}
+
+export function buildListProspectsSql(limit: number, offset: number): string {
+    return `
+        SELECT id, name, type, status, relevance_score, source_agent,
+               source_url, notes, entity_path, created_at, updated_at
+        FROM prospects
+        ORDER BY relevance_score DESC, updated_at DESC
+        LIMIT ${clampLimit(limit)} OFFSET ${clampOffset(offset)}
+    `;
+}
+
+// -----------------------------------------------------------------------------
+// Missing-table handling
+// company.db is initialized from schema.sql during sandbox setup. A read that
+// races initialization (file exists, tables not yet created) surfaces sqlite's
+// "no such table" — a genuine empty state, not a failure. Every other error
+// propagates (fail-fast). Mirrors getProjectOverview in company-workspace-db.service.ts.
+// -----------------------------------------------------------------------------
+
+export function isMissingTableError(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes('no such table');
+}
+
+function emptyOnMissingTable<T>(err: unknown): T[] {
+    if (isMissingTableError(err)) return [];
+    throw err;
+}
+
+// -----------------------------------------------------------------------------
+// Readers
+// -----------------------------------------------------------------------------
+
+export function listTopics(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    limit: number,
+    offset: number,
+): Promise<TopicRow[]> {
+    return executeSandboxDbJsonQuery<TopicRow>(
+        provider, sandboxId, COMPANY_DB_PATH, buildListTopicsSql(limit, offset),
+    ).catch(emptyOnMissingTable<TopicRow>);
+}
+
+export function listResearchReports(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    limit: number,
+    offset: number,
+): Promise<ResearchReportRow[]> {
+    return executeSandboxDbJsonQuery<ResearchReportRow>(
+        provider, sandboxId, COMPANY_DB_PATH, buildListResearchReportsSql(limit, offset),
+    ).catch(emptyOnMissingTable<ResearchReportRow>);
+}
+
+export function listProspects(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    limit: number,
+    offset: number,
+): Promise<ProspectRow[]> {
+    return executeSandboxDbJsonQuery<ProspectRow>(
+        provider, sandboxId, COMPANY_DB_PATH, buildListProspectsSql(limit, offset),
+    ).catch(emptyOnMissingTable<ProspectRow>);
+}
+
+export async function getCompanyBusinessData(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    limit: number,
+    offset: number,
+): Promise<CompanyBusinessData> {
+    const [topics, research_reports, prospects] = await Promise.all([
+        listTopics(provider, sandboxId, limit, offset),
+        listResearchReports(provider, sandboxId, limit, offset),
+        listProspects(provider, sandboxId, limit, offset),
+    ]);
+    return { topics, research_reports, prospects };
+}

--- a/xerus_backend/src/domains/company/company-workspace-db.service.ts
+++ b/xerus_backend/src/domains/company/company-workspace-db.service.ts
@@ -47,6 +47,8 @@ export interface ChannelMessageRow {
 
 export interface ChannelWithCount extends ChannelRow {
     agent_count: number;
+    message_count: number;
+    last_message_at: string | null;
 }
 
 export interface DomainWithChannels extends DomainRow {
@@ -70,7 +72,9 @@ export async function listDomainsWithChannels(
 
     const channelsSql = `
         SELECT c.slug, c.name, c.domain_slug, c.lead_agent_slug, c.description, c.goals, c.config, c.created_at, c.updated_at,
-               (SELECT COUNT(*) FROM channel_members cm WHERE cm.channel_slug = c.slug) AS agent_count
+               (SELECT COUNT(*) FROM channel_members cm WHERE cm.channel_slug = c.slug) AS agent_count,
+               (SELECT COUNT(*) FROM channel_messages m WHERE m.channel_slug = c.slug) AS message_count,
+               (SELECT MAX(posted_at) FROM channel_messages m WHERE m.channel_slug = c.slug) AS last_message_at
         FROM channels c
         ORDER BY c.name
     `;
@@ -490,9 +494,11 @@ export async function syncDeliverablesFromFilesystem(
 ): Promise<{ synced: number }> {
     const wp = SANDBOX_CONFIG.workspacePath;
 
+    // Scan both write locations documented in xerus-workspace/CLAUDE.md: the per-channel
+    // path (preferred) and the top-level output/deliverables/ path.
     const { result: findResult } = await provider.executeCommand(
         sandboxId,
-        `find ${wp}/projects -path '*/output/deliverables/*' -type f 2>/dev/null; echo ""`,
+        `find ${wp}/projects -path '*/output/deliverables/*' -type f 2>/dev/null; find ${wp}/output/deliverables -type f 2>/dev/null; echo ""`,
     );
 
     const filePaths = findResult.trim().split('\n').filter(p => p.trim());
@@ -501,11 +507,13 @@ export async function syncDeliverablesFromFilesystem(
     const inserts: string[] = [];
 
     for (const filePath of filePaths) {
-        // Extract agent info from path: projects/{domain}/channels/{channel}/output/deliverables/{filename}
-        const pathMatch = filePath.match(/projects\/([^/]+)\/channels\/([^/]+)\/output\/deliverables\/(.+)$/);
-        if (!pathMatch) continue;
-        const channelSlug = pathMatch[2];
-        const filename = pathMatch[3];
+        // Per-channel: projects/{domain}/channels/{channel}/output/deliverables/{filename}
+        // Top-level:   output/deliverables/{filename} — no channel to attribute the file to.
+        const perChannel = filePath.match(/projects\/([^/]+)\/channels\/([^/]+)\/output\/deliverables\/(.+)$/);
+        const topLevel = perChannel ? null : filePath.match(/(?:^|\/)output\/deliverables\/(.+)$/);
+        if (!perChannel && !topLevel) continue;
+        const channelSlug = perChannel ? perChannel[2] : null;
+        const filename = perChannel ? perChannel[3] : topLevel![1];
 
         // Get file info
         const { result: stat } = await provider.executeCommand(
@@ -530,14 +538,18 @@ export async function syncDeliverablesFromFilesystem(
             : ['json', 'csv', 'jsonl'].includes(ext) ? 'data'
             : 'file';
 
-        // Get channel lead as the likely author
-        const agentSql = `
-            SELECT cm.agent_slug FROM channel_members cm
-            WHERE cm.channel_slug = '${escapeSQL(channelSlug)}'
-            ORDER BY cm.role ASC LIMIT 1
-        `;
-        const agentRows = await executeWorkspaceJsonQuery<{ agent_slug: string }>(provider, sandboxId, agentSql);
-        const agentSlug = agentRows[0]?.agent_slug ?? 'unknown';
+        // Get channel lead as the likely author. Top-level deliverables have no channel,
+        // so they are attributed to 'unknown'.
+        let agentSlug = 'unknown';
+        if (channelSlug) {
+            const agentSql = `
+                SELECT cm.agent_slug FROM channel_members cm
+                WHERE cm.channel_slug = '${escapeSQL(channelSlug)}'
+                ORDER BY cm.role ASC LIMIT 1
+            `;
+            const agentRows = await executeWorkspaceJsonQuery<{ agent_slug: string }>(provider, sandboxId, agentSql);
+            agentSlug = agentRows[0]?.agent_slug ?? 'unknown';
+        }
 
         const relPath = filePath.replace(wp + '/', '');
 

--- a/xerus_backend/src/domains/company/company.routes.ts
+++ b/xerus_backend/src/domains/company/company.routes.ts
@@ -34,6 +34,7 @@ import {
     updateChannel,
     getProjectOverview,
 } from './company-workspace-db.service';
+import { getCompanyBusinessData, DEFAULT_BUSINESS_LIMIT, MAX_BUSINESS_LIMIT } from './company-business-db.service';
 import { addSystemAgentsToChannel } from './system-agent-assignment.service';
 import { logger } from '../../utils/logger';
 
@@ -105,11 +106,44 @@ router.get('/domains', auth, async (req: AuthenticatedRequest, res: Response, ne
                     name: c.name,
                     description: c.description,
                     agent_count: c.agent_count ?? 0,
+                    message_count: c.message_count ?? 0,
+                    last_message_at: c.last_message_at ?? null,
                 })),
             };
         });
 
         sendResponse(res, 200, { workspace, domains }, startTime);
+    } catch (err) {
+        next(err);
+    }
+});
+
+// -------------------------------------------------------------------------
+// GET /api/v1/company/business - Business data from company.db
+// Returns topics, research reports, and prospects agents have produced.
+// Query params: limit (default 50, max 200), offset (default 0)
+// -------------------------------------------------------------------------
+
+router.get('/business', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const startTime = res.locals.startTime || Date.now();
+    try {
+        const userId = req.user?.uid;
+        if (!userId) {
+            throw new UnauthorizedError();
+        }
+        if (!companyDeps) {
+            throw new Error('Company routes dependencies not initialized');
+        }
+        const { sandboxService } = companyDeps;
+        const sandboxId = await requireRunningSandbox(sandboxService, userId);
+        const provider = getDaytonaProvider(sandboxService);
+
+        const limit = Math.min(parseInt(req.query.limit as string, 10) || DEFAULT_BUSINESS_LIMIT, MAX_BUSINESS_LIMIT);
+        const offset = parseInt(req.query.offset as string, 10) || 0;
+
+        const business = await getCompanyBusinessData(provider, sandboxId, limit, offset);
+
+        sendResponse(res, 200, business, startTime);
     } catch (err) {
         next(err);
     }

--- a/xerus_backend/src/domains/conversations/workspace-db.helpers.ts
+++ b/xerus_backend/src/domains/conversations/workspace-db.helpers.ts
@@ -11,8 +11,9 @@ const log = logger('WorkspaceDB');
 
 export const WORKSPACE_DB_PATH = `${SANDBOX_CONFIG.workspacePath}/data/workspace.db`;
 
-// Shell-safe version of the DB path (escapes single quotes for use in shell commands)
-const ESCAPED_DB_PATH = shellEscapePath(WORKSPACE_DB_PATH);
+// Business data DB — research reports, prospects, topics, etc.
+// Agents write here via sqlite3; the company domain reads it for the UI.
+export const COMPANY_DB_PATH = `${SANDBOX_CONFIG.workspacePath}/data/company.db`;
 
 const HEREDOC_DELIM = 'XERUS_SQL_EOF_7f3a';
 
@@ -35,12 +36,17 @@ export function escapeLikePattern(value: string): string {
 }
 
 export function buildSqliteCommand(sql: string): string {
+    return buildSqliteCommandForDb(WORKSPACE_DB_PATH, sql);
+}
+
+export function buildSqliteCommandForDb(dbPath: string, sql: string): string {
     // Pipe SQL via stdin using a single-quoted heredoc to prevent shell injection.
     // Single-quoted heredoc disables all shell expansion (no $(), backticks, variable interpolation).
     // Delimiter is unique enough that agent content won't contain it (escapeSQL guards this).
     // Prepend PRAGMA foreign_keys=ON so FK constraints are enforced on every connection.
+    const escapedDbPath = shellEscapePath(dbPath);
     const fullSql = `PRAGMA foreign_keys=ON;\n${sql}`;
-    return `sqlite3 -json ${ESCAPED_DB_PATH} <<'${HEREDOC_DELIM}'\n${fullSql}\n${HEREDOC_DELIM}`;
+    return `sqlite3 -json ${escapedDbPath} <<'${HEREDOC_DELIM}'\n${fullSql}\n${HEREDOC_DELIM}`;
 }
 
 export function parseJsonResult<T>(output: string): T[] | null {
@@ -64,17 +70,26 @@ export async function executeWorkspaceQuery(
     sandboxId: string,
     sql: string,
 ): Promise<string> {
+    return executeSandboxDbQuery(provider, sandboxId, WORKSPACE_DB_PATH, sql);
+}
+
+export async function executeSandboxDbQuery(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    dbPath: string,
+    sql: string,
+): Promise<string> {
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-        const result = await provider.executeCommand(sandboxId, buildSqliteCommand(sql));
+        const result = await provider.executeCommand(sandboxId, buildSqliteCommandForDb(dbPath, sql));
         const output = result.result || '';
         if (output.includes('database is locked')) {
-            log.warn('SQLite locked, retrying', { attempt, sandboxId });
+            log.warn('SQLite locked, retrying', { attempt, sandboxId, dbPath });
             await sleep(100 * Math.pow(2, attempt));
             continue;
         }
         return output;
     }
-    throw new Error('Workspace DB query failed after retries: database is locked');
+    throw new Error(`SQLite query failed after retries (database is locked): ${dbPath}`);
 }
 
 export async function executeWorkspaceJsonQuery<T>(
@@ -82,13 +97,22 @@ export async function executeWorkspaceJsonQuery<T>(
     sandboxId: string,
     sql: string,
 ): Promise<T[]> {
-    const output = await executeWorkspaceQuery(provider, sandboxId, sql);
+    return executeSandboxDbJsonQuery<T>(provider, sandboxId, WORKSPACE_DB_PATH, sql);
+}
+
+export async function executeSandboxDbJsonQuery<T>(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    dbPath: string,
+    sql: string,
+): Promise<T[]> {
+    const output = await executeSandboxDbQuery(provider, sandboxId, dbPath, sql);
     const parsed = parseJsonResult<T>(output);
     if (parsed !== null) {
         return parsed;
     }
 
     const trimmed = output.trim();
-    log.error('Failed to parse JSON', { preview: trimmed.slice(0, 200) });
-    throw new Error(`Workspace DB returned invalid JSON: ${trimmed.slice(0, 300)}`);
+    log.error('Failed to parse JSON', { preview: trimmed.slice(0, 200), dbPath });
+    throw new Error(`SQLite returned invalid JSON: ${trimmed.slice(0, 300)}`);
 }

--- a/xerus_backend/src/domains/drive/__tests__/deliverables-projection.test.ts
+++ b/xerus_backend/src/domains/drive/__tests__/deliverables-projection.test.ts
@@ -1,0 +1,227 @@
+// Deliverables Projection Tests
+// Validates the path contract between where agents write deliverables and where
+// the drive UI surfaces them. Two write locations are supported:
+//   - Per-channel (preferred): projects/<domain>/channels/<channel>/output/deliverables/<file>
+//   - Top-level (workspace CLAUDE.md default): output/deliverables/<file>
+// Both must project into drive/ and reverse-resolve back to their real path.
+// Pure functions — no sandbox, no mocks.
+
+import {
+    collectDeliverablesFromTree,
+    injectDeliverablesProjection,
+    resolveVirtualDeliverablePath,
+    type DeliverableFile,
+    type ProjectMap,
+} from '../deliverables-projection';
+import type { FileNode } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRoot(): FileNode {
+    return { name: 'workspace', type: 'directory', path: '', children: [] };
+}
+
+function makeProjectMap(
+    entries: Array<{ slug: string; name: string; channels: Array<[string, string]> }>,
+): ProjectMap {
+    const map: ProjectMap = new Map();
+    for (const e of entries) {
+        map.set(e.slug, { slug: e.slug, name: e.name, channels: new Map(e.channels) });
+    }
+    return map;
+}
+
+function findNode(node: FileNode, path: string): FileNode | null {
+    if (node.path === path) return node;
+    for (const child of node.children ?? []) {
+        const found = findNode(child, path);
+        if (found) return found;
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// collectDeliverablesFromTree
+// ---------------------------------------------------------------------------
+
+describe('collectDeliverablesFromTree', () => {
+    it('collects per-channel deliverables with domain and channel slugs', () => {
+        const root: FileNode = {
+            name: 'workspace',
+            type: 'directory',
+            path: '',
+            children: [{
+                name: 'post.md',
+                type: 'file',
+                path: 'projects/marketing/channels/marketing--blog/output/deliverables/post.md',
+                size: 42,
+            }],
+        };
+
+        const files = collectDeliverablesFromTree(root);
+
+        expect(files).toHaveLength(1);
+        expect(files[0]).toMatchObject({
+            realPath: 'projects/marketing/channels/marketing--blog/output/deliverables/post.md',
+            domainSlug: 'marketing',
+            channelSlug: 'marketing--blog',
+            fileName: 'post.md',
+            size: 42,
+        });
+    });
+
+    it('collects top-level output/deliverables/ files without slugs', () => {
+        const root: FileNode = {
+            name: 'workspace',
+            type: 'directory',
+            path: '',
+            children: [{
+                name: 'report.md',
+                type: 'file',
+                path: 'output/deliverables/report.md',
+            }],
+        };
+
+        const files = collectDeliverablesFromTree(root);
+
+        expect(files).toHaveLength(1);
+        expect(files[0].realPath).toBe('output/deliverables/report.md');
+        expect(files[0].fileName).toBe('report.md');
+        expect(files[0].domainSlug).toBeUndefined();
+        expect(files[0].channelSlug).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// injectDeliverablesProjection
+// ---------------------------------------------------------------------------
+
+describe('injectDeliverablesProjection', () => {
+    it('projects top-level deliverables into drive/Deliverables/', () => {
+        const root = makeRoot();
+        const deliverables: DeliverableFile[] = [
+            { realPath: 'output/deliverables/report.md', fileName: 'report.md' },
+        ];
+
+        injectDeliverablesProjection(root, deliverables, new Map());
+
+        const node = findNode(root, 'drive/Deliverables/report.md');
+        expect(node).not.toBeNull();
+        expect(node!.type).toBe('file');
+    });
+
+    it('collapses a single-channel project under drive/<Project>/', () => {
+        const root = makeRoot();
+        const map = makeProjectMap([
+            { slug: 'marketing', name: 'Marketing', channels: [['marketing--blog', 'Blog']] },
+        ]);
+        const deliverables: DeliverableFile[] = [{
+            realPath: 'projects/marketing/channels/marketing--blog/output/deliverables/post.md',
+            domainSlug: 'marketing',
+            channelSlug: 'marketing--blog',
+            fileName: 'post.md',
+        }];
+
+        injectDeliverablesProjection(root, deliverables, map);
+
+        expect(findNode(root, 'drive/Marketing/post.md')).not.toBeNull();
+    });
+
+    it('expands a multi-channel project into channel subfolders', () => {
+        const root = makeRoot();
+        const map = makeProjectMap([
+            { slug: 'eng', name: 'Engineering', channels: [['eng--api', 'API'], ['eng--web', 'Web']] },
+        ]);
+        const deliverables: DeliverableFile[] = [
+            { realPath: 'projects/eng/channels/eng--api/output/deliverables/api.md', domainSlug: 'eng', channelSlug: 'eng--api', fileName: 'api.md' },
+            { realPath: 'projects/eng/channels/eng--web/output/deliverables/web.md', domainSlug: 'eng', channelSlug: 'eng--web', fileName: 'web.md' },
+        ];
+
+        injectDeliverablesProjection(root, deliverables, map);
+
+        expect(findNode(root, 'drive/Engineering/API/api.md')).not.toBeNull();
+        expect(findNode(root, 'drive/Engineering/Web/web.md')).not.toBeNull();
+    });
+
+    it('projects deliverables for unregistered projects using slug-derived names', () => {
+        const root = makeRoot();
+        const deliverables: DeliverableFile[] = [{
+            realPath: 'projects/growth/channels/growth--ads/output/deliverables/plan.md',
+            domainSlug: 'growth',
+            channelSlug: 'growth--ads',
+            fileName: 'plan.md',
+        }];
+
+        // Empty project map — simulates a file-created project absent from workspace.db.
+        injectDeliverablesProjection(root, deliverables, new Map());
+
+        expect(findNode(root, 'drive/growth/plan.md')).not.toBeNull();
+    });
+
+    it('does not overwrite a real drive folder that collides with the Deliverables alias', () => {
+        const root = makeRoot();
+        const drive: FileNode = {
+            name: 'drive', type: 'directory', path: 'drive', children: [
+                { name: 'Deliverables', type: 'directory', path: 'drive/Deliverables', children: [
+                    { name: 'real.md', type: 'file', path: 'drive/Deliverables/real.md' },
+                ] },
+            ],
+        };
+        root.children = [drive];
+
+        injectDeliverablesProjection(root, [
+            { realPath: 'output/deliverables/report.md', fileName: 'report.md' },
+        ], new Map());
+
+        // Real folder is preserved; the projected alias is skipped.
+        expect(findNode(root, 'drive/Deliverables/real.md')).not.toBeNull();
+        expect(findNode(root, 'drive/Deliverables/report.md')).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVirtualDeliverablePath
+// ---------------------------------------------------------------------------
+
+describe('resolveVirtualDeliverablePath', () => {
+    it('reverse-resolves drive/Deliverables/<file> to output/deliverables/<file>', () => {
+        expect(resolveVirtualDeliverablePath('drive/Deliverables/report.md', new Map()))
+            .toBe('output/deliverables/report.md');
+    });
+
+    it('reverse-resolves a top-level deliverable inside a subfolder', () => {
+        expect(resolveVirtualDeliverablePath('drive/Deliverables/reports/q1.md', new Map()))
+            .toBe('output/deliverables/reports/q1.md');
+    });
+
+    it('reverse-resolves a collapsed project path to the real per-channel path', () => {
+        const map = makeProjectMap([
+            { slug: 'marketing', name: 'Marketing', channels: [['marketing--blog', 'Blog']] },
+        ]);
+        expect(resolveVirtualDeliverablePath('drive/Marketing/post.md', map))
+            .toBe('projects/marketing/channels/marketing--blog/output/deliverables/post.md');
+    });
+
+    it('reverse-resolves a discovered slug-named project path', () => {
+        // loadProjectMap discovers on-disk projects with name === slug.
+        const map = makeProjectMap([
+            { slug: 'growth', name: 'growth', channels: [['growth--ads', 'growth--ads']] },
+        ]);
+        expect(resolveVirtualDeliverablePath('drive/growth/plan.md', map))
+            .toBe('projects/growth/channels/growth--ads/output/deliverables/plan.md');
+    });
+
+    it('prefers a real project named Deliverables over the top-level alias', () => {
+        const map = makeProjectMap([
+            { slug: 'deliverables-team', name: 'Deliverables', channels: [['deliverables-team--main', 'Main']] },
+        ]);
+        expect(resolveVirtualDeliverablePath('drive/Deliverables/x.md', map))
+            .toBe('projects/deliverables-team/channels/deliverables-team--main/output/deliverables/x.md');
+    });
+
+    it('returns null for a non-virtual path', () => {
+        expect(resolveVirtualDeliverablePath('agents/foo/SOUL.md', new Map())).toBeNull();
+    });
+});

--- a/xerus_backend/src/domains/drive/deliverables-projection.ts
+++ b/xerus_backend/src/domains/drive/deliverables-projection.ts
@@ -1,196 +1,93 @@
 // Deliverables Projection
 // Surface agent deliverables inside the user's drive view without moving them on disk.
 //
-// Real layout (unchanged — agents still write here, organized per channel):
-//   projects/<domain-slug>/channels/<channel-slug>/output/deliverables/<file>
+// Real layout (unchanged — agents still write here):
+//   projects/<domain-slug>/channels/<channel-slug>/output/deliverables/<file>   (per-channel, preferred)
+//   output/deliverables/<file>                                                  (top-level)
 //
 // Virtual projection exposed in the tree:
 //   drive/<Project Display Name>/<file>                           (project has 1 channel — collapsed)
 //   drive/<Project Display Name>/<Channel Display Name>/<file>    (project has 2+ channels)
+//   drive/Deliverables/<file>                                     (top-level output/deliverables/)
 //
-// Display names come from workspace.db (domains.name, channels.name). Slugs stay on disk;
-// users see the names they picked. Projection is read-only — writes to virtual paths
-// aren't routed back to the real filesystem; reads translate the virtual path on the way in.
+// Display names come from workspace.db (domains.name, channels.name), falling back to the
+// slug for on-disk projects not yet registered. Slugs stay on disk; users see friendly names.
+// Projection is read-only — reads/writes translate the virtual path back to the real path.
+//
+// Filesystem/DB scanning lives in deliverables-scan.ts and is re-exported here so callers
+// have a single entry point.
 
-import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
-import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona.provider';
-import { executeWorkspaceJsonQuery } from '../conversations/workspace-db.helpers';
 import type { FileNode } from './types';
 import { logger } from '../../utils/logger';
+import {
+    TOP_LEVEL_DELIVERABLES_PATH,
+    type DeliverableFile,
+    type ProjectMap,
+    type ProjectMapEntry,
+} from './deliverables-scan';
+
+export {
+    loadProjectMap,
+    loadDeliverablesDeep,
+    collectDeliverablesFromTree,
+} from './deliverables-scan';
+export type { DeliverableFile, ProjectMap, ProjectMapEntry } from './deliverables-scan';
 
 const log = logger('DeliverablesProjection');
 
-const DELIVERABLES_ROOT = 'projects';
-const DELIVERABLES_LIST_DEPTH = 6; // <domain>/channels/<channel>/output/deliverables/<file> = 6 levels under projects/
-
-// -----------------------------------------------------------------------------
-// Types
-// -----------------------------------------------------------------------------
-
-interface DomainRow { slug: string; name: string }
-interface ChannelRow { slug: string; name: string; domain_slug: string }
-
-export interface ProjectMapEntry {
-    /** Display name (e.g., "Marketing") */
-    name: string;
-    /** Domain slug on disk (e.g., "marketing-dept") */
-    slug: string;
-    /** channel slug -> display name */
-    channels: Map<string, string>;
-}
-
-/** Map of domain slug -> project entry. Built once per tree request. */
-export type ProjectMap = Map<string, ProjectMapEntry>;
-
-// -----------------------------------------------------------------------------
-// Loading display names from workspace.db
-// -----------------------------------------------------------------------------
-
-export async function loadProjectMap(
-    provider: DaytonaProvider,
-    sandboxId: string,
-): Promise<ProjectMap> {
-    const map: ProjectMap = new Map();
-
-    try {
-        const domains = await executeWorkspaceJsonQuery<DomainRow>(
-            provider, sandboxId,
-            `SELECT slug, name FROM domains ORDER BY slug;`,
-        );
-        for (const d of domains) {
-            map.set(d.slug, { slug: d.slug, name: d.name, channels: new Map() });
-        }
-
-        const channels = await executeWorkspaceJsonQuery<ChannelRow>(
-            provider, sandboxId,
-            `SELECT slug, name, domain_slug FROM channels ORDER BY slug;`,
-        );
-        for (const c of channels) {
-            const project = map.get(c.domain_slug);
-            if (project) project.channels.set(c.slug, c.name);
-        }
-    } catch (err) {
-        // workspace.db may not exist yet on a brand-new sandbox — return empty map, projection is skipped.
-        log.warn('Failed to load project map', {
-            error: err instanceof Error ? err.message : String(err),
-        });
-    }
-
-    return map;
-}
-
-// -----------------------------------------------------------------------------
-// Listing real deliverable files
-// -----------------------------------------------------------------------------
-
-export interface DeliverableFile {
-    /** Real workspace-relative path: projects/<domain>/channels/<channel>/output/deliverables/<name> */
-    realPath: string;
-    domainSlug: string;
-    channelSlug: string;
-    fileName: string;
-    size?: number;
-    modified?: string;
-}
-
-/**
- * Walks the tree to collect every file living under
- * projects/<x>/channels/<y>/output/deliverables/. We scan the already-built tree
- * instead of a second listFilesRecursive call when possible.
- */
-export function collectDeliverablesFromTree(root: FileNode): DeliverableFile[] {
-    const files: DeliverableFile[] = [];
-
-    const visit = (node: FileNode) => {
-        if (node.type === 'file') {
-            const match = node.path.match(
-                /^projects\/([^/]+)\/channels\/([^/]+)\/output\/deliverables\/(.+)$/,
-            );
-            if (match) {
-                files.push({
-                    realPath: node.path,
-                    domainSlug: match[1],
-                    channelSlug: match[2],
-                    fileName: match[3],
-                    size: node.size,
-                    modified: node.modified,
-                });
-            }
-        }
-        node.children?.forEach(visit);
-    };
-
-    visit(root);
-    return files;
-}
-
-/**
- * Fallback: load deliverable files directly via a deeper listing on the projects/ subtree.
- * Used when the tree's maxDepth cut off deliverables (they live 6 levels deep under workspace root).
- */
-export async function loadDeliverablesDeep(
-    provider: DaytonaProvider,
-    sandboxId: string,
-): Promise<DeliverableFile[]> {
-    const projectsRoot = `${SANDBOX_CONFIG.workspacePath}/${DELIVERABLES_ROOT}`;
-    let files: string[];
-    try {
-        files = await provider.listFilesRecursive(sandboxId, projectsRoot, DELIVERABLES_LIST_DEPTH);
-    } catch (err) {
-        log.warn('Failed to list deliverables', {
-            error: err instanceof Error ? err.message : String(err),
-        });
-        return [];
-    }
-
-    const prefixLen = projectsRoot.endsWith('/') ? projectsRoot.length : projectsRoot.length + 1;
-    const results: DeliverableFile[] = [];
-    for (const absolute of files) {
-        const relativeToProjects = absolute.startsWith(projectsRoot) ? absolute.slice(prefixLen) : absolute;
-        const match = relativeToProjects.match(
-            /^([^/]+)\/channels\/([^/]+)\/output\/deliverables\/(.+)$/,
-        );
-        if (!match) continue;
-        results.push({
-            realPath: `${DELIVERABLES_ROOT}/${relativeToProjects}`,
-            domainSlug: match[1],
-            channelSlug: match[2],
-            fileName: match[3],
-        });
-    }
-    return results;
-}
+/** Virtual drive folder that top-level output/deliverables/ files project into. */
+const TOP_LEVEL_DELIVERABLES_FOLDER = 'Deliverables';
 
 // -----------------------------------------------------------------------------
 // Injecting virtual nodes into the tree
 // -----------------------------------------------------------------------------
 
 /**
- * Mutates root by adding virtual project folders under drive/.
- * Safe to call with an empty ProjectMap (no-op).
+ * Mutates root by adding virtual deliverable folders under drive/. Handles both
+ * per-channel deliverables (grouped by project) and top-level output/deliverables/
+ * (grouped under a single "Deliverables" folder). Safe to call with an empty map.
  */
 export function injectDeliverablesProjection(
     root: FileNode,
     deliverables: DeliverableFile[],
     projectMap: ProjectMap,
 ): void {
-    if (projectMap.size === 0 || deliverables.length === 0) return;
+    if (deliverables.length === 0) return;
 
     // Ensure drive/ exists in the tree
     const drive = getOrCreateChild(root, 'drive', 'drive');
 
-    // Group deliverables by project (domain slug)
+    injectPerChannelDeliverables(drive, deliverables.filter(f => f.domainSlug), projectMap);
+    injectTopLevelDeliverables(drive, deliverables.filter(f => !f.domainSlug));
+
+    // Keep drive children sorted: directories first, then alphabetical — matches how the
+    // rest of the tree sorts.
+    drive.children!.sort((a, b) => {
+        if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+        return a.name.localeCompare(b.name);
+    });
+}
+
+/**
+ * Project per-channel deliverables into drive/<Project>/[<Channel>/]<file>. Missing
+ * project/channel display names fall back to the slug so unregistered (file-created)
+ * projects still surface rather than being silently dropped.
+ */
+function injectPerChannelDeliverables(
+    drive: FileNode,
+    files: DeliverableFile[],
+    projectMap: ProjectMap,
+): void {
     const byProject = new Map<string, DeliverableFile[]>();
-    for (const file of deliverables) {
-        if (!projectMap.has(file.domainSlug)) continue; // orphan project — skip silently
-        const list = byProject.get(file.domainSlug) ?? [];
+    for (const file of files) {
+        const list = byProject.get(file.domainSlug!) ?? [];
         list.push(file);
-        byProject.set(file.domainSlug, list);
+        byProject.set(file.domainSlug!, list);
     }
 
-    for (const [domainSlug, files] of byProject) {
-        const project = projectMap.get(domainSlug)!;
-        const projectFolderName = sanitizeDisplayName(project.name, domainSlug);
+    for (const [domainSlug, projectFiles] of byProject) {
+        const project = projectMap.get(domainSlug);
+        const projectFolderName = sanitizeDisplayName(project?.name ?? domainSlug, domainSlug);
 
         // Skip if the user has a real drive folder with the same name — real wins.
         if (drive.children?.some(c => c.name === projectFolderName)) {
@@ -201,7 +98,7 @@ export function injectDeliverablesProjection(
         }
 
         // Count distinct channels with deliverables so we know whether to collapse
-        const channelsWithFiles = new Set(files.map(f => f.channelSlug));
+        const channelsWithFiles = new Set(projectFiles.map(f => f.channelSlug));
         const collapse = channelsWithFiles.size === 1;
 
         const projectNode: FileNode = {
@@ -211,13 +108,12 @@ export function injectDeliverablesProjection(
             children: [],
         };
 
-        for (const file of files) {
-            const channelName = project.channels.get(file.channelSlug);
-            if (!channelName) continue; // unknown channel — skip
+        for (const file of projectFiles) {
+            const channelName = project?.channels.get(file.channelSlug!) ?? file.channelSlug!;
 
             let parent = projectNode;
             if (!collapse) {
-                const channelFolderName = sanitizeDisplayName(channelName, file.channelSlug);
+                const channelFolderName = sanitizeDisplayName(channelName, file.channelSlug!);
                 parent = getOrCreateChild(
                     projectNode,
                     channelFolderName,
@@ -238,13 +134,41 @@ export function injectDeliverablesProjection(
             drive.children!.push(projectNode);
         }
     }
+}
 
-    // Keep drive children sorted: user files first (alphabetical), then projected project folders (alphabetical).
-    // Simpler rule: sort all alphabetically, directories first — matches how the rest of the tree sorts.
-    drive.children!.sort((a, b) => {
-        if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
-        return a.name.localeCompare(b.name);
-    });
+/**
+ * Project top-level output/deliverables/ files into a single drive/Deliverables/ folder.
+ * Skips if a real drive folder of the same name already exists — real wins.
+ */
+function injectTopLevelDeliverables(drive: FileNode, files: DeliverableFile[]): void {
+    if (files.length === 0) return;
+    if (drive.children?.some(c => c.name === TOP_LEVEL_DELIVERABLES_FOLDER)) {
+        log.debug('Skipping top-level deliverables projection — real drive entry exists', {
+            name: TOP_LEVEL_DELIVERABLES_FOLDER,
+        });
+        return;
+    }
+
+    const folder: FileNode = {
+        name: TOP_LEVEL_DELIVERABLES_FOLDER,
+        type: 'directory',
+        path: `drive/${TOP_LEVEL_DELIVERABLES_FOLDER}`,
+        children: [],
+    };
+
+    for (const file of files) {
+        folder.children!.push({
+            name: file.fileName,
+            type: 'file',
+            path: `${folder.path}/${file.fileName}`,
+            size: file.size,
+            modified: file.modified,
+        });
+    }
+
+    if (folder.children!.length > 0) {
+        drive.children!.push(folder);
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -266,9 +190,16 @@ export function resolveVirtualDeliverablePath(
     const projectFolderName = match[1];
     const tail = match[2];
 
-    // Match project by sanitized display name
+    // Match project by sanitized display name. A real project takes priority over the
+    // top-level Deliverables alias, mirroring the "real wins" rule in the forward projection.
     const project = findProjectByFolderName(projectMap, projectFolderName);
-    if (!project) return null;
+    if (!project) {
+        // Top-level deliverables alias: drive/Deliverables/<tail> -> output/deliverables/<tail>
+        if (projectFolderName === TOP_LEVEL_DELIVERABLES_FOLDER) {
+            return `${TOP_LEVEL_DELIVERABLES_PATH}/${tail}`;
+        }
+        return null;
+    }
 
     // Case 1: collapsed layout — tail is just a filename
     // Case 2: expanded layout — tail is "<ChannelName>/<file>"

--- a/xerus_backend/src/domains/drive/deliverables-scan.ts
+++ b/xerus_backend/src/domains/drive/deliverables-scan.ts
@@ -1,0 +1,253 @@
+// Deliverables Scan
+// Reads the sandbox filesystem and workspace.db to discover projects/channels and the
+// deliverable files agents produce. Pairs with deliverables-projection.ts, which turns
+// this data into the virtual drive tree.
+//
+// Two write locations are supported (see xerus-workspace/CLAUDE.md):
+//   - Per-channel (preferred): projects/<domain>/channels/<channel>/output/deliverables/<file>
+//   - Top-level:               output/deliverables/<file>
+
+import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
+import type { DaytonaProvider } from '../sandbox-infra/sandbox/providers/daytona.provider';
+import { executeWorkspaceJsonQuery } from '../conversations/workspace-db.helpers';
+import type { FileNode } from './types';
+import { logger } from '../../utils/logger';
+
+const log = logger('DeliverablesScan');
+
+const DELIVERABLES_ROOT = 'projects';
+const DELIVERABLES_LIST_DEPTH = 6; // <domain>/channels/<channel>/output/deliverables/<file> = 6 levels under projects/
+const TOP_LEVEL_LIST_DEPTH = 4; // output/deliverables/<...>/<file> — allow a few subfolders
+
+/**
+ * Top-level deliverables location. The workspace CLAUDE.md documents output/deliverables/
+ * as a valid write location (per-channel is preferred, but non-channel work lands here).
+ * Shared with the projection so both agree on the same contract.
+ */
+export const TOP_LEVEL_DELIVERABLES_PATH = 'output/deliverables';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+interface DomainRow { slug: string; name: string }
+interface ChannelRow { slug: string; name: string; domain_slug: string }
+
+export interface ProjectMapEntry {
+    /** Display name (e.g., "Marketing") */
+    name: string;
+    /** Domain slug on disk (e.g., "marketing-dept") */
+    slug: string;
+    /** channel slug -> display name */
+    channels: Map<string, string>;
+}
+
+/** Map of domain slug -> project entry. Built once per tree request. */
+export type ProjectMap = Map<string, ProjectMapEntry>;
+
+export interface DeliverableFile {
+    /**
+     * Real workspace-relative path. Per-channel deliverables live at
+     * projects/<domain>/channels/<channel>/output/deliverables/<name>; top-level
+     * deliverables live at output/deliverables/<name>.
+     */
+    realPath: string;
+    /** Present for per-channel deliverables; absent for top-level output/deliverables/. */
+    domainSlug?: string;
+    /** Present for per-channel deliverables; absent for top-level output/deliverables/. */
+    channelSlug?: string;
+    fileName: string;
+    size?: number;
+    modified?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Loading display names from workspace.db + on-disk discovery
+// -----------------------------------------------------------------------------
+
+export async function loadProjectMap(
+    provider: DaytonaProvider,
+    sandboxId: string,
+): Promise<ProjectMap> {
+    const map: ProjectMap = new Map();
+
+    try {
+        const domains = await executeWorkspaceJsonQuery<DomainRow>(
+            provider, sandboxId,
+            `SELECT slug, name FROM domains ORDER BY slug;`,
+        );
+        for (const d of domains) {
+            map.set(d.slug, { slug: d.slug, name: d.name, channels: new Map() });
+        }
+
+        const channels = await executeWorkspaceJsonQuery<ChannelRow>(
+            provider, sandboxId,
+            `SELECT slug, name, domain_slug FROM channels ORDER BY slug;`,
+        );
+        for (const c of channels) {
+            const project = map.get(c.domain_slug);
+            if (project) project.channels.set(c.slug, c.name);
+        }
+    } catch (err) {
+        // workspace.db may not exist yet on a brand-new sandbox — carry on with an empty
+        // map; filesystem discovery below still lets on-disk projects project.
+        log.warn('Failed to load project map from workspace.db', {
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+
+    // Discover on-disk projects/channels so file-created projects (absent from workspace.db)
+    // still project their deliverables and reverse-resolve. DB display names win; discovered
+    // entries fall back to the slug so nothing is silently hidden.
+    await discoverProjectsFromFilesystem(provider, sandboxId, map);
+
+    return map;
+}
+
+/**
+ * Scan projects/<domain>/channels/<channel> directories and register any that are
+ * missing from the map (using the slug as the display name). This is the automation
+ * that closes the "unregistered project/channel" gap without writing to workspace.db —
+ * it re-runs on every load, so it survives fresh deploys and new environments.
+ */
+async function discoverProjectsFromFilesystem(
+    provider: DaytonaProvider,
+    sandboxId: string,
+    map: ProjectMap,
+): Promise<void> {
+    const projectsRoot = `${SANDBOX_CONFIG.workspacePath}/${DELIVERABLES_ROOT}`;
+    let output: string;
+    try {
+        const res = await provider.executeCommand(
+            sandboxId,
+            `find ${projectsRoot} -mindepth 3 -maxdepth 3 -type d -path '*/channels/*' 2>/dev/null || true`,
+        );
+        output = res.result ?? '';
+    } catch (err) {
+        log.warn('Failed to discover projects from filesystem', {
+            error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+    }
+
+    const prefixLen = projectsRoot.endsWith('/') ? projectsRoot.length : projectsRoot.length + 1;
+    for (const line of output.trim().split('\n')) {
+        const absolute = line.trim();
+        if (!absolute) continue;
+        const relative = absolute.startsWith(projectsRoot) ? absolute.slice(prefixLen) : absolute;
+        const match = relative.match(/^([^/]+)\/channels\/([^/]+)$/);
+        if (!match) continue;
+        const [, domainSlug, channelSlug] = match;
+
+        let project = map.get(domainSlug);
+        if (!project) {
+            project = { slug: domainSlug, name: domainSlug, channels: new Map() };
+            map.set(domainSlug, project);
+        }
+        if (!project.channels.has(channelSlug)) {
+            project.channels.set(channelSlug, channelSlug);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Listing real deliverable files
+// -----------------------------------------------------------------------------
+
+/**
+ * Walks an already-built tree to collect deliverable files from both the per-channel
+ * path and the top-level output/deliverables/ path.
+ */
+export function collectDeliverablesFromTree(root: FileNode): DeliverableFile[] {
+    const files: DeliverableFile[] = [];
+
+    const visit = (node: FileNode) => {
+        if (node.type === 'file') {
+            const perChannel = node.path.match(
+                /^projects\/([^/]+)\/channels\/([^/]+)\/output\/deliverables\/(.+)$/,
+            );
+            if (perChannel) {
+                files.push({
+                    realPath: node.path,
+                    domainSlug: perChannel[1],
+                    channelSlug: perChannel[2],
+                    fileName: perChannel[3],
+                    size: node.size,
+                    modified: node.modified,
+                });
+            } else {
+                const topLevel = node.path.match(/^output\/deliverables\/(.+)$/);
+                if (topLevel) {
+                    files.push({
+                        realPath: node.path,
+                        fileName: topLevel[1],
+                        size: node.size,
+                        modified: node.modified,
+                    });
+                }
+            }
+        }
+        node.children?.forEach(visit);
+    };
+
+    visit(root);
+    return files;
+}
+
+/**
+ * Load deliverable files directly via a deeper listing. Used because deliverables live
+ * below the default tree depth. Scans both the per-channel path (6 levels under projects/)
+ * and the top-level output/deliverables/ path.
+ */
+export async function loadDeliverablesDeep(
+    provider: DaytonaProvider,
+    sandboxId: string,
+): Promise<DeliverableFile[]> {
+    const wp = SANDBOX_CONFIG.workspacePath;
+    const results: DeliverableFile[] = [];
+
+    // Per-channel deliverables under projects/<domain>/channels/<channel>/output/deliverables/
+    const projectsRoot = `${wp}/${DELIVERABLES_ROOT}`;
+    try {
+        const files = await provider.listFilesRecursive(sandboxId, projectsRoot, DELIVERABLES_LIST_DEPTH);
+        const prefixLen = projectsRoot.endsWith('/') ? projectsRoot.length : projectsRoot.length + 1;
+        for (const absolute of files) {
+            const relativeToProjects = absolute.startsWith(projectsRoot) ? absolute.slice(prefixLen) : absolute;
+            const match = relativeToProjects.match(
+                /^([^/]+)\/channels\/([^/]+)\/output\/deliverables\/(.+)$/,
+            );
+            if (!match) continue;
+            results.push({
+                realPath: `${DELIVERABLES_ROOT}/${relativeToProjects}`,
+                domainSlug: match[1],
+                channelSlug: match[2],
+                fileName: match[3],
+            });
+        }
+    } catch (err) {
+        log.warn('Failed to list per-channel deliverables', {
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+
+    // Top-level deliverables under output/deliverables/ (workspace CLAUDE.md default location)
+    const topLevelRoot = `${wp}/${TOP_LEVEL_DELIVERABLES_PATH}`;
+    try {
+        const files = await provider.listFilesRecursive(sandboxId, topLevelRoot, TOP_LEVEL_LIST_DEPTH);
+        const prefixLen = topLevelRoot.endsWith('/') ? topLevelRoot.length : topLevelRoot.length + 1;
+        for (const absolute of files) {
+            const relative = absolute.startsWith(topLevelRoot) ? absolute.slice(prefixLen) : absolute;
+            if (!relative) continue;
+            results.push({
+                realPath: `${TOP_LEVEL_DELIVERABLES_PATH}/${relative}`,
+                fileName: relative,
+            });
+        }
+    } catch (err) {
+        log.warn('Failed to list top-level deliverables', {
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+
+    return results;
+}

--- a/xerus_backend/src/domains/drive/drive.service.ts
+++ b/xerus_backend/src/domains/drive/drive.service.ts
@@ -90,14 +90,14 @@ export class DriveService {
         sandboxId: string,
         provider: DaytonaProvider,
     ): Promise<void> {
-        const map = await this.getProjectMap(sandboxId, provider);
-        if (map.size === 0) return;
-
-        // Deliverables live 6 levels deep under workspace root; the default tree depth (5)
-        // usually cuts them off, so fetch them directly from the projects/ subtree.
+        // Deliverables live below the default tree depth, so fetch them directly. The
+        // project map only decorates them with display names — an empty map still projects
+        // top-level deliverables and slug-named unregistered projects, so we key the decision
+        // on the deliverables, not the map.
         const deliverables = await loadDeliverablesDeep(provider, sandboxId);
         if (deliverables.length === 0) return;
 
+        const map = await this.getProjectMap(sandboxId, provider);
         injectDeliverablesProjection(root, deliverables, map);
     }
 

--- a/xerus_backend/src/domains/execution/__tests__/execution-pipeline-resilience.test.ts
+++ b/xerus_backend/src/domains/execution/__tests__/execution-pipeline-resilience.test.ts
@@ -40,6 +40,24 @@ class HealthyDatabase implements ExecutionDatabase {
     }
 }
 
+// Throws a PostgreSQL schema error (undefined table). SQLSTATE class 42 marks a
+// query/schema bug — a programmer error the wrapper must surface, not degrade.
+class SchemaErrorDatabase implements ExecutionDatabase {
+    async query<T>(_sql: string, _params?: unknown[]): Promise<{ rows: T[] }> {
+        const err = new Error('relation "workspaces" does not exist') as Error & { code: string };
+        err.code = '42P01';
+        throw err;
+    }
+}
+
+// Throws a TypeError, standing in for a code defect that surfaces inside a
+// handler (e.g. calling an undefined function). Must be surfaced, not degraded.
+class TypeErrorDatabase implements ExecutionDatabase {
+    async query<T>(_sql: string, _params?: unknown[]): Promise<{ rows: T[] }> {
+        throw new TypeError('deps.provider.run is not a function');
+    }
+}
+
 class InMemoryCreditService implements CreditService {
     public currentBalance = 100;
 
@@ -185,62 +203,45 @@ function getStream(ctx: PipelineContext): FakeStream {
 // -----------------------------------------------------------------------------
 
 describe('routeEventWithResilience', () => {
-    describe('non-fatal handler errors', () => {
-        it('does not throw when a handler fails for a non-invariant reason', async () => {
+    // sandbox_lifecycle routes straight through deps.db.query with no other
+    // dependency, so the injected database controls exactly which error surfaces.
+    const sandboxLifecycleEvent = { data: { sandbox_id: 'sbx-001', action: 'start' } };
+
+    describe('transient handler errors (degraded, never swallowed)', () => {
+        it('does not re-throw when a handler fails for a transient reason', async () => {
             const ctx = createTestContext();
             const deps = createDeps(new FailingDatabase());
             const state = createResilienceState();
 
-            // create_inbox_item routes through deps.db.query, which throws.
-            // The wrapper should catch and degrade — not propagate.
             await expect(
-                routeEventWithResilience(
-                    'create_inbox_item',
-                    { data: { content: 'hello world', priority: 'normal' } },
-                    ctx,
-                    deps,
-                    state,
-                ),
+                routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state),
             ).resolves.toBeUndefined();
 
             expect(state.consecutiveErrors).toBe(1);
         });
 
-        it('emits a notification stream event when degrading a handler error', async () => {
+        it('surfaces a transient failure as an error notification (never silent)', async () => {
             const ctx = createTestContext();
             const deps = createDeps(new FailingDatabase());
             const state = createResilienceState();
 
-            await routeEventWithResilience(
-                'create_inbox_item',
-                { data: { content: 'hello world' } },
-                ctx,
-                deps,
-                state,
-            );
+            await routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state);
 
-            const stream = getStream(ctx);
-            const notifications = stream.sentEvents.filter(e => e.type === 'notification');
+            const notifications = getStream(ctx).sentEvents.filter(e => e.type === 'notification');
             expect(notifications).toHaveLength(1);
             const content = notifications[0].content as { priority: string; message: string };
             expect(content.priority).toBe('error');
             expect(content.message).toMatch(/agent is still running/i);
         });
 
-        it('does not emit a notification when the stream is already closed', async () => {
+        it('still counts the error when the stream is already closed', async () => {
             const ctx = createTestContext();
             const stream = getStream(ctx);
             stream.closed = true;
             const deps = createDeps(new FailingDatabase());
             const state = createResilienceState();
 
-            await routeEventWithResilience(
-                'create_inbox_item',
-                { data: { content: 'hello' } },
-                ctx,
-                deps,
-                state,
-            );
+            await routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state);
 
             expect(stream.sentEvents).toHaveLength(0);
             expect(state.consecutiveErrors).toBe(1);
@@ -250,20 +251,46 @@ describe('routeEventWithResilience', () => {
             const ctx = createTestContext();
             const deps = createDeps(new HealthyDatabase());
             const state = createResilienceState();
-
-            // First, simulate prior failures by setting state.
             state.consecutiveErrors = 3;
 
-            // create_inbox_item against HealthyDatabase succeeds.
+            // credit_usage succeeds with no external dependency.
             await routeEventWithResilience(
-                'create_inbox_item',
-                { data: { content: 'success' } },
+                'credit_usage',
+                { data: { credits_consumed: 5 } },
                 ctx,
                 deps,
                 state,
             );
 
             expect(state.consecutiveErrors).toBe(0);
+        });
+    });
+
+    describe('programmer errors (fail-fast, surfaced not swallowed)', () => {
+        it('re-throws a database schema error (undefined table, SQLSTATE 42P01)', async () => {
+            const ctx = createTestContext();
+            const deps = createDeps(new SchemaErrorDatabase());
+            const state = createResilienceState();
+
+            await expect(
+                routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state),
+            ).rejects.toThrow(/does not exist/);
+
+            expect(state.consecutiveErrors).toBe(0);
+            expect(getStream(ctx).sentEvents.filter(e => e.type === 'notification')).toHaveLength(0);
+        });
+
+        it('re-throws a TypeError (undefined function) without degrading', async () => {
+            const ctx = createTestContext();
+            const deps = createDeps(new TypeErrorDatabase());
+            const state = createResilienceState();
+
+            await expect(
+                routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state),
+            ).rejects.toBeInstanceOf(TypeError);
+
+            expect(state.consecutiveErrors).toBe(0);
+            expect(getStream(ctx).sentEvents.filter(e => e.type === 'notification')).toHaveLength(0);
         });
     });
 
@@ -303,7 +330,7 @@ describe('routeEventWithResilience', () => {
     });
 
     describe('escalation after MAX_CONSECUTIVE_HANDLER_ERRORS', () => {
-        it('escalates to fatal after 5 in a row, without emitting an extra notification', async () => {
+        it('escalates to fatal after 5 transient failures in a row, without an extra notification', async () => {
             expect(MAX_CONSECUTIVE_HANDLER_ERRORS).toBe(5);
 
             const ctx = createTestContext();
@@ -311,16 +338,10 @@ describe('routeEventWithResilience', () => {
             const state = createResilienceState();
             const stream = getStream(ctx);
 
-            // First (MAX - 1) calls degrade silently and emit one notification each.
+            // First (MAX - 1) calls degrade and emit one notification each.
             for (let i = 0; i < MAX_CONSECUTIVE_HANDLER_ERRORS - 1; i++) {
                 await expect(
-                    routeEventWithResilience(
-                        'create_inbox_item',
-                        { data: { content: `attempt ${i}` } },
-                        ctx,
-                        deps,
-                        state,
-                    ),
+                    routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state),
                 ).resolves.toBeUndefined();
             }
             expect(state.consecutiveErrors).toBe(MAX_CONSECUTIVE_HANDLER_ERRORS - 1);
@@ -329,13 +350,7 @@ describe('routeEventWithResilience', () => {
 
             // The MAXth call must re-throw and NOT emit a notification.
             await expect(
-                routeEventWithResilience(
-                    'create_inbox_item',
-                    { data: { content: 'final' } },
-                    ctx,
-                    deps,
-                    state,
-                ),
+                routeEventWithResilience('sandbox_lifecycle', sandboxLifecycleEvent, ctx, deps, state),
             ).rejects.toThrow('database unavailable');
 
             expect(state.consecutiveErrors).toBe(MAX_CONSECUTIVE_HANDLER_ERRORS);

--- a/xerus_backend/src/domains/execution/__tests__/post-session-memory-indexer.test.ts
+++ b/xerus_backend/src/domains/execution/__tests__/post-session-memory-indexer.test.ts
@@ -1,0 +1,204 @@
+// Post-Session Memory Indexer Tests
+// Uses in-memory fakes (not jest.mock) per project conventions.
+
+import {
+    indexAgentSessionMemory,
+    runPostSessionMemoryIndexing,
+    type SandboxMemoryReader,
+} from '../post-session-memory-indexer';
+import type { IndexFileOptions, MemoryIndexer } from '../../memory/git-memory/memory-search-index.service';
+import type { PipelineContext, ResolvedExecutionDeps } from '../execution-pipeline.types';
+import { PipelineInvariantError } from '../errors';
+import { SANDBOX_CONFIG } from '../../sandbox-infra/sandbox/sandbox.config';
+
+// -----------------------------------------------------------------------------
+// In-memory fakes (real objects implementing the injected interfaces)
+// -----------------------------------------------------------------------------
+
+class FakeMemoryReader implements SandboxMemoryReader {
+    constructor(
+        private readonly listing: Record<string, string[]>,
+        private readonly files: Record<string, string>,
+    ) {}
+
+    async listFiles(_sandboxId: string, dirPath: string): Promise<string[]> {
+        return this.listing[dirPath] ?? [];
+    }
+
+    async readFile(_sandboxId: string, filePath: string): Promise<string> {
+        const content = this.files[filePath];
+        if (content === undefined) {
+            throw new Error(`file not found: ${filePath}`);
+        }
+        return content;
+    }
+}
+
+class RecordingIndexer implements MemoryIndexer {
+    public readonly calls: IndexFileOptions[] = [];
+
+    async indexFile(options: IndexFileOptions): Promise<void> {
+        this.calls.push(options);
+    }
+}
+
+const ROOT = '/home/daytona';
+const AGENT = 'seo-agent';
+const AGENT_DIR = `${ROOT}/.memory/agents/${AGENT}`;
+
+// -----------------------------------------------------------------------------
+// indexAgentSessionMemory (core)
+// -----------------------------------------------------------------------------
+
+describe('indexAgentSessionMemory', () => {
+    it('indexes every .md file with the correct relative path, type, scope, and slug', async () => {
+        const reader = new FakeMemoryReader(
+            { [AGENT_DIR]: ['working.md', 'expertise.md', 'notes.txt', '.gitkeep'] },
+            {
+                [`${AGENT_DIR}/working.md`]: '# Working\nProgress so far.',
+                [`${AGENT_DIR}/expertise.md`]: '# Expertise\nSEO knowledge.',
+            },
+        );
+        const indexer = new RecordingIndexer();
+
+        const result = await indexAgentSessionMemory({
+            sandboxId: 'sbx-1',
+            workspaceId: 'ws-1',
+            agentSlug: AGENT,
+            provider: reader,
+            indexer,
+            workspaceRootPath: ROOT,
+        });
+
+        expect(result.indexedFiles).toBe(2);
+        expect(indexer.calls).toHaveLength(2);
+
+        expect(indexer.calls[0]).toEqual({
+            workspaceId: 'ws-1',
+            filePath: 'agents/seo-agent/working.md',
+            content: '# Working\nProgress so far.',
+            memoryType: 'working',
+            scope: 'agent',
+            agentSlug: AGENT,
+        });
+        expect(indexer.calls[1]).toMatchObject({
+            filePath: 'agents/seo-agent/expertise.md',
+            memoryType: 'expertise',
+            scope: 'agent',
+        });
+    });
+
+    it('skips empty and whitespace-only files', async () => {
+        const reader = new FakeMemoryReader(
+            { [AGENT_DIR]: ['working.md', 'empty.md', 'blank.md'] },
+            {
+                [`${AGENT_DIR}/working.md`]: 'real content',
+                [`${AGENT_DIR}/empty.md`]: '',
+                [`${AGENT_DIR}/blank.md`]: '   \n\t  ',
+            },
+        );
+        const indexer = new RecordingIndexer();
+
+        const result = await indexAgentSessionMemory({
+            sandboxId: 'sbx-1',
+            workspaceId: 'ws-1',
+            agentSlug: AGENT,
+            provider: reader,
+            indexer,
+            workspaceRootPath: ROOT,
+        });
+
+        expect(result.indexedFiles).toBe(1);
+        expect(indexer.calls.map((c) => c.filePath)).toEqual(['agents/seo-agent/working.md']);
+    });
+
+    it('indexes nothing when the agent memory directory has no .md files', async () => {
+        const reader = new FakeMemoryReader({ [AGENT_DIR]: ['.gitkeep'] }, {});
+        const indexer = new RecordingIndexer();
+
+        const result = await indexAgentSessionMemory({
+            sandboxId: 'sbx-1',
+            workspaceId: 'ws-1',
+            agentSlug: AGENT,
+            provider: reader,
+            indexer,
+            workspaceRootPath: ROOT,
+        });
+
+        expect(result.indexedFiles).toBe(0);
+        expect(indexer.calls).toHaveLength(0);
+    });
+
+    it('indexes nothing when the agent memory directory does not exist', async () => {
+        const reader = new FakeMemoryReader({}, {});
+        const indexer = new RecordingIndexer();
+
+        const result = await indexAgentSessionMemory({
+            sandboxId: 'sbx-1',
+            workspaceId: 'ws-1',
+            agentSlug: AGENT,
+            provider: reader,
+            indexer,
+            workspaceRootPath: ROOT,
+        });
+
+        expect(result.indexedFiles).toBe(0);
+        expect(indexer.calls).toHaveLength(0);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// runPostSessionMemoryIndexing (pipeline wrapper)
+// -----------------------------------------------------------------------------
+
+describe('runPostSessionMemoryIndexing', () => {
+    function makeCtx(agent: unknown, sandboxId: string | null): PipelineContext {
+        return { agent, sandboxId } as unknown as PipelineContext;
+    }
+
+    it('reads the agent memory dir via the daytona provider and indexes it', async () => {
+        const agentDir = `${SANDBOX_CONFIG.workspacePath}/.memory/agents/${AGENT}`;
+        const reader = new FakeMemoryReader(
+            { [agentDir]: ['working.md'] },
+            { [`${agentDir}/working.md`]: 'session progress' },
+        );
+        const indexer = new RecordingIndexer();
+        const deps = {
+            memorySearchIndex: indexer,
+            sandboxService: { getDaytonaProvider: () => reader },
+        } as unknown as ResolvedExecutionDeps;
+
+        await runPostSessionMemoryIndexing(
+            makeCtx({ slug: AGENT, workspace_id: 'ws-1' }, 'sbx-1'),
+            deps,
+        );
+
+        expect(indexer.calls).toHaveLength(1);
+        expect(indexer.calls[0]).toMatchObject({
+            workspaceId: 'ws-1',
+            filePath: 'agents/seo-agent/working.md',
+            agentSlug: AGENT,
+        });
+    });
+
+    it('throws a pipeline invariant error when workspace_id is missing', async () => {
+        const deps = { memorySearchIndex: {}, sandboxService: {} } as unknown as ResolvedExecutionDeps;
+        await expect(
+            runPostSessionMemoryIndexing(makeCtx({ slug: AGENT }, 'sbx-1'), deps),
+        ).rejects.toBeInstanceOf(PipelineInvariantError);
+    });
+
+    it('throws a pipeline invariant error when sandboxId is missing', async () => {
+        const deps = { memorySearchIndex: {}, sandboxService: {} } as unknown as ResolvedExecutionDeps;
+        await expect(
+            runPostSessionMemoryIndexing(makeCtx({ slug: AGENT, workspace_id: 'ws-1' }, null), deps),
+        ).rejects.toBeInstanceOf(PipelineInvariantError);
+    });
+
+    it('fails fast with a clear error when OPENAI_API_KEY (memorySearchIndex) is missing', async () => {
+        const deps = { memorySearchIndex: null, sandboxService: {} } as unknown as ResolvedExecutionDeps;
+        await expect(
+            runPostSessionMemoryIndexing(makeCtx({ slug: AGENT, workspace_id: 'ws-1' }, 'sbx-1'), deps),
+        ).rejects.toThrow(/OPENAI_API_KEY/);
+    });
+});

--- a/xerus_backend/src/domains/execution/__tests__/runner-event-router.test.ts
+++ b/xerus_backend/src/domains/execution/__tests__/runner-event-router.test.ts
@@ -425,82 +425,92 @@ describe('routeEventToBackend', () => {
     // --- Category B: DB write handlers ---
 
     describe('create_inbox_item', () => {
-        it('should insert inbox item with correct fields', async () => {
-            const ctx = createTestContext();
+        function createDepsWithWorkspaceDb() {
             const { deps, db } = createTestDeps();
+            const executedCommands: string[] = [];
+            deps.sandboxService = {
+                getDaytonaProvider: () => ({
+                    executeCommand: async (_sandboxId: string, command: string) => {
+                        executedCommands.push(command);
+                        return { code: 0, result: '[]' };
+                    },
+                }),
+                invalidateRegistryCache: () => {},
+            } as unknown as ResolvedExecutionDeps['sandboxService'];
+            return { deps, db, executedCommands };
+        }
+
+        it('should insert inbox item into workspace.db with correct fields', async () => {
+            const ctx = createTestContext();
+            const { deps, executedCommands } = createDepsWithWorkspaceDb();
 
             await routeEventToBackend('create_inbox_item', {
                 data: { channel: 'ch-001', content: 'Task completed', priority: 'high' },
             }, ctx, deps);
 
-            expect(db.queries).toHaveLength(1);
-            const q = db.getLastQuery()!;
-            expect(q.sql).toContain('INSERT INTO inbox_items');
-            expect(q.params[0]).toBe('user-123'); // userId
-            expect(q.params[1]).toBe('ch-001');   // channel_id
-            expect(q.params[2]).toBe('test-agent'); // agent_slug
-            expect(q.params[5]).toBe('Task completed'); // content
-            expect(q.params[6]).toBe('high');       // priority
+            expect(executedCommands).toHaveLength(1);
+            const sql = executedCommands[0];
+            expect(sql).toContain('INSERT INTO inbox_items');
+            expect(sql).toContain('test-agent');
+            expect(sql).toContain('Task completed');
+            expect(sql).toContain('high');
         });
 
         it('should default priority to normal', async () => {
             const ctx = createTestContext();
-            const { deps, db } = createTestDeps();
+            const { deps, executedCommands } = createDepsWithWorkspaceDb();
 
             await routeEventToBackend('create_inbox_item', {
                 data: { content: 'No priority specified' },
             }, ctx, deps);
 
-            const q = db.getLastQuery()!;
-            expect(q.params[6]).toBe('normal');
+            const sql = executedCommands[0];
+            expect(sql).toContain("'normal'");
         });
 
-        it('should truncate long content for title', async () => {
+        it('should truncate long content for subject', async () => {
             const ctx = createTestContext();
-            const { deps, db } = createTestDeps();
+            const { deps, executedCommands } = createDepsWithWorkspaceDb();
             const longContent = 'A'.repeat(100);
 
             await routeEventToBackend('create_inbox_item', {
                 data: { content: longContent },
             }, ctx, deps);
 
-            const q = db.getLastQuery()!;
-            const title = q.params[3] as string;
-            expect(title.length).toBe(80);
-            expect(title.endsWith('...')).toBe(true);
+            const sql = executedCommands[0];
+            expect(sql).toContain('...');
         });
 
-        it('should not truncate short content for title', async () => {
-            const ctx = createTestContext();
-            const { deps, db } = createTestDeps();
+        it('should throw when sandboxId is not set', async () => {
+            const ctx = createTestContext({ sandboxId: null });
+            const { deps } = createDepsWithWorkspaceDb();
 
-            await routeEventToBackend('create_inbox_item', {
-                data: { content: 'Short' },
-            }, ctx, deps);
-
-            const q = db.getLastQuery()!;
-            expect(q.params[3]).toBe('Short');
+            await expect(routeEventToBackend('create_inbox_item', {
+                data: { content: 'test' },
+            }, ctx, deps)).rejects.toThrow('sandboxId not set');
         });
 
         it('should throw when content is missing', async () => {
             const ctx = createTestContext();
-            const { deps } = createTestDeps();
+            const { deps } = createDepsWithWorkspaceDb();
 
             await expect(routeEventToBackend('create_inbox_item', {
                 data: { channel: 'ch-001' },
             }, ctx, deps)).rejects.toThrow('create_inbox_item');
         });
 
-        it('should use null for missing channel', async () => {
+        it('should write to workspace.db even without channel', async () => {
             const ctx = createTestContext();
-            const { deps, db } = createTestDeps();
+            const { deps, executedCommands } = createDepsWithWorkspaceDb();
 
             await routeEventToBackend('create_inbox_item', {
                 data: { content: 'No channel' },
             }, ctx, deps);
 
-            const q = db.getLastQuery()!;
-            expect(q.params[1]).toBeNull();
+            expect(executedCommands).toHaveLength(1);
+            const sql = executedCommands[0];
+            expect(sql).toContain('INSERT INTO inbox_items');
+            expect(sql).toContain('No channel');
         });
     });
 

--- a/xerus_backend/src/domains/execution/agent-config-resolver.ts
+++ b/xerus_backend/src/domains/execution/agent-config-resolver.ts
@@ -6,6 +6,10 @@ import type { AdapterType } from './types';
 import type { ResolvedExecutionDeps } from './execution-pipeline.types';
 import { parseAgentYamlFields } from '../../shared/agent-yaml-parser';
 import { buildWorkspaceStateSummary } from './workspace-state-builder';
+import {
+    COMMON_PLATFORM_TOOLS,
+    ALL_ORCHESTRATOR_PLATFORM_TOOLS,
+} from '../platform-tools/orchestrator/tool-access.constants';
 
 // -----------------------------------------------------------------------------
 // Agent Config Resolution
@@ -86,32 +90,13 @@ export async function resolveAdapterType(
 
 const XERUS_MASTER_SLUG = 'xerus-master';
 
-const ORCHESTRATOR_TOOLS = [
-    'create_agent', 'clone_agent', 'update_agent', 'delete_agent',
-    'create_channel', 'add_to_channel',
-    'upload_kb', 'assign_kb',
-    'create_skill', 'install_skill', 'uninstall_skill',
-    'connect_tool', 'register_trigger', 'deregister_trigger',
-    'create_schedule', 'update_schedule', 'delete_schedule',
-].map(t => `mcp__platform__${t}`);
-
-const COMMON_TOOLS = [
-    'create_task', 'update_task',
-    'search_agents', 'list_agents', 'search_kb',
-    'query_memory', 'write_memory', 'analyze_memory_patterns',
-    'search_outputs', 'send_notification',
-    'get_status', 'get_billing_status',
-    'search_skills', 'search_tools', 'list_domains',
-    'list_triggers', 'list_schedules',
-    'pause_execution', 'resume_execution', 'get_session_state',
-    'complete_session', 'cancel_execution',
-].map(t => `mcp__platform__${t}`);
+// Tool lists imported from tool-access.constants.ts — single source of truth
 
 export function buildPlatformRules(agentSlug: string, connectorTools?: string[]): string {
     const isOrchestrator = agentSlug === XERUS_MASTER_SLUG;
     const tools = isOrchestrator
-        ? [...ORCHESTRATOR_TOOLS, ...COMMON_TOOLS]
-        : COMMON_TOOLS;
+        ? ALL_ORCHESTRATOR_PLATFORM_TOOLS
+        : COMMON_PLATFORM_TOOLS;
 
     const lines = [
         '== Platform Rules ==',
@@ -183,6 +168,11 @@ export function buildPlatformRules(agentSlug: string, connectorTools?: string[])
             '- If the task description is long, write it to a markdown file in the channel first,',
             '  then reference the file path in the description',
             '',
+            'DELEGATION (critical):',
+            '- Delegate execution work to specialists via tasks — never do the work yourself.',
+            '- Follow up on task events. If a task stalls, reassign or escalate.',
+            '- Never poll for completion — react to events.',
+            '',
         );
     } else {
         lines.push(
@@ -192,6 +182,17 @@ export function buildPlatformRules(agentSlug: string, connectorTools?: string[])
             '',
         );
     }
+
+    lines.push(
+        '== Execution Contract ==',
+        '',
+        'START: Begin actionable work immediately. Do not stop at a plan unless the task explicitly asks for one.',
+        'WORK: Produce deliverables, not just commentary. Write files to output/deliverables/ and create/update tasks via MCP.',
+        'EXIT: Before ending, state what was produced, where it lives, and what remains. This is your exit disposition — it must be falsifiable.',
+        'COMMENTS: Updates and comments are evidence of work, not substitutes for work products.',
+        'AUTONOMY: Never ask a human to do what you could do with your tools. Attempt it first.',
+        '',
+    );
 
     return lines.join('\n');
 }

--- a/xerus_backend/src/domains/execution/background/heartbeat-daemon.ts
+++ b/xerus_backend/src/domains/execution/background/heartbeat-daemon.ts
@@ -1,254 +1,31 @@
-// Heartbeat Scheduler Daemon
-// Polls each running sandbox's workspace.db `schedules` table for due recurring
-// automations (status='active', next_run_at <= now) and triggers agent
-// executions through the execution pipeline with trigger_type='schedule'.
-// Advances next_run_at via the schedule's rrule so each schedule fires on its
-// cadence, and records every run in `schedule_runs`. One failed schedule never
-// blocks the others — each is wrapped in its own error boundary.
+// Heartbeat Daemon — SUPERSEDED by wake-daemon.ts + in-sandbox 9to5 scheduler.
 //
-// Sandbox enumeration uses SandboxService.getActiveSessions() (in-memory running
-// sandboxes). Schedules on paused sandboxes fire once their sandbox is resumed;
-// the daemon does not wake sandboxes (that would defeat the pause-to-save model).
+// Previously: polled each running sandbox's workspace.db schedules table and
+// fired agent executions directly from the backend. Replaced because:
+// 1. O(N) per-sandbox polling doesn't scale
+// 2. Dual schedulers (backend + in-sandbox) caused double-fire risk
+// 3. In-sandbox 9to5 now fires through POST /internal/v1/schedules/fire
+//    which gets full identity resolution, events, channel writes, SSE, billing
+//
+// Kept as a thin shim exporting start/stop so index.ts doesn't need changes
+// beyond the wake-daemon addition. The actual wake-for-sleeping-sandboxes
+// logic is in wake-daemon.ts.
 
-import { randomUUID } from 'crypto';
-import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service';
-import type { DaytonaProvider } from '../../sandbox-infra/sandbox/providers/daytona.provider';
-import type { ExecutionService } from '../execution.service';
-import type { ScheduleEntry } from '../../platform-tools/platform/platform-tool.inlined-types';
-import {
-    executeWorkspaceQuery,
-    executeWorkspaceJsonQuery,
-    escapeSQL,
-} from '../../conversations/workspace-db.helpers';
-import { computeNextRunAt } from '../../platform-tools/platform/tools/schedule.tools';
-import { NullStreamingResponse } from '../streaming/stream.handler';
 import { logger } from '../../../utils/logger';
 
 const log = logger('HeartbeatDaemon');
 
-const DEFAULT_INTERVAL_MS = 30_000;
-
 export interface HeartbeatDaemonDeps {
-    sandboxService: SandboxService;
-    executionService: ExecutionService;
+    sandboxService: unknown;
+    executionService: unknown;
     intervalMs?: number;
 }
 
-function nowEpochSeconds(): number {
-    return Math.floor(Date.now() / 1000);
-}
-
-export class HeartbeatDaemon {
-    private timer: NodeJS.Timeout | null = null;
-    private polling = false;
-    // Schedule ids with an execution still in flight — prevents stacking runs
-    // when an execution outlives its interval (e.g. a MINUTELY schedule whose
-    // agent takes several minutes). The claimed run fires once it finishes.
-    private readonly inFlight = new Set<string>();
-    private readonly deps: HeartbeatDaemonDeps;
-    private readonly intervalMs: number;
-
-    constructor(deps: HeartbeatDaemonDeps) {
-        this.deps = deps;
-        this.intervalMs = deps.intervalMs && deps.intervalMs > 0 ? deps.intervalMs : DEFAULT_INTERVAL_MS;
-    }
-
-    start(): void {
-        if (this.timer) return;
-        log.info('Starting heartbeat daemon', { interval_ms: this.intervalMs });
-        this.timer = setInterval(() => { void this.tick(); }, this.intervalMs);
-        // The express server keeps the process alive; the poller alone should not.
-        this.timer.unref?.();
-    }
-
-    stop(): void {
-        if (!this.timer) return;
-        clearInterval(this.timer);
-        this.timer = null;
-        log.info('Stopped heartbeat daemon');
-    }
-
-    isRunning(): boolean {
-        return this.timer !== null;
-    }
-
-    // One poll cycle. Guarded so a slow cycle never overlaps the next tick.
-    async tick(): Promise<void> {
-        if (this.polling) {
-            log.debug('Skipping tick — previous poll still running');
-            return;
-        }
-        this.polling = true;
-        try {
-            const sessions = this.deps.sandboxService.getActiveSessions();
-            for (const session of sessions) {
-                try {
-                    await this.processSandbox(session.userId, session.sandboxId);
-                } catch (err) {
-                    log.error('Failed to process sandbox schedules', {
-                        user_id: session.userId,
-                        sandbox_id: session.sandboxId,
-                        error: err instanceof Error ? err.message : String(err),
-                    });
-                }
-            }
-        } finally {
-            this.polling = false;
-        }
-    }
-
-    private async processSandbox(userId: string, sandboxId: string): Promise<void> {
-        const provider = this.deps.sandboxService.getDaytonaProvider();
-        const now = nowEpochSeconds();
-        const dueSql = `SELECT * FROM schedules
-            WHERE status = 'active'
-              AND rrule IS NOT NULL
-              AND next_run_at IS NOT NULL
-              AND next_run_at <= ${now}
-            ORDER BY next_run_at ASC;`;
-
-        const due = await executeWorkspaceJsonQuery<ScheduleEntry>(provider, sandboxId, dueSql);
-        if (due.length === 0) return;
-
-        log.info('Due schedules found', { user_id: userId, sandbox_id: sandboxId, count: due.length });
-
-        for (const schedule of due) {
-            try {
-                await this.fireSchedule(userId, sandboxId, provider, schedule);
-            } catch (err) {
-                log.error('Failed to fire schedule', {
-                    schedule_id: schedule.id,
-                    schedule_name: schedule.name,
-                    error: err instanceof Error ? err.message : String(err),
-                });
-            }
-        }
-    }
-
-    private async fireSchedule(
-        userId: string,
-        sandboxId: string,
-        provider: DaytonaProvider,
-        schedule: ScheduleEntry,
-    ): Promise<void> {
-        if (this.inFlight.has(schedule.id)) {
-            log.debug('Schedule still executing, skipping this tick', { schedule_id: schedule.id });
-            return;
-        }
-        if (!schedule.rrule) return; // guarded by the query; defensive
-
-        // Compute the next occurrence BEFORE triggering. A throw here (corrupt
-        // rrule) propagates to the per-schedule error boundary in processSandbox,
-        // which logs and skips without triggering an execution.
-        const nextRunAt = computeNextRunAt(schedule.rrule);
-        const now = nowEpochSeconds();
-
-        // Claim the schedule: advance next_run_at (NULL when the rule has no
-        // further occurrences) and stamp last_run_at. This must happen before
-        // triggering so the next poll does not re-fire this same occurrence.
-        const nextRunAtSql = nextRunAt != null ? String(nextRunAt) : 'NULL';
-        await executeWorkspaceQuery(
-            provider,
-            sandboxId,
-            `UPDATE schedules SET next_run_at = ${nextRunAtSql}, last_run_at = ${now}, updated_at = ${now}
-             WHERE id = '${escapeSQL(schedule.id)}';`,
-        );
-
-        const runId = randomUUID();
-        await executeWorkspaceQuery(
-            provider,
-            sandboxId,
-            `INSERT INTO schedule_runs (id, schedule_id, status, started_at, created_at)
-             VALUES ('${runId}', '${escapeSQL(schedule.id)}', 'running', ${now}, ${now});`,
-        );
-
-        this.inFlight.add(schedule.id);
-        log.info('Triggering scheduled execution', {
-            schedule_id: schedule.id,
-            schedule_name: schedule.name,
-            agent_slug: schedule.agent_slug,
-            user_id: userId,
-            run_id: runId,
-            next_run_at: nextRunAt,
-        });
-
-        // Fire the execution without blocking the poll loop, then close out the
-        // run-history row. Errors are captured on the run row, not thrown here.
-        const startedAtMs = Date.now();
-        void this.deps.executionService
-            .startExecution({
-                request: {
-                    agentSlug: schedule.agent_slug,
-                    task: schedule.prompt,
-                    userId,
-                    context: {
-                        trigger: 'schedule',
-                        schedule_id: schedule.id,
-                        schedule_name: schedule.name,
-                    },
-                },
-                stream: new NullStreamingResponse(),
-                triggerType: 'schedule',
-            })
-            .then(() => this.completeRun(provider, sandboxId, runId, 'completed', Date.now() - startedAtMs, null))
-            .catch((err: unknown) => {
-                const msg = err instanceof Error ? err.message : String(err);
-                log.error('Scheduled execution failed', { schedule_id: schedule.id, run_id: runId, error: msg });
-                return this.completeRun(provider, sandboxId, runId, 'failed', Date.now() - startedAtMs, msg);
-            })
-            .finally(() => {
-                this.inFlight.delete(schedule.id);
-            });
-    }
-
-    private async completeRun(
-        provider: DaytonaProvider,
-        sandboxId: string,
-        runId: string,
-        status: 'completed' | 'failed',
-        durationMs: number,
-        error: string | null,
-    ): Promise<void> {
-        const now = nowEpochSeconds();
-        const errorSql = error != null ? `'${escapeSQL(error)}'` : 'NULL';
-        try {
-            await executeWorkspaceQuery(
-                provider,
-                sandboxId,
-                `UPDATE schedule_runs SET status = '${status}', completed_at = ${now}, duration_ms = ${durationMs}, error = ${errorSql}
-                 WHERE id = '${runId}';`,
-            );
-        } catch (err) {
-            log.warn('Failed to record schedule run completion', {
-                run_id: runId,
-                error: err instanceof Error ? err.message : String(err),
-            });
-        }
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Process-level lifecycle (wired from index.ts)
-// -----------------------------------------------------------------------------
-
-let daemonInstance: HeartbeatDaemon | null = null;
-
-export function startHeartbeatDaemon(deps: HeartbeatDaemonDeps): HeartbeatDaemon {
-    if (daemonInstance) {
-        log.warn('Heartbeat daemon already started');
-        return daemonInstance;
-    }
-    const envRaw = process.env.HEARTBEAT_INTERVAL_MS;
-    const envInterval = envRaw ? Number(envRaw) : NaN;
-    const intervalMs = deps.intervalMs ?? (Number.isFinite(envInterval) && envInterval > 0 ? envInterval : undefined);
-
-    daemonInstance = new HeartbeatDaemon({ ...deps, intervalMs });
-    daemonInstance.start();
-    return daemonInstance;
+export function startHeartbeatDaemon(_deps: HeartbeatDaemonDeps): void {
+    log.info('HeartbeatDaemon superseded by wake-daemon + in-sandbox 9to5 scheduler — no-op');
 }
 
 export function stopHeartbeatDaemon(): void {
-    if (!daemonInstance) return;
-    daemonInstance.stop();
-    daemonInstance = null;
+    // no-op
 }
+

--- a/xerus_backend/src/domains/execution/background/wake-daemon.ts
+++ b/xerus_backend/src/domains/execution/background/wake-daemon.ts
@@ -1,0 +1,105 @@
+// Wake Daemon
+// Scans sandbox_wake_schedule (Neon) for sandboxes with due schedules,
+// wakes them via sandboxScheduler.wakeForHeartbeat(), then advances or
+// clears next_wake_at. Runs as a 60s setInterval in the backend process.
+
+import { query } from '../../../database/connection';
+import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service';
+import { logger } from '../../../utils/logger';
+
+const log = logger('WakeDaemon');
+
+const WAKE_INTERVAL_MS = 60_000;
+
+interface WakeRow {
+    sandbox_id: string;
+    user_id: string;
+}
+
+let timer: NodeJS.Timeout | null = null;
+let _sandboxService: SandboxService | null = null;
+
+async function tick(): Promise<void> {
+    if (!_sandboxService) return;
+
+    try {
+        const result = await query<WakeRow>(
+            `SELECT sandbox_id, user_id FROM sandbox_wake_schedule
+             WHERE next_wake_at IS NOT NULL AND next_wake_at <= NOW()`,
+        );
+
+        if (result.rows.length === 0) return;
+
+        log.info('Waking sandboxes with due schedules', { count: result.rows.length });
+
+        for (const row of result.rows) {
+            try {
+                const status = await _sandboxService.getSandboxStatus(row.user_id);
+                if (status.status === 'running') {
+                    log.debug('Sandbox already running, clearing wake', { sandbox_id: row.sandbox_id });
+                } else {
+                    log.info('Waking sandbox for due schedule', { sandbox_id: row.sandbox_id, user_id: row.user_id });
+                    await _sandboxService.getOrCreateSandbox({ userId: row.user_id });
+                }
+
+                // Clear next_wake_at — the 9to5 daemon inside the sandbox handles the actual firing.
+                // It will be re-set when the schedule fires and advances next_run_at,
+                // or when a new schedule is created/updated via schedule.tools.ts.
+                await query(
+                    `UPDATE sandbox_wake_schedule SET next_wake_at = NULL, updated_at = NOW()
+                     WHERE sandbox_id = $1`,
+                    [row.sandbox_id],
+                );
+            } catch (err) {
+                log.error('Failed to wake sandbox', {
+                    sandbox_id: row.sandbox_id,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            }
+        }
+    } catch (err) {
+        log.error('Wake daemon tick failed', {
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+}
+
+export function startWakeDaemon(sandboxService: SandboxService): void {
+    _sandboxService = sandboxService;
+    timer = setInterval(tick, WAKE_INTERVAL_MS);
+    log.info('Wake daemon started', { interval_ms: WAKE_INTERVAL_MS });
+}
+
+export function stopWakeDaemon(): void {
+    if (timer) {
+        clearInterval(timer);
+        timer = null;
+    }
+    _sandboxService = null;
+    log.info('Wake daemon stopped');
+}
+
+/**
+ * Recompute and upsert the earliest next_wake_at for a sandbox.
+ * Called by schedule routes after create/update/delete to keep the
+ * alarm clock in sync. Queries workspace.db for the minimum next_run_at
+ * across all active schedules.
+ */
+export async function recomputeWakeSchedule(
+    sandboxId: string,
+    userId: string,
+    earliestNextRunEpoch: number | null,
+): Promise<void> {
+    const nextWakeAt = earliestNextRunEpoch
+        ? new Date(earliestNextRunEpoch * 1000).toISOString()
+        : null;
+
+    await query(
+        `INSERT INTO sandbox_wake_schedule (sandbox_id, user_id, next_wake_at, updated_at)
+         VALUES ($1, $2, $3, NOW())
+         ON CONFLICT (sandbox_id) DO UPDATE SET
+             next_wake_at = $3,
+             updated_at = NOW()`,
+        [sandboxId, userId, nextWakeAt],
+    );
+}

--- a/xerus_backend/src/domains/execution/event-resilience.ts
+++ b/xerus_backend/src/domains/execution/event-resilience.ts
@@ -1,11 +1,22 @@
 // Event Routing Resilience
 //
-// Wraps routeEventToBackend so a single bad runner event cannot kill the
-// entire execution session. Fatal pipeline-invariant errors still propagate;
-// other handler exceptions are logged, counted, and degraded into a
-// 'notification' stream event. After MAX_CONSECUTIVE_HANDLER_ERRORS in a row
-// the latest error is re-thrown (the runner is producing nothing but bad
-// events — there is nothing to recover).
+// Wraps routeEventToBackend so a single bad runner event cannot kill the entire
+// execution session — WITHOUT ever swallowing an error silently.
+//
+// Fatal errors always propagate (fail-fast). They bubble up to the pipeline's
+// error handler, which marks the execution failed and emits the terminal SSE
+// error (done, success: false) the frontend renders as a failed run:
+//   - PipelineInvariantError — a missing required dep/state; the pipeline is broken.
+//   - Programmer errors — a bug in our own code or SQL (TypeError/ReferenceError,
+//     undefined table/column/function, malformed query). Recovering would only
+//     hide the defect.
+//
+// Transient external errors (DB temporarily unavailable, network blip) are the
+// only errors that may be caught. They are logged with structure, counted, and
+// surfaced to the user as a visible 'notification' (the agent is still running).
+// After MAX_CONSECUTIVE_HANDLER_ERRORS transient failures in a row the latest
+// error is re-thrown — the runner is producing nothing usable, so escalate to
+// fatal instead of looping.
 
 import { logger } from '../../utils/logger';
 import { PipelineInvariantError } from './errors';
@@ -14,8 +25,17 @@ import type { PipelineContext, ResolvedExecutionDeps } from './execution-pipelin
 
 const log = logger('EventResilience');
 
-/** Maximum consecutive non-fatal handler failures before escalating to fatal. */
+/** Maximum consecutive transient handler failures before escalating to fatal. */
 export const MAX_CONSECUTIVE_HANDLER_ERRORS = 5;
+
+// PostgreSQL SQLSTATE class 42 = "Syntax Error or Access Rule Violation":
+// undefined_table (42P01), undefined_column (42703), undefined_function (42883),
+// syntax_error (42601), etc. These are query/schema bugs, never transient.
+const PROGRAMMER_ERROR_SQLSTATE_CLASS = '42';
+
+// JS runtime errors that only occur from a code defect (calling/accessing an
+// undefined function or value, referencing an undefined name).
+const PROGRAMMER_ERROR_NAMES: ReadonlySet<string> = new Set(['TypeError', 'ReferenceError']);
 
 /** Mutable state for routeEventWithResilience across iterations of the event loop. */
 export interface ResilienceState {
@@ -24,6 +44,23 @@ export interface ResilienceState {
 
 export function createResilienceState(): ResilienceState {
     return { consecutiveErrors: 0 };
+}
+
+/**
+ * Distinguish a programmer error (a bug — fail fast) from a transient external
+ * error (a DB/network blip — degrade and keep running). Programmer errors are
+ * defects in our own code or SQL: a missing table/column/function, a malformed
+ * query, or a JS type/reference violation. They must never be swallowed.
+ */
+function isProgrammerError(err: unknown): boolean {
+    if (!(err instanceof Error)) {
+        return false;
+    }
+    if (PROGRAMMER_ERROR_NAMES.has(err.name)) {
+        return true;
+    }
+    const code = (err as { code?: unknown }).code;
+    return typeof code === 'string' && code.startsWith(PROGRAMMER_ERROR_SQLSTATE_CLASS);
 }
 
 export async function routeEventWithResilience(
@@ -37,18 +74,40 @@ export async function routeEventWithResilience(
         await routeEventToBackend(eventType, raw, ctx, deps);
         state.consecutiveErrors = 0;
     } catch (err) {
-        if (err instanceof PipelineInvariantError) {
+        const error = err as Error;
+        const errorCode = (err as { code?: unknown }).code ?? null;
+
+        // Fail-fast: pipeline invariants and programmer errors surface immediately
+        // so the execution is marked failed. Never degraded, never swallowed.
+        if (err instanceof PipelineInvariantError || isProgrammerError(err)) {
+            log.error('Event routing failed (fatal)', {
+                event_type: eventType,
+                error: error.message,
+                error_name: error.name,
+                error_code: errorCode,
+                fatal: true,
+            });
             throw err;
         }
+
         state.consecutiveErrors++;
-        log.error('Event routing failed (non-fatal)', {
+        log.error('Event routing failed (transient)', {
             event_type: eventType,
-            error: (err as Error).message,
+            error: error.message,
+            error_code: errorCode,
             consecutive_errors: state.consecutiveErrors,
+            fatal: false,
         });
+
+        // Too many transient failures in a row — the runner is producing nothing
+        // usable. Escalate to fatal so the execution fails instead of looping.
         if (state.consecutiveErrors >= MAX_CONSECUTIVE_HANDLER_ERRORS) {
             throw err;
         }
+
+        // Surface the degraded error to the user. The agent is still running, so
+        // this is a non-terminal 'notification' (priority 'error'), NOT a 'done'
+        // error — visible, never silent.
         if (!ctx.stream.isClosed()) {
             ctx.stream.send('notification', {
                 priority: 'error',

--- a/xerus_backend/src/domains/execution/execution-lifecycle.routes.ts
+++ b/xerus_backend/src/domains/execution/execution-lifecycle.routes.ts
@@ -1,0 +1,287 @@
+// Execution Lifecycle Routes
+// Neon-backed execution session endpoints:
+// - GET    /execute/sessions        -> List execution sessions (Neon PostgreSQL)
+// - POST   /execute/:id/respond     -> HITL response
+// - POST   /execute/:id/cancel      -> Cancel execution
+// - GET    /execute/:id/status      -> Get execution status
+//
+// Extracted from execution.routes.ts to keep files under 400 lines.
+// Mounted at '/' by execution.routes.ts AFTER the conversation/stream routes,
+// so earlier specific routes keep their matching precedence.
+
+import { Router, Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../../types';
+import { sendResponse } from '../../utils/response';
+import { BadRequestError, UnauthorizedError, NotFoundError } from '../../utils/errors';
+import { authenticateFirebaseToken } from '../../middleware/auth';
+import { query } from '../../database/connection';
+import { getSessionControlService } from '../platform-tools/platform/tools/session-control.tools';
+import {
+    serializeExecutionStatus,
+    serializeHITLAcknowledgment,
+    serializeCancellationResult,
+} from './streaming/response.contract';
+import { buildExecutionTimeline } from './execution-timeline';
+import type { ToolCallDetail } from './execution-pipeline.types';
+import {
+    validateUUID,
+    validateRespondBody,
+    validateCancelBody,
+} from './execution.validators';
+import { getExecutionService } from './execution-service.registry';
+
+const router = Router();
+const auth = authenticateFirebaseToken;
+
+// GET /api/v1/execute/sessions - List execution sessions (Neon PostgreSQL)
+// Supports ?agent_slug=... &limit=... &offset=...
+router.get('/sessions', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const startTime = res.locals.startTime || Date.now();
+    try {
+        if (!req.user) throw new UnauthorizedError();
+
+        const agentSlug = req.query.agent_slug as string | undefined;
+        const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
+        const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : 0;
+
+        if (isNaN(limit) || limit < 1) {
+            throw new BadRequestError('limit must be a positive integer');
+        }
+        if (isNaN(offset) || offset < 0) {
+            throw new BadRequestError('offset must be a non-negative integer');
+        }
+
+        // limit and offset are validated integers above, so safe to interpolate.
+        // Binding them as parameters causes "could not determine data type" on
+        // Neon/Postgres because LIMIT/OFFSET positions don't give pg enough
+        // context to infer the type.
+        const params: unknown[] = [req.user.uid];
+        let agentFilter = '';
+        if (agentSlug) {
+            agentFilter = 'AND es.agent_slug = $2';
+            params.push(agentSlug);
+        }
+
+        const result = await query<SessionListRow>(
+            `SELECT es.id, es.agent_slug, es.status, es.trigger_type,
+                    es.user_prompt, es.input_tokens, es.output_tokens,
+                    es.credits_used, es.started_at, es.completed_at, es.created_at
+             FROM execution_sessions es
+             JOIN workspaces w ON es.workspace_id = w.id
+             WHERE w.user_id = $1 ${agentFilter}
+             ORDER BY es.created_at DESC
+             LIMIT ${limit} OFFSET ${offset}`,
+            params,
+        );
+
+        const countResult = await query<{ count: string }>(
+            `SELECT COUNT(*) as count
+             FROM execution_sessions es
+             JOIN workspaces w ON es.workspace_id = w.id
+             WHERE w.user_id = $1 ${agentFilter}`,
+            params,
+        );
+
+        const total = parseInt(countResult.rows[0]?.count ?? '0', 10);
+
+        sendResponse(res, 200, { sessions: result.rows, total }, startTime);
+    } catch (err) {
+        next(err);
+    }
+});
+
+// POST /api/v1/execute/:id/respond - HITL response
+router.post('/:id/respond', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const startTime = res.locals.startTime || Date.now();
+    try {
+        if (!req.user) {
+            throw new UnauthorizedError();
+        }
+
+        validateUUID(req.params.id, 'execution id');
+        const validated = validateRespondBody(req.body);
+
+        const sessionControl = getSessionControlService();
+
+        // Validate guidance_id BEFORE resuming to avoid accidentally resolving the wrong pause
+        if (validated.guidance_id) {
+            const state = await sessionControl.getSessionState(req.user.uid, { sessionId: req.params.id });
+            const activePauseId = state.pendingApproval?.pauseId;
+            if (activePauseId && activePauseId !== validated.guidance_id) {
+                throw new BadRequestError(
+                    `guidance_id mismatch: expected ${activePauseId}, got ${validated.guidance_id}`,
+                );
+            }
+        }
+
+        const resumeResult = await sessionControl.resumeExecution(req.user.uid, {
+            sessionId: req.params.id,
+            approved: validated.accepted,
+            feedback: validated.response_value,
+        });
+
+        // Forward HITL response to the runner process via stdin
+        const executionService = getExecutionService();
+        const sent = await executionService.respondToHitl(
+            req.params.id,
+            resumeResult.pauseId,
+            validated.accepted,
+            validated.response_value,
+        );
+        if (!sent) {
+            throw new NotFoundError('Active execution not found; runner may have restarted');
+        }
+
+        const response = serializeHITLAcknowledgment({
+            executionId: req.params.id,
+            guidanceId: validated.guidance_id,
+            accepted: validated.accepted,
+            responseValue: validated.response_value,
+        });
+
+        sendResponse(res, 200, response, startTime);
+    } catch (err) {
+        next(err);
+    }
+});
+
+// POST /api/v1/execute/:id/cancel - Cancel execution
+router.post('/:id/cancel', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const startTime = res.locals.startTime || Date.now();
+    try {
+        if (!req.user) {
+            throw new UnauthorizedError();
+        }
+
+        validateUUID(req.params.id, 'execution id');
+        const validated = validateCancelBody(req.body);
+
+        // Verify ownership before allowing cancellation
+        const ownershipCheck = await query(
+            `SELECT es.id FROM execution_sessions es
+             JOIN workspaces w ON es.workspace_id = w.id
+             WHERE es.id = $1::uuid AND w.user_id = $2`,
+            [req.params.id, req.user.uid],
+        );
+        if (ownershipCheck.rows.length === 0) {
+            throw new NotFoundError('Execution session');
+        }
+
+        const executionService = getExecutionService();
+        const cancelled = executionService.cancelExecution(req.params.id);
+
+        if (cancelled) {
+            await query(
+                `UPDATE execution_sessions SET status = 'cancelled', completed_at = NOW()
+                 WHERE id = $1::uuid`,
+                [req.params.id],
+            );
+        }
+
+        const response = serializeCancellationResult({
+            executionId: req.params.id,
+            cancelled,
+            method: validated.method,
+            reason: validated.reason,
+        });
+
+        sendResponse(res, 200, response, startTime);
+    } catch (err) {
+        next(err);
+    }
+});
+
+// GET /api/v1/execute/:id/status - Get execution status
+router.get('/:id/status', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const startTime = res.locals.startTime || Date.now();
+    try {
+        if (!req.user) {
+            throw new UnauthorizedError();
+        }
+
+        validateUUID(req.params.id, 'execution id');
+
+        const result = await query<StatusRow>(
+            `SELECT es.id, es.status, es.agent_slug, es.started_at, es.completed_at,
+                    es.input_tokens, es.output_tokens, es.credits_used, es.message_metadata, es.key_source
+             FROM execution_sessions es
+             JOIN workspaces w ON es.workspace_id = w.id
+             WHERE es.id = $1::uuid AND w.user_id = $2`,
+            [req.params.id, req.user.uid],
+        );
+
+        if (result.rows.length === 0) {
+            throw new NotFoundError('Execution session');
+        }
+
+        const row = result.rows[0];
+
+        if (!row.started_at && row.status !== 'pending') {
+            throw new Error(`Data integrity: execution ${row.id} has status '${row.status}' but null started_at`);
+        }
+
+        // Tool calls are persisted in message_metadata JSONB (no dedicated column).
+        // Build a step-level timeline for the "View work" panel; the summary's
+        // toolCalls count is derived from the same array.
+        const rawToolCalls: ToolCallDetail[] = Array.isArray(row.message_metadata?.tool_calls)
+            ? (row.message_metadata.tool_calls as ToolCallDetail[])
+            : [];
+        const timeline = buildExecutionTimeline(rawToolCalls);
+
+        const response = serializeExecutionStatus({
+            executionId: row.id,
+            status: row.status as 'pending' | 'running' | 'completed' | 'failed' | 'cancelled',
+            agentSlug: row.agent_slug,
+            startedAt: row.started_at ? row.started_at.toISOString() : new Date().toISOString(),
+            completedAt: row.completed_at?.toISOString(),
+            summary: row.status === 'completed' ? {
+                totalTokens: (row.input_tokens ?? 0) + (row.output_tokens ?? 0),
+                durationMs: row.completed_at && row.started_at
+                    ? new Date(row.completed_at).getTime() - new Date(row.started_at).getTime()
+                    : 0,
+                toolCalls: rawToolCalls.length,
+                agentsUsed: 1,
+                billingType: row.key_source ?? undefined,
+            } : undefined,
+            steps: timeline.steps,
+            filesChanged: timeline.files_changed,
+        });
+
+        sendResponse(res, 200, response, startTime);
+    } catch (err) {
+        next(err);
+    }
+});
+
+// -----------------------------------------------------------------------------
+// DB Row Types
+// -----------------------------------------------------------------------------
+
+interface StatusRow {
+    id: string;
+    status: string;
+    agent_slug: string;
+    started_at: Date | null;
+    completed_at: Date | null;
+    input_tokens: number | null;
+    output_tokens: number | null;
+    credits_used: string | null;
+    message_metadata: { tool_calls?: unknown[] } | null;
+    key_source: 'byok' | 'platform' | null;
+}
+
+interface SessionListRow {
+    id: string;
+    agent_slug: string;
+    status: string;
+    trigger_type: string | null;
+    user_prompt: string | null;
+    input_tokens: number | null;
+    output_tokens: number | null;
+    credits_used: string | null;
+    started_at: Date | null;
+    completed_at: Date | null;
+    created_at: Date;
+}
+
+export default router;

--- a/xerus_backend/src/domains/execution/execution-pipeline.ts
+++ b/xerus_backend/src/domains/execution/execution-pipeline.ts
@@ -299,9 +299,10 @@ async function processEventStream(
     // events belonging to its agent — prevents identity leakage across streams.
     const expectedSlug = requireAgent(ctx).slug;
     let eventsProcessed = 0;
-    // Resilience: routeEventWithResilience tracks consecutive non-fatal handler
-    // failures across iterations. Fatal invariants re-throw; non-fatal errors are
-    // logged + degraded into a 'notification' until MAX_CONSECUTIVE_HANDLER_ERRORS.
+    // Resilience: routeEventWithResilience tracks consecutive transient handler
+    // failures across iterations. Fatal invariants and programmer errors re-throw
+    // (fail-fast); transient errors are logged + surfaced as a visible
+    // 'notification' until MAX_CONSECUTIVE_HANDLER_ERRORS escalates to fatal.
     const resilience = createResilienceState();
 
     // Safety: abort if no events arrive within FIRST_EVENT_TIMEOUT_MS.

--- a/xerus_backend/src/domains/execution/execution-service.registry.ts
+++ b/xerus_backend/src/domains/execution/execution-service.registry.ts
@@ -1,0 +1,20 @@
+// Execution Service Registry
+// Lazy singleton access to the ExecutionService instance.
+// Extracted from execution.routes.ts so multiple route modules
+// (execution.routes.ts, execution-lifecycle.routes.ts) share one instance
+// without importing each other (avoids circular deps).
+
+import { ExecutionService } from './execution.service';
+
+let executionServiceInstance: ExecutionService | null = null;
+
+export function getExecutionService(): ExecutionService {
+    if (!executionServiceInstance) {
+        throw new Error('ExecutionService not initialized. Call setExecutionService() at startup.');
+    }
+    return executionServiceInstance;
+}
+
+export function setExecutionService(service: ExecutionService): void {
+    executionServiceInstance = service;
+}

--- a/xerus_backend/src/domains/execution/execution.routes.ts
+++ b/xerus_backend/src/domains/execution/execution.routes.ts
@@ -7,14 +7,15 @@
 // - DELETE /execute/conversations/:id          -> Delete conversation (soft)
 // - GET    /execute/conversations/:id/stream   -> Long-lived SSE stream per conversation
 // - POST   /execute/conversations/:id/messages -> Submit message (returns 202)
-// - POST   /execute/:id/respond                -> HITL response
-// - POST   /execute/:id/cancel                 -> Cancel execution
-// - GET    /execute/:id/status                 -> Get execution status
 // - GET    /execute/schedules                  -> List schedules (workspace.db)
 // - POST   /execute/schedules                  -> Create schedule
 // - PATCH  /execute/schedules/:id              -> Update schedule
 // - DELETE /execute/schedules/:id              -> Delete schedule
 // - GET    /execute/schedules/runs             -> List schedule runs (workspace.db)
+//
+// Neon-backed session lifecycle routes (/sessions, /:id/respond, /:id/cancel,
+// /:id/status) live in execution-lifecycle.routes.ts and are mounted below,
+// after the conversation/stream routes to preserve route-matching precedence.
 
 import { Router, Response, NextFunction } from 'express';
 import { logger } from '../../utils/logger';
@@ -24,30 +25,17 @@ import { sendResponse } from '../../utils/response';
 import { BadRequestError, UnauthorizedError, NotFoundError, RateLimitError } from '../../utils/errors';
 import { authenticateFirebaseToken } from '../../middleware/auth';
 import { sseAuth, createSseTokenHandler } from '../../middleware/sse-auth';
-import { query } from '../../database/connection';
-import { ExecutionService } from './execution.service';
 import { StreamingResponse } from './streaming/stream.handler';
 import { sseRegistry } from './streaming/sse-registry';
-import { getSessionControlService } from '../platform-tools/platform/tools/session-control.tools';
-import {
-    serializeExecutionStatus,
-    serializeHITLAcknowledgment,
-    serializeCancellationResult,
-} from './streaming/response.contract';
-import { buildExecutionTimeline } from './execution-timeline';
-import type { ToolCallDetail } from './execution-pipeline.types';
-import {
-    validateUUID,
-    validateMessageBody,
-    validateRespondBody,
-    validateCancelBody,
-} from './execution.validators';
+import { validateUUID, validateMessageBody } from './execution.validators';
 import type { SandboxService } from '../sandbox-infra/sandbox/sandbox.service';
 import { requireRunningSandbox, getDaytonaProvider } from '../sandbox-infra/sandbox/sandbox-route-helpers';
 import agentFilesRouter from './agent-files.routes';
 import conversationRouter from '../conversations/conversation.routes';
 import scheduleFrontendRouter, { setScheduleFrontendRoutesDeps } from './schedule.routes';
 import { getConversation } from '../conversations/workspace-db.service';
+import executionLifecycleRouter from './execution-lifecycle.routes';
+import { getExecutionService, setExecutionService } from './execution-service.registry';
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -108,63 +96,6 @@ router.use('/conversations', conversationRouter);
 
 // Mount schedule CRUD + run history routes (workspace.db queries)
 router.use('/schedules', scheduleFrontendRouter);
-
-// GET /api/v1/execute/sessions - List execution sessions (Neon PostgreSQL)
-// Supports ?agent_slug=... &limit=... &offset=...
-router.get('/sessions', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const startTime = res.locals.startTime || Date.now();
-    try {
-        if (!req.user) throw new UnauthorizedError();
-
-        const agentSlug = req.query.agent_slug as string | undefined;
-        const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
-        const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : 0;
-
-        if (isNaN(limit) || limit < 1) {
-            throw new BadRequestError('limit must be a positive integer');
-        }
-        if (isNaN(offset) || offset < 0) {
-            throw new BadRequestError('offset must be a non-negative integer');
-        }
-
-        // limit and offset are validated integers above, so safe to interpolate.
-        // Binding them as parameters causes "could not determine data type" on
-        // Neon/Postgres because LIMIT/OFFSET positions don't give pg enough
-        // context to infer the type.
-        const params: unknown[] = [req.user.uid];
-        let agentFilter = '';
-        if (agentSlug) {
-            agentFilter = 'AND es.agent_slug = $2';
-            params.push(agentSlug);
-        }
-
-        const result = await query<SessionListRow>(
-            `SELECT es.id, es.agent_slug, es.status, es.trigger_type,
-                    es.user_prompt, es.input_tokens, es.output_tokens,
-                    es.credits_used, es.started_at, es.completed_at, es.created_at
-             FROM execution_sessions es
-             JOIN workspaces w ON es.workspace_id = w.id
-             WHERE w.user_id = $1 ${agentFilter}
-             ORDER BY es.created_at DESC
-             LIMIT ${limit} OFFSET ${offset}`,
-            params,
-        );
-
-        const countResult = await query<{ count: string }>(
-            `SELECT COUNT(*) as count
-             FROM execution_sessions es
-             JOIN workspaces w ON es.workspace_id = w.id
-             WHERE w.user_id = $1 ${agentFilter}`,
-            params,
-        );
-
-        const total = parseInt(countResult.rows[0]?.count ?? '0', 10);
-
-        sendResponse(res, 200, { sessions: result.rows, total }, startTime);
-    } catch (err) {
-        next(err);
-    }
-});
 
 // POST /api/v1/execute/sse-token - Issue a short-lived, single-use token for SSE auth
 router.post('/sse-token', auth, createSseTokenHandler());
@@ -302,215 +233,18 @@ router.post('/conversations/:id/messages', auth, executionRateLimit, async (req:
     }
 });
 
-// POST /api/v1/execute/:id/respond - HITL response
-router.post('/:id/respond', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const startTime = res.locals.startTime || Date.now();
-    try {
-        if (!req.user) {
-            throw new UnauthorizedError();
-        }
-
-        validateUUID(req.params.id, 'execution id');
-        const validated = validateRespondBody(req.body);
-
-        const sessionControl = getSessionControlService();
-
-        // Validate guidance_id BEFORE resuming to avoid accidentally resolving the wrong pause
-        if (validated.guidance_id) {
-            const state = await sessionControl.getSessionState(req.user.uid, { sessionId: req.params.id });
-            const activePauseId = state.pendingApproval?.pauseId;
-            if (activePauseId && activePauseId !== validated.guidance_id) {
-                throw new BadRequestError(
-                    `guidance_id mismatch: expected ${activePauseId}, got ${validated.guidance_id}`,
-                );
-            }
-        }
-
-        const resumeResult = await sessionControl.resumeExecution(req.user.uid, {
-            sessionId: req.params.id,
-            approved: validated.accepted,
-            feedback: validated.response_value,
-        });
-
-        // Forward HITL response to the runner process via stdin
-        const executionService = getExecutionService();
-        const sent = await executionService.respondToHitl(
-            req.params.id,
-            resumeResult.pauseId,
-            validated.accepted,
-            validated.response_value,
-        );
-        if (!sent) {
-            throw new NotFoundError('Active execution not found; runner may have restarted');
-        }
-
-        const response = serializeHITLAcknowledgment({
-            executionId: req.params.id,
-            guidanceId: validated.guidance_id,
-            accepted: validated.accepted,
-            responseValue: validated.response_value,
-        });
-
-        sendResponse(res, 200, response, startTime);
-    } catch (err) {
-        next(err);
-    }
-});
-
-// POST /api/v1/execute/:id/cancel - Cancel execution
-router.post('/:id/cancel', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const startTime = res.locals.startTime || Date.now();
-    try {
-        if (!req.user) {
-            throw new UnauthorizedError();
-        }
-
-        validateUUID(req.params.id, 'execution id');
-        const validated = validateCancelBody(req.body);
-
-        // Verify ownership before allowing cancellation
-        const ownershipCheck = await query(
-            `SELECT es.id FROM execution_sessions es
-             JOIN workspaces w ON es.workspace_id = w.id
-             WHERE es.id = $1::uuid AND w.user_id = $2`,
-            [req.params.id, req.user.uid],
-        );
-        if (ownershipCheck.rows.length === 0) {
-            throw new NotFoundError('Execution session');
-        }
-
-        const executionService = getExecutionService();
-        const cancelled = executionService.cancelExecution(req.params.id);
-
-        if (cancelled) {
-            await query(
-                `UPDATE execution_sessions SET status = 'cancelled', completed_at = NOW()
-                 WHERE id = $1::uuid`,
-                [req.params.id],
-            );
-        }
-
-        const response = serializeCancellationResult({
-            executionId: req.params.id,
-            cancelled,
-            method: validated.method,
-            reason: validated.reason,
-        });
-
-        sendResponse(res, 200, response, startTime);
-    } catch (err) {
-        next(err);
-    }
-});
-
-// GET /api/v1/execute/:id/status - Get execution status
-router.get('/:id/status', auth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const startTime = res.locals.startTime || Date.now();
-    try {
-        if (!req.user) {
-            throw new UnauthorizedError();
-        }
-
-        validateUUID(req.params.id, 'execution id');
-
-        const result = await query<StatusRow>(
-            `SELECT es.id, es.status, es.agent_slug, es.started_at, es.completed_at,
-                    es.input_tokens, es.output_tokens, es.credits_used, es.message_metadata, es.key_source
-             FROM execution_sessions es
-             JOIN workspaces w ON es.workspace_id = w.id
-             WHERE es.id = $1::uuid AND w.user_id = $2`,
-            [req.params.id, req.user.uid],
-        );
-
-        if (result.rows.length === 0) {
-            throw new NotFoundError('Execution session');
-        }
-
-        const row = result.rows[0];
-
-        if (!row.started_at && row.status !== 'pending') {
-            throw new Error(`Data integrity: execution ${row.id} has status '${row.status}' but null started_at`);
-        }
-
-        // Tool calls are persisted in message_metadata JSONB (no dedicated column).
-        // Build a step-level timeline for the "View work" panel; the summary's
-        // toolCalls count is derived from the same array.
-        const rawToolCalls: ToolCallDetail[] = Array.isArray(row.message_metadata?.tool_calls)
-            ? (row.message_metadata.tool_calls as ToolCallDetail[])
-            : [];
-        const timeline = buildExecutionTimeline(rawToolCalls);
-
-        const response = serializeExecutionStatus({
-            executionId: row.id,
-            status: row.status as 'pending' | 'running' | 'completed' | 'failed' | 'cancelled',
-            agentSlug: row.agent_slug,
-            startedAt: row.started_at ? row.started_at.toISOString() : new Date().toISOString(),
-            completedAt: row.completed_at?.toISOString(),
-            summary: row.status === 'completed' ? {
-                totalTokens: (row.input_tokens ?? 0) + (row.output_tokens ?? 0),
-                durationMs: row.completed_at && row.started_at
-                    ? new Date(row.completed_at).getTime() - new Date(row.started_at).getTime()
-                    : 0,
-                toolCalls: rawToolCalls.length,
-                agentsUsed: 1,
-                billingType: row.key_source ?? undefined,
-            } : undefined,
-            steps: timeline.steps,
-            filesChanged: timeline.files_changed,
-        });
-
-        sendResponse(res, 200, response, startTime);
-    } catch (err) {
-        next(err);
-    }
-});
+// Mount Neon-backed session lifecycle routes (/sessions, /:id/respond,
+// /:id/cancel, /:id/status). Registered last so the specific routes above
+// (e.g. /conversations/:id/stream, /sse-token) keep matching precedence.
+router.use('/', executionLifecycleRouter);
 
 // -----------------------------------------------------------------------------
-// DB Row Types
+// Re-exports (backward compatibility)
 // -----------------------------------------------------------------------------
 
-interface StatusRow {
-    id: string;
-    status: string;
-    agent_slug: string;
-    started_at: Date | null;
-    completed_at: Date | null;
-    input_tokens: number | null;
-    output_tokens: number | null;
-    credits_used: string | null;
-    message_metadata: { tool_calls?: unknown[] } | null;
-    key_source: 'byok' | 'platform' | null;
-}
-
-interface SessionListRow {
-    id: string;
-    agent_slug: string;
-    status: string;
-    trigger_type: string | null;
-    user_prompt: string | null;
-    input_tokens: number | null;
-    output_tokens: number | null;
-    credits_used: string | null;
-    started_at: Date | null;
-    completed_at: Date | null;
-    created_at: Date;
-}
-
-// -----------------------------------------------------------------------------
-// Lazy Service Access
-// -----------------------------------------------------------------------------
-
-let executionServiceInstance: ExecutionService | null = null;
-
-export function getExecutionService(): ExecutionService {
-    if (!executionServiceInstance) {
-        throw new Error('ExecutionService not initialized. Call setExecutionService() at startup.');
-    }
-    return executionServiceInstance;
-}
-
-export function setExecutionService(service: ExecutionService): void {
-    executionServiceInstance = service;
-}
+// Callers (index.ts, jobs/digest-scheduler.ts, internal-mcp/channel-task.routes.ts)
+// import these from execution.routes; the implementations live in the shared
+// execution-service.registry module.
+export { getExecutionService, setExecutionService };
 
 export default router;

--- a/xerus_backend/src/domains/execution/execution.service.ts
+++ b/xerus_backend/src/domains/execution/execution.service.ts
@@ -50,6 +50,7 @@ import { checkHookHealth } from '../sandbox-infra/sandbox/hook-health';
 import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
 import { createChannelMessage } from '../company/company-workspace-db.service';
 import { syncMessageToSandbox } from '../company/channel-execution.service';
+import { escapeSQL, executeWorkspaceJsonQuery } from '../conversations/workspace-db.helpers';
 
 const log = logger('ExecutionService');
 // -----------------------------------------------------------------------------
@@ -319,26 +320,48 @@ export class ExecutionService {
 
             // Channel message routing: write agent response to channel_messages
             // so it appears in the /inbox activity feed (not just /chat).
-            const channelSlug = ctx.request.context?.channel_slug as string | undefined;
-            if (ctx.triggerType === 'channel_message' && channelSlug && ctx.responseText && ctx.sandboxId) {
+            // Supports: channel_message (explicit channel), schedule/task_assigned (resolve from membership).
+            const responseText = ctx.responseText || ctx.responseChunks.join('');
+            if (responseText && ctx.sandboxId) {
                 const agentSlug = ctx.agent?.slug || ctx.request.agentSlug;
-                log.info('Writing agent response to channel_messages', {
-                    channel: channelSlug, agent: agentSlug, length: ctx.responseText.length,
-                });
+                let targetChannel = ctx.request.context?.channel_slug as string | undefined;
 
-                // Join response chunks if responseText is empty but chunks exist
-                const responseText = ctx.responseText || ctx.responseChunks.join('');
-                if (responseText) {
+                // For non-channel triggers, resolve the agent's primary channel from workspace.db
+                if (!targetChannel && (ctx.triggerType === 'schedule' || ctx.triggerType === 'task_assigned')) {
+                    try {
+                        const rows = await executeWorkspaceJsonQuery<{ channel_slug: string }>(
+                            daytonaProvider, ctx.sandboxId,
+                            `SELECT channel_slug FROM channel_members WHERE agent_slug = '${escapeSQL(agentSlug)}' LIMIT 1`,
+                        );
+                        targetChannel = rows[0]?.channel_slug;
+                    } catch (err) {
+                        log.warn('Failed to resolve agent channel for autonomous post', {
+                            agent: agentSlug, error: err instanceof Error ? err.message : String(err),
+                        });
+                    }
+                }
+
+                const shouldWriteChannel = targetChannel && (
+                    ctx.triggerType === 'channel_message' ||
+                    ctx.triggerType === 'schedule' ||
+                    ctx.triggerType === 'task_assigned'
+                );
+
+                if (shouldWriteChannel && targetChannel) {
+                    log.info('Writing agent response to channel_messages', {
+                        channel: targetChannel, agent: agentSlug, trigger: ctx.triggerType,
+                        length: responseText.length,
+                    });
+
                     await createChannelMessage(
                         daytonaProvider, ctx.sandboxId,
-                        channelSlug, 'agent', agentSlug,
+                        targetChannel, 'agent', agentSlug,
                         responseText, 'post', {},
                     ).catch(err => log.warn('Failed to write agent response to channel_messages', {
                         error: err instanceof Error ? err.message : String(err),
                     }));
 
-                    // Also sync to posts.jsonl for agent IPC
-                    const parts = channelSlug.split('--');
+                    const parts = targetChannel.split('--');
                     if (parts.length === 2) {
                         const channelTag = `${parts[0]}/${parts[1]}`;
                         syncMessageToSandbox(resolved.sandboxService, request.userId, channelTag, {

--- a/xerus_backend/src/domains/execution/internal-execution.routes.ts
+++ b/xerus_backend/src/domains/execution/internal-execution.routes.ts
@@ -1,0 +1,146 @@
+// Internal Execution Routes
+// Backend API endpoints for in-sandbox schedule daemon to fire executions.
+// Auth: same internal-token middleware as platform-tools/internal-mcp.
+
+import crypto from 'crypto';
+import { Router, Response, NextFunction } from 'express';
+import { BadRequestError, UnauthorizedError } from '../../utils/errors';
+import { logger } from '../../utils/logger';
+import { NullStreamingResponse } from './streaming/stream.handler';
+import type { ExecutionService } from './execution.service';
+
+const log = logger('InternalExecution');
+
+const INTERNAL_API_TOKEN = process.env.XERUS_INTERNAL_API_TOKEN;
+
+const router = Router();
+
+let _executionService: ExecutionService | null = null;
+
+const inFlightSchedules = new Map<string, string>();
+
+export function setInternalExecutionDeps(deps: { executionService: ExecutionService }): void {
+    _executionService = deps.executionService;
+}
+
+function getExecutionService(): ExecutionService {
+    if (!_executionService) {
+        throw new Error('Internal execution routes dependencies not initialized');
+    }
+    return _executionService;
+}
+
+function authenticateInternal(
+    req: { headers: { authorization?: string }; body: Record<string, unknown> },
+    _res: Response,
+    next: NextFunction,
+): void {
+    try {
+        if (!INTERNAL_API_TOKEN) {
+            throw new UnauthorizedError('XERUS_INTERNAL_API_TOKEN not configured');
+        }
+
+        const authHeader = req.headers.authorization;
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            throw new UnauthorizedError('Missing internal API token');
+        }
+
+        const token = authHeader.split('Bearer ')[1];
+        const tokenBuf = Buffer.from(token);
+        const expectedBuf = Buffer.from(INTERNAL_API_TOKEN);
+        if (tokenBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(tokenBuf, expectedBuf)) {
+            throw new UnauthorizedError('Invalid internal API token');
+        }
+
+        next();
+    } catch (error) {
+        next(error);
+    }
+}
+
+router.use(authenticateInternal);
+
+// POST /internal/v1/schedules/fire
+// Body: { schedule_id, agent_slug, prompt, system_prompt?, scheduled_for, user_id }
+// Idempotent: duplicate (schedule_id, scheduled_for) returns existing execution id.
+router.post('/schedules/fire', async (req, res: Response, next: NextFunction) => {
+    try {
+        const { schedule_id, agent_slug, prompt, system_prompt, scheduled_for, user_id } = req.body;
+
+        if (!schedule_id || typeof schedule_id !== 'string') {
+            throw new BadRequestError('schedule_id is required');
+        }
+        if (!agent_slug || typeof agent_slug !== 'string') {
+            throw new BadRequestError('agent_slug is required');
+        }
+        if (!prompt || typeof prompt !== 'string') {
+            throw new BadRequestError('prompt is required');
+        }
+        if (!user_id || typeof user_id !== 'string') {
+            throw new BadRequestError('user_id is required');
+        }
+        if (!scheduled_for || typeof scheduled_for !== 'string') {
+            throw new BadRequestError('scheduled_for is required');
+        }
+
+        const idempotencyKey = `${schedule_id}:${scheduled_for}`;
+        const existing = inFlightSchedules.get(idempotencyKey);
+        if (existing) {
+            log.info('Duplicate schedule fire — returning existing execution', {
+                schedule_id, scheduled_for, execution_id: existing,
+            });
+            res.json({ success: true, execution_id: existing, duplicate: true });
+            return;
+        }
+
+        const executionService = getExecutionService();
+        const executionId = crypto.randomUUID();
+
+        inFlightSchedules.set(idempotencyKey, executionId);
+
+        log.info('Firing scheduled execution', {
+            schedule_id, agent_slug, user_id, scheduled_for, execution_id: executionId,
+        });
+
+        const task = system_prompt
+            ? `${prompt}\n\n[Schedule Task Brief]\n${system_prompt}`
+            : prompt;
+
+        executionService.startExecution({
+            request: {
+                agentSlug: agent_slug,
+                task,
+                userId: user_id,
+                context: {
+                    trigger: 'schedule',
+                    schedule_id,
+                    scheduled_for,
+                },
+            },
+            stream: new NullStreamingResponse(executionId),
+            triggerType: 'schedule',
+        }).catch(err => {
+            log.error('Scheduled execution failed', {
+                schedule_id, execution_id: executionId,
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }).finally(() => {
+            setTimeout(() => inFlightSchedules.delete(idempotencyKey), 300_000);
+        });
+
+        res.json({ success: true, execution_id: executionId, duplicate: false });
+    } catch (error) {
+        next(error);
+    }
+});
+
+router.use((error: Error, _req: unknown, res: Response, _next: NextFunction) => {
+    log.error('Internal execution request failed', error);
+    const statusCode = (error as { statusCode?: number }).statusCode || 500;
+    res.status(statusCode).json({
+        success: false,
+        error: error.message,
+    });
+});
+
+export { router as internalExecutionRouter };

--- a/xerus_backend/src/domains/execution/post-session-memory-indexer.ts
+++ b/xerus_backend/src/domains/execution/post-session-memory-indexer.ts
@@ -1,0 +1,110 @@
+// Post-Session Memory Indexer
+// After an agent session completes, reads the agent's .memory/agents/{slug}/*.md
+// files from the sandbox and indexes them into memory_search_index (pgvector),
+// so the agent detail page can surface them.
+//
+// This is the backend consumer that closes the git-memory -> Neon search-index
+// pipeline on the live shell-hook path: the runner's session-end.sh commits the
+// .memory git repo, and this consumer (invoked from handleSessionCompleted) reads
+// those files back and embeds them. Repeated runs are idempotent — the indexer
+// skips chunks whose content_hash is unchanged.
+
+import { logger } from '../../utils/logger';
+import type { PipelineContext, ResolvedExecutionDeps } from './execution-pipeline.types';
+import { PipelineInvariantError } from './errors';
+import { SANDBOX_CONFIG } from '../sandbox-infra/sandbox/sandbox.config';
+import { inferMemoryType, inferMemoryScope } from '../memory/git-memory/memory-path-inference';
+import type { MemoryIndexer } from '../memory/git-memory/memory-search-index.service';
+import type { MemoryType, MemoryScope } from '../memory/memory.types';
+
+const log = logger('PostSessionMemoryIndexer');
+
+/** Minimal sandbox filesystem surface needed to read agent memory files. */
+export interface SandboxMemoryReader {
+    listFiles(sandboxId: string, dirPath: string): Promise<string[]>;
+    readFile(sandboxId: string, filePath: string): Promise<string>;
+}
+
+export interface IndexAgentSessionMemoryParams {
+    sandboxId: string;
+    workspaceId: string;
+    agentSlug: string;
+    provider: SandboxMemoryReader;
+    indexer: MemoryIndexer;
+    workspaceRootPath: string;
+}
+
+/**
+ * Read every .md file under .memory/agents/{slug}/ in the sandbox and index it
+ * into memory_search_index. Returns the number of files indexed. Empty files are
+ * skipped; unchanged chunks are deduplicated by the indexer's content_hash check.
+ */
+export async function indexAgentSessionMemory(
+    params: IndexAgentSessionMemoryParams,
+): Promise<{ indexedFiles: number }> {
+    const { sandboxId, workspaceId, agentSlug, provider, indexer, workspaceRootPath } = params;
+
+    const relativeDir = `agents/${agentSlug}`;
+    const absoluteDir = `${workspaceRootPath}/.memory/${relativeDir}`;
+
+    const entries = await provider.listFiles(sandboxId, absoluteDir);
+    const memoryFiles = entries.filter((name) => name.endsWith('.md'));
+
+    let indexedFiles = 0;
+    for (const fileName of memoryFiles) {
+        const content = await provider.readFile(sandboxId, `${absoluteDir}/${fileName}`);
+        if (!content || content.trim().length === 0) {
+            continue;
+        }
+        const relativePath = `${relativeDir}/${fileName}`;
+        await indexer.indexFile({
+            workspaceId,
+            filePath: relativePath,
+            content,
+            memoryType: inferMemoryType(relativePath) as MemoryType,
+            scope: inferMemoryScope(relativePath) as MemoryScope,
+            agentSlug,
+        });
+        indexedFiles++;
+    }
+
+    return { indexedFiles };
+}
+
+/**
+ * Pipeline entry point: resolve deps/context and index the agent's memory after a
+ * session completes. Fails fast (throws) when required pipeline state or the
+ * pgvector indexer (OPENAI_API_KEY) is missing, so callers log the failure loudly
+ * instead of silently skipping indexing.
+ */
+export async function runPostSessionMemoryIndexing(
+    ctx: PipelineContext,
+    deps: ResolvedExecutionDeps,
+): Promise<void> {
+    const agentSlug = ctx.agent?.slug;
+    const workspaceId = ctx.agent?.workspace_id;
+    const sandboxId = ctx.sandboxId;
+    if (!agentSlug || !workspaceId || !sandboxId) {
+        throw new PipelineInvariantError(
+            'post-session memory indexing: missing agentSlug, workspaceId, or sandboxId',
+        );
+    }
+    if (!deps.memorySearchIndex) {
+        throw new Error(
+            'Post-session memory indexing requires OPENAI_API_KEY: memorySearchIndex is not initialized. ' +
+            'Set OPENAI_API_KEY in the backend environment to enable pgvector memory indexing.',
+        );
+    }
+
+    const provider = deps.sandboxService.getDaytonaProvider();
+    const { indexedFiles } = await indexAgentSessionMemory({
+        sandboxId,
+        workspaceId,
+        agentSlug,
+        provider,
+        indexer: deps.memorySearchIndex,
+        workspaceRootPath: SANDBOX_CONFIG.workspacePath,
+    });
+
+    log.info('post-session memory indexed', { agent_slug: agentSlug, files_indexed: indexedFiles });
+}

--- a/xerus_backend/src/domains/execution/runner-event-router.ts
+++ b/xerus_backend/src/domains/execution/runner-event-router.ts
@@ -9,6 +9,7 @@ import { STREAM_EVENT_TYPES, type RunnerEventType, type StreamEventType } from '
 import type { HITLRequest } from './hitl/hitl.types';
 import { handleMetadataSync } from './metadata-sync-router';
 import { handleTriggerIndexing } from './indexing-event-handler';
+import { runPostSessionMemoryIndexing } from './post-session-memory-indexer';
 import { handleCliStreamEvent } from './cli-stream-router';
 import { dispatchCrossChannelCoordination, dispatchMentionToAgent } from './coordination-router';
 import { handleSseForward, handleAgentOutput } from './sse-forward-handler';
@@ -17,6 +18,7 @@ import { scheduleIncrementalPersist } from './session-record';
 import { FILE_WRITE_TOOLS, syncFileChangeToNeon, emitFileChangedFromToolCall } from './file-change-handler';
 import { ChannelNotFoundError, MentionParser } from '../inbox';
 import { updateSdkSessionId } from '../conversations/workspace-db.service';
+import { escapeSQL, executeWorkspaceJsonQuery } from '../conversations/workspace-db.helpers';
 import {
     assertToolCallData,
     assertToolResultData,
@@ -38,6 +40,7 @@ const mentionParser = new MentionParser();
 
 export const EVENT_ROUTER_LOG_PREFIX = '[EventRouter]';
 const log = logger('EventRouter');
+const XERUS_MASTER_SLUG = 'xerus-master';
 
 // Canonical allowlist: only events the frontend knows how to handle (from STREAM_EVENT_TYPES)
 export const VALID_SSE_FORWARD_EVENTS: ReadonlySet<string> = new Set(STREAM_EVENT_TYPES);
@@ -282,9 +285,11 @@ async function handleSessionCompleted(
             `UPDATE agents SET status = 'idle', updated_at = '${new Date().toISOString()}' WHERE slug = '${escapeSQL(agentSlug)}'`,
         ).catch(err => log.warn('Failed to update agent status to idle', { error: (err as Error).message }));
 
-        // Trigger memory indexing for files changed during this session
-        handleTriggerIndexing({ agent_slug: agentSlug, scope: 'session' }, ctx, deps)
-            .catch(err => log.warn('Post-session memory indexing failed (non-critical)', { error: (err as Error).message }));
+        // Index the agent's .memory/agents/{slug}/*.md files into pgvector so the
+        // agent detail page surfaces them (closes the git-memory -> memory_search_index
+        // pipeline). Failures are logged loudly, not silently skipped.
+        runPostSessionMemoryIndexing(ctx, deps)
+            .catch(err => log.error('Post-session memory indexing failed', { agent_slug: agentSlug, error: (err as Error).message }));
     }
 }
 
@@ -299,13 +304,23 @@ async function handleCreateInboxItem(
     d: Record<string, unknown>, ctx: PipelineContext, deps: ResolvedExecutionDeps,
 ): Promise<void> {
     const data = assertCreateInboxItemData(d);
-    const title = (data.content.length > 80 ? data.content.slice(0, 77) + '...' : data.content);
-    const summary = data.content.slice(0, 200);
-    await deps.db.query(
-        `INSERT INTO inbox_items (user_id, channel_id, agent_slug, title, summary, content, status, priority, metadata)
-         VALUES ($1, $2, $3, $4, $5, $6, 'delivered', $7, $8)`,
-        [ctx.request.userId, data.channel || null, requireAgent(ctx).slug, title, summary, data.content, data.priority, JSON.stringify({})],
-    );
+    const subject = (data.content.length > 80 ? data.content.slice(0, 77) + '...' : data.content);
+    const senderSlug = requireAgent(ctx).slug;
+
+    if (!ctx.sandboxId) {
+        throw new PipelineInvariantError(`${EVENT_ROUTER_LOG_PREFIX} create_inbox_item: sandboxId not set`);
+    }
+
+    const provider = deps.sandboxService.getDaytonaProvider();
+    const now = new Date().toISOString();
+    const metadata = JSON.stringify({ channel_id: data.channel || null, priority: data.priority });
+
+    const sql = `
+        INSERT INTO inbox_items (agent_slug, sender_slug, message_type, subject, content, metadata, priority, status, received_at)
+        VALUES ('${escapeSQL(XERUS_MASTER_SLUG)}', '${escapeSQL(senderSlug)}', 'coordination', '${escapeSQL(subject)}', '${escapeSQL(data.content)}', '${escapeSQL(metadata)}', '${escapeSQL(data.priority || 'normal')}', 'unread', '${now}');
+    `;
+
+    await executeWorkspaceJsonQuery(provider, ctx.sandboxId, sql);
 }
 
 async function handleAgentMessage(

--- a/xerus_backend/src/domains/execution/runner/continuation/continuation-engine.ts
+++ b/xerus_backend/src/domains/execution/runner/continuation/continuation-engine.ts
@@ -1,0 +1,122 @@
+// Continuation Engine — decides whether to continue an agent's execution.
+// Ported from Kortix continuation engine: "Open todos are AUTHORITATIVE;
+// we continue even if the agent's final message was a premature 'all done' claim."
+
+import { classifyIntent, type IntentDisposition } from './intent-gate';
+import { enforceTodos, type TrackedTodo, type TodoEnforcerResult } from './todo-enforcer';
+import { logger } from '../../../../utils/logger';
+
+const log = logger('ContinuationEngine');
+
+export interface ContinuationDecision {
+    shouldContinue: boolean;
+    reason: string;
+    intent: IntentDisposition;
+    todoResult: TodoEnforcerResult;
+    continuationCount: number;
+}
+
+export interface ContinuationState {
+    continuationCount: number;
+    lastContinuationAt: number;
+    consecutiveAborts: number;
+}
+
+const MAX_CONTINUATIONS = 3;
+const MIN_WORK_DURATION_MS = 5_000;
+const COOLDOWN_MS = 2_000;
+const MAX_CONSECUTIVE_ABORTS = 2;
+
+export function createContinuationState(): ContinuationState {
+    return {
+        continuationCount: 0,
+        lastContinuationAt: 0,
+        consecutiveAborts: 0,
+    };
+}
+
+export function evaluateContinuation(
+    finalMessage: string,
+    todos: TrackedTodo[],
+    state: ContinuationState,
+    executionDurationMs: number,
+): ContinuationDecision {
+    const intent = classifyIntent(finalMessage);
+    const todoResult = enforceTodos(todos);
+
+    const base = { intent, todoResult, continuationCount: state.continuationCount };
+
+    if (state.continuationCount >= MAX_CONTINUATIONS) {
+        log.info('Max continuations reached', { count: state.continuationCount });
+        return { ...base, shouldContinue: false, reason: `Max continuations (${MAX_CONTINUATIONS}) reached` };
+    }
+
+    if (state.consecutiveAborts >= MAX_CONSECUTIVE_ABORTS) {
+        log.info('Circuit breaker: consecutive aborts', { aborts: state.consecutiveAborts });
+        return { ...base, shouldContinue: false, reason: `Circuit breaker: ${state.consecutiveAborts} consecutive aborts` };
+    }
+
+    if (executionDurationMs < MIN_WORK_DURATION_MS) {
+        log.info('Execution too short for continuation', { duration_ms: executionDurationMs });
+        return { ...base, shouldContinue: false, reason: 'Execution too short — may indicate a loop' };
+    }
+
+    const timeSinceLastContinuation = Date.now() - state.lastContinuationAt;
+    if (state.lastContinuationAt > 0 && timeSinceLastContinuation < COOLDOWN_MS) {
+        return { ...base, shouldContinue: false, reason: 'Cooldown period active' };
+    }
+
+    if (intent === 'blocked-human' || intent === 'blocked-external') {
+        return { ...base, shouldContinue: false, reason: `Agent blocked: ${intent}` };
+    }
+
+    if (intent === 'completed' && !todoResult.hasUnfinishedWork) {
+        return { ...base, shouldContinue: false, reason: 'Genuinely completed — no open todos' };
+    }
+
+    if (todoResult.hasUnfinishedWork) {
+        return { ...base, shouldContinue: true, reason: `Unfinished work: ${todoResult.summary}` };
+    }
+
+    if (intent === 'planning') {
+        return { ...base, shouldContinue: true, reason: 'Agent stopped at a plan — should execute' };
+    }
+
+    if (intent === 'premature-stop') {
+        return { ...base, shouldContinue: true, reason: 'Premature stop without clear completion signal' };
+    }
+
+    return { ...base, shouldContinue: false, reason: 'No continuation trigger matched' };
+}
+
+export function buildContinuationPrompt(decision: ContinuationDecision): string {
+    const parts = [
+        'You have unfinished work. Continue from where you left off.',
+        '',
+    ];
+
+    if (decision.todoResult.hasUnfinishedWork) {
+        parts.push(
+            `Open todos (${decision.todoResult.actionableCount} remaining):`,
+            decision.todoResult.summary,
+            '',
+        );
+    }
+
+    parts.push(
+        'Do not stop until every todo is completed or genuinely blocked on external dependencies.',
+        `This is continuation ${decision.continuationCount + 1} of ${MAX_CONTINUATIONS}.`,
+    );
+
+    return parts.join('\n');
+}
+
+export function recordContinuation(state: ContinuationState, wasProductive: boolean): void {
+    state.continuationCount++;
+    state.lastContinuationAt = Date.now();
+    if (wasProductive) {
+        state.consecutiveAborts = 0;
+    } else {
+        state.consecutiveAborts++;
+    }
+}

--- a/xerus_backend/src/domains/execution/runner/continuation/intent-gate.ts
+++ b/xerus_backend/src/domains/execution/runner/continuation/intent-gate.ts
@@ -1,0 +1,63 @@
+// Intent Gate — classifies the agent's final message disposition.
+// Ported from Kortix continuation engine pattern.
+
+export type IntentDisposition =
+    | 'completed'
+    | 'executing'
+    | 'planning'
+    | 'blocked-human'
+    | 'blocked-external'
+    | 'premature-stop';
+
+const BLOCKED_HUMAN_PATTERNS = [
+    /\bwait(?:ing)?\s+(?:for\s+)?(?:your|user|human)\s+(?:input|response|feedback|approval|confirmation)/i,
+    /\bplease\s+(?:provide|share|confirm|let\s+me\s+know)/i,
+    /\bneed\s+(?:your|user)\s+(?:input|credentials|api.?key|token|password)/i,
+    /\bcannot\s+proceed\s+without/i,
+    /\brequires?\s+(?:your|manual|human)\s+(?:action|intervention|approval)/i,
+];
+
+const BLOCKED_EXTERNAL_PATTERNS = [
+    /\bapi\s+(?:key|token|secret)\s+(?:is\s+)?(?:missing|invalid|expired|not\s+(?:set|configured))/i,
+    /\bcredentials?\s+(?:are\s+)?(?:missing|invalid|expired)/i,
+    /\bauthentication\s+(?:failed|required|error)/i,
+    /\brate\s+limit/i,
+    /\bservice\s+unavailable/i,
+    /\btimeout/i,
+];
+
+const COMPLETED_PATTERNS = [
+    /\ball\s+(?:tasks?|items?|work)\s+(?:(?:have\s+been|are)\s+)?completed/i,
+    /\bsuccessfully\s+(?:completed|finished|implemented|delivered)/i,
+    /\beverything\s+(?:is\s+)?(?:done|complete|finished|in\s+place)/i,
+    /\bnothing\s+(?:else|more|further)\s+(?:to\s+do|remains?|needed)/i,
+];
+
+const PLANNING_PATTERNS = [
+    /\bhere(?:'s|\s+is)\s+(?:my|the|a)\s+plan/i,
+    /\bi\s+(?:will|would|can|should)\s+(?:start|begin|proceed)\s+(?:by|with)/i,
+    /\bsteps?\s+(?:to|for|i(?:'ll| will))\s+(?:take|follow)/i,
+    /\blet\s+me\s+(?:outline|plan|think\s+through)/i,
+];
+
+export function classifyIntent(finalMessage: string): IntentDisposition {
+    const text = finalMessage.slice(-2000);
+
+    for (const pattern of BLOCKED_HUMAN_PATTERNS) {
+        if (pattern.test(text)) return 'blocked-human';
+    }
+
+    for (const pattern of BLOCKED_EXTERNAL_PATTERNS) {
+        if (pattern.test(text)) return 'blocked-external';
+    }
+
+    for (const pattern of PLANNING_PATTERNS) {
+        if (pattern.test(text)) return 'planning';
+    }
+
+    for (const pattern of COMPLETED_PATTERNS) {
+        if (pattern.test(text)) return 'completed';
+    }
+
+    return 'premature-stop';
+}

--- a/xerus_backend/src/domains/execution/runner/continuation/todo-enforcer.ts
+++ b/xerus_backend/src/domains/execution/runner/continuation/todo-enforcer.ts
@@ -1,0 +1,56 @@
+// Todo Enforcer — checks tracked todos for genuinely unfinished work.
+// Todos are authoritative over the model's prose.
+
+export interface TrackedTodo {
+    text: string;
+    done: boolean;
+}
+
+const BLOCKED_KEYWORDS = [
+    'blocked', 'waiting', 'pending approval', 'need credentials',
+    'requires access', 'api key', 'permission denied', 'cannot proceed',
+];
+
+function isTodoBlocked(todo: TrackedTodo): boolean {
+    const lower = todo.text.toLowerCase();
+    return BLOCKED_KEYWORDS.some(kw => lower.includes(kw));
+}
+
+export interface TodoEnforcerResult {
+    hasUnfinishedWork: boolean;
+    openCount: number;
+    blockedCount: number;
+    actionableCount: number;
+    summary: string;
+}
+
+export function enforceTodos(todos: TrackedTodo[]): TodoEnforcerResult {
+    const open = todos.filter(t => !t.done);
+    const blocked = open.filter(isTodoBlocked);
+    const actionable = open.filter(t => !isTodoBlocked(t));
+
+    if (actionable.length === 0) {
+        return {
+            hasUnfinishedWork: false,
+            openCount: open.length,
+            blockedCount: blocked.length,
+            actionableCount: 0,
+            summary: blocked.length > 0
+                ? `${blocked.length} todo(s) blocked on external dependencies`
+                : 'All todos completed',
+        };
+    }
+
+    const todoList = actionable
+        .slice(0, 5)
+        .map(t => `- ${t.text}`)
+        .join('\n');
+
+    return {
+        hasUnfinishedWork: true,
+        openCount: open.length,
+        blockedCount: blocked.length,
+        actionableCount: actionable.length,
+        summary: `${actionable.length} actionable todo(s) remain:\n${todoList}`,
+    };
+}

--- a/xerus_backend/src/domains/execution/runner/sandbox-adapters.ts
+++ b/xerus_backend/src/domains/execution/runner/sandbox-adapters.ts
@@ -15,6 +15,7 @@ import { GitMemoryRepository } from '../../memory/git-memory/git-memory.reposito
 import { MemoryFileWriterService } from '../../memory/git-memory/memory-file-writer.service';
 import { DRMCompressionService } from '../../memory/git-memory/drm-compression.service';
 import type { MemoryIndexer, IndexFileOptions } from '../../memory/git-memory/memory-search-index.service';
+import { inferMemoryType, inferMemoryScope } from '../../memory/git-memory/memory-path-inference';
 import type { StdoutEmitter } from './stdout-emitter';
 import { LEGACY_LIGHT_MODEL } from '../../agents/types';
 
@@ -292,37 +293,4 @@ export function createSandboxDRMCompressor(
             return { entriesCompressed: total };
         },
     };
-}
-
-// -----------------------------------------------------------------------------
-// Memory file type/scope inference from .memory/ file paths
-// Paths follow: agents/{slug}/{type}.md or shared/{type}.md or company/{type}.md
-// -----------------------------------------------------------------------------
-
-const MEMORY_TYPE_MAP: Record<string, string> = {
-    'working': 'working',
-    'expertise': 'expertise',
-    'episodic': 'episodic',
-    'semantic': 'semantic',
-    'procedural': 'procedural',
-    'learnings': 'semantic',
-    'patterns': 'procedural',
-    'digest': 'context',
-    'context': 'context',
-};
-
-function inferMemoryType(filePath: string): string {
-    const basename = path.basename(filePath, '.md');
-    return MEMORY_TYPE_MAP[basename] || 'working';
-}
-
-function inferMemoryScope(filePath: string): string {
-    if (filePath.startsWith('agents/')) return 'agent';
-    if (filePath.startsWith('shared/')) return 'company';
-    if (filePath.startsWith('company/')) return 'company';
-    if (filePath.startsWith('user/')) return 'user';
-    if (filePath.startsWith('entities/')) return 'entity';
-    if (filePath.startsWith('topics/')) return 'topic';
-    if (filePath.startsWith('projects/')) return 'project';
-    return 'agent';
 }

--- a/xerus_backend/src/domains/memory/git-memory/__tests__/memory-path-inference.test.ts
+++ b/xerus_backend/src/domains/memory/git-memory/__tests__/memory-path-inference.test.ts
@@ -1,0 +1,50 @@
+// Memory Path Inference Tests
+// Pure unit tests for the .memory/-relative path -> memory_type/scope mapping
+// shared by the runner adapter and the backend post-session indexer.
+
+import { inferMemoryType, inferMemoryScope } from '../memory-path-inference';
+
+describe('inferMemoryType', () => {
+    it('maps agent working/expertise files to their own types', () => {
+        expect(inferMemoryType('agents/seo-agent/working.md')).toBe('working');
+        expect(inferMemoryType('agents/seo-agent/expertise.md')).toBe('expertise');
+    });
+
+    it('maps learnings -> semantic and patterns -> procedural', () => {
+        expect(inferMemoryType('projects/growth/learnings.md')).toBe('semantic');
+        expect(inferMemoryType('projects/growth/patterns.md')).toBe('procedural');
+    });
+
+    it('maps digest and context to context', () => {
+        expect(inferMemoryType('agents/seo-agent/digest.md')).toBe('context');
+        expect(inferMemoryType('projects/growth/context.md')).toBe('context');
+    });
+
+    it('preserves episodic/semantic/procedural basenames', () => {
+        expect(inferMemoryType('agents/x/episodic.md')).toBe('episodic');
+        expect(inferMemoryType('agents/x/semantic.md')).toBe('semantic');
+        expect(inferMemoryType('agents/x/procedural.md')).toBe('procedural');
+    });
+
+    it('falls back to working for unknown basenames', () => {
+        expect(inferMemoryType('agents/x/random-notes.md')).toBe('working');
+        expect(inferMemoryType('company/vision.md')).toBe('working');
+    });
+});
+
+describe('inferMemoryScope', () => {
+    it('maps top-level directories to scopes', () => {
+        expect(inferMemoryScope('agents/seo-agent/working.md')).toBe('agent');
+        expect(inferMemoryScope('shared/notes.md')).toBe('company');
+        expect(inferMemoryScope('company/vision.md')).toBe('company');
+        expect(inferMemoryScope('user/preferences.md')).toBe('user');
+        expect(inferMemoryScope('entities/people/jane.md')).toBe('entity');
+        expect(inferMemoryScope('topics/pricing.md')).toBe('topic');
+        expect(inferMemoryScope('projects/growth/context.md')).toBe('project');
+    });
+
+    it('defaults to agent for unrecognized paths', () => {
+        expect(inferMemoryScope('unknown/file.md')).toBe('agent');
+        expect(inferMemoryScope('index.md')).toBe('agent');
+    });
+});

--- a/xerus_backend/src/domains/memory/git-memory/memory-path-inference.ts
+++ b/xerus_backend/src/domains/memory/git-memory/memory-path-inference.ts
@@ -1,0 +1,44 @@
+// Memory Path Inference
+// Pure functions that map a .memory/-relative file path to its memory_type and
+// scope. Shared by the in-sandbox runner adapter (sandbox-adapters.ts) and the
+// backend post-session memory indexer so both emit identical metadata.
+//
+// Paths are relative to the .memory/ root, e.g.:
+//   agents/{slug}/working.md   -> type 'working',  scope 'agent'
+//   company/decisions.md       -> type 'decisions' (via map miss -> 'working'), scope 'company'
+//   projects/{domain}/context.md -> type 'context', scope 'project'
+
+import path from 'path';
+
+// Maps a file basename (without .md) to a memory_type. Basenames not present
+// here fall back to 'working'. Values must be accepted by the
+// memory_search_index.msi_memory_type_check constraint (migration 096).
+const MEMORY_TYPE_MAP: Record<string, string> = {
+    'working': 'working',
+    'expertise': 'expertise',
+    'episodic': 'episodic',
+    'semantic': 'semantic',
+    'procedural': 'procedural',
+    'learnings': 'semantic',
+    'patterns': 'procedural',
+    'digest': 'context',
+    'context': 'context',
+};
+
+/** Infer memory_type from a .memory/-relative file path (by basename). */
+export function inferMemoryType(filePath: string): string {
+    const basename = path.basename(filePath, '.md');
+    return MEMORY_TYPE_MAP[basename] || 'working';
+}
+
+/** Infer scope from a .memory/-relative file path (by top-level directory). */
+export function inferMemoryScope(filePath: string): string {
+    if (filePath.startsWith('agents/')) return 'agent';
+    if (filePath.startsWith('shared/')) return 'company';
+    if (filePath.startsWith('company/')) return 'company';
+    if (filePath.startsWith('user/')) return 'user';
+    if (filePath.startsWith('entities/')) return 'entity';
+    if (filePath.startsWith('topics/')) return 'topic';
+    if (filePath.startsWith('projects/')) return 'project';
+    return 'agent';
+}

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/notification.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/notification.routes.ts
@@ -1,12 +1,30 @@
 // Notification Routes
 // Handles send_notification MCP tool
+// Writes to workspace.db (SQLite) on sandbox, NOT Postgres (inbox_items was dropped by migration 084).
 
 import { Router, Response, NextFunction } from 'express';
-import { query } from '../../../database/connection';
 import { BadRequestError } from '../../../utils/errors';
 import { InternalMcpRequest, McpToolResult } from './types';
+import { escapeSQL, executeWorkspaceJsonQuery } from '../../conversations/workspace-db.helpers';
+import { requireRunningSandbox, getDaytonaProvider } from '../../sandbox-infra/sandbox/sandbox-route-helpers';
+import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service';
 
 const router = Router();
+
+const XERUS_MASTER_SLUG = 'xerus-master';
+
+let _sandboxService: SandboxService | null = null;
+
+export function setNotificationRoutesDeps(deps: { sandboxService: SandboxService }): void {
+    _sandboxService = deps.sandboxService;
+}
+
+function getSandboxService(): SandboxService {
+    if (!_sandboxService) {
+        throw new Error('Notification routes dependencies not initialized');
+    }
+    return _sandboxService;
+}
 
 // POST /api/v1/internal/mcp/send_notification
 router.post('/send_notification', async (req: InternalMcpRequest, res: Response, next: NextFunction) => {
@@ -18,22 +36,32 @@ router.post('/send_notification', async (req: InternalMcpRequest, res: Response,
             throw new BadRequestError('message is required');
         }
 
-        // Store notification in inbox
-        const notificationResult = await query<{ id: string }>(
-            `INSERT INTO inbox_items (user_id, agent_slug, message, priority, notification_type, created_at)
-             VALUES ($1, $2, $3, $4, $5, NOW())
-             RETURNING id`,
-            [userId, agent_slug || 'system', message, priority || 'medium', 'agent_notification']
-        );
+        const sandboxService = getSandboxService();
+        const sandboxId = await requireRunningSandbox(sandboxService, userId);
+        const provider = getDaytonaProvider(sandboxService);
+
+        const senderSlug = agent_slug || 'system';
+        const prio = priority || 'medium';
+        const subject = message.length > 80 ? message.slice(0, 77) + '...' : message;
+        const now = new Date().toISOString();
+        const metadata = JSON.stringify({ notification_type: 'agent_notification', priority: prio });
+
+        const sql = `
+            INSERT INTO inbox_items (agent_slug, sender_slug, message_type, subject, content, metadata, priority, status, received_at)
+            VALUES ('${escapeSQL(XERUS_MASTER_SLUG)}', '${escapeSQL(senderSlug)}', 'notification', '${escapeSQL(subject)}', '${escapeSQL(message)}', '${escapeSQL(metadata)}', '${escapeSQL(prio)}', 'unread', '${now}');
+            SELECT id FROM inbox_items WHERE id = last_insert_rowid();
+        `;
+
+        const rows = await executeWorkspaceJsonQuery<{ id: number }>(provider, sandboxId, sql);
 
         const mcpResult: McpToolResult = {
             success: true,
             data: {
-                notification_id: notificationResult.rows[0]?.id,
+                notification_id: rows[0]?.id ? String(rows[0].id) : undefined,
                 message,
-                priority: priority || 'medium',
-                agent_slug: agent_slug || 'system',
-                delivered_at: new Date().toISOString(),
+                priority: prio,
+                agent_slug: senderSlug,
+                delivered_at: now,
             },
         };
 

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/schedule.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/schedule.routes.ts
@@ -8,15 +8,20 @@ import { BadRequestError } from '../../../utils/errors';
 import { InternalMcpRequest, McpToolResult } from './types';
 import { ScheduleService } from '../platform/tools/schedule.tools';
 import type { SandboxService } from '../../sandbox-infra/sandbox/sandbox.service';
+import { recomputeWakeSchedule } from '../../execution/background/wake-daemon';
+import { executeWorkspaceJsonQuery } from '../../conversations/workspace-db.helpers';
+import type { DaytonaProvider } from '../../sandbox-infra/sandbox/providers/daytona.provider';
 
 // -----------------------------------------------------------------------------
 // Dependencies (injected at startup)
 // -----------------------------------------------------------------------------
 
 let scheduleService: ScheduleService | null = null;
+let _provider: DaytonaProvider | null = null;
 
 export function setScheduleRoutesDeps(deps: { sandboxService: SandboxService }): void {
-    scheduleService = new ScheduleService(deps.sandboxService.getDaytonaProvider());
+    _provider = deps.sandboxService.getDaytonaProvider();
+    scheduleService = new ScheduleService(_provider);
 }
 
 function getScheduleService(): ScheduleService {
@@ -38,6 +43,19 @@ async function requireSandboxId(userId: string): Promise<string> {
         throw new BadRequestError('Sandbox not running — start a session first');
     }
     return result.rows[0].sandbox_id;
+}
+
+async function syncWakeSchedule(sandboxId: string, userId: string): Promise<void> {
+    if (!_provider) return;
+    try {
+        const rows = await executeWorkspaceJsonQuery<{ min_next: number | null }>(
+            _provider, sandboxId,
+            `SELECT MIN(next_run_at) as min_next FROM schedules WHERE status = 'active' AND next_run_at IS NOT NULL`,
+        );
+        await recomputeWakeSchedule(sandboxId, userId, rows[0]?.min_next ?? null);
+    } catch {
+        // Non-blocking — wake schedule is a best-effort optimization
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -67,6 +85,8 @@ router.post('/create_schedule', async (req: InternalMcpRequest, res: Response, n
             agent_slug, name, prompt, rrule, adapter_type, model,
             max_budget_usd, allowed_tools, system_prompt,
         });
+
+        void syncWakeSchedule(sandboxId, userId);
 
         const mcpResult: McpToolResult = { success: true, data: result };
         res.json(mcpResult);
@@ -107,6 +127,8 @@ router.post('/update_schedule', async (req: InternalMcpRequest, res: Response, n
             max_budget_usd, allowed_tools, system_prompt,
         });
 
+        void syncWakeSchedule(sandboxId, userId);
+
         const mcpResult: McpToolResult = { success: true, data: result };
         res.json(mcpResult);
     } catch (error) {
@@ -126,6 +148,8 @@ router.post('/delete_schedule', async (req: InternalMcpRequest, res: Response, n
 
         const sandboxId = await requireSandboxId(userId);
         const result = await getScheduleService().deleteSchedule(sandboxId, { schedule_id });
+
+        void syncWakeSchedule(sandboxId, userId);
 
         const mcpResult: McpToolResult = { success: true, data: result };
         res.json(mcpResult);

--- a/xerus_backend/src/domains/platform-tools/internal-mcp/tool-connection.routes.ts
+++ b/xerus_backend/src/domains/platform-tools/internal-mcp/tool-connection.routes.ts
@@ -5,6 +5,7 @@ import { Router, Response, NextFunction } from 'express';
 // TECH DEBT: Cross-domain import. Should use interface injection.
 // See: docs/planning/execution/sqlite-neon-sync.md#cross-domain-dependencies
 import { toolsService } from '../../tools/service';
+import { resolvePipedreamWebhookUrl } from '../../tools/pipedream-webhook';
 import { BadRequestError } from '../../../utils/errors';
 import { InternalMcpRequest, McpToolResult } from './types';
 
@@ -20,10 +21,13 @@ router.post('/connect_tool', async (req: InternalMcpRequest, res: Response, next
             throw new BadRequestError('tool_slug is required');
         }
 
-        // Start OAuth connection flow via Pipedream Connect
+        // Start OAuth connection flow via Pipedream Connect.
+        // Pass the SAME webhook_url the user-initiated flow uses so agent-initiated
+        // OAuth completions reach the (signature-verified) webhook and persist.
         const connectionResult = await toolsService.startConnection({
             user_id: userId,
             allowed_origins: process.env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()) ?? [],
+            webhook_url: resolvePipedreamWebhookUrl(),
         });
 
         const mcpResult: McpToolResult = {

--- a/xerus_backend/src/domains/platform-tools/orchestrator/__tests__/tool.filter.test.ts
+++ b/xerus_backend/src/domains/platform-tools/orchestrator/__tests__/tool.filter.test.ts
@@ -15,6 +15,12 @@ import {
     COMMON_TOOLS,
     TOOL_FILTER_CATEGORIES,
 } from '../tool.filter';
+import {
+    COMMON_PLATFORM_TOOLS,
+    ALL_ORCHESTRATOR_PLATFORM_TOOLS,
+    ORCHESTRATOR_ONLY_PLATFORM_TOOLS,
+} from '../tool-access.constants';
+import { buildPlatformRules } from '../../../execution/agent-config-resolver';
 
 describe('Tool Filter', () => {
     describe('validateToolAccess', () => {
@@ -329,6 +335,77 @@ describe('Tool Filter', () => {
             expect(TOOL_FILTER_CATEGORIES.specialist).toBe(SPECIALIST_TOOLS);
             expect(TOOL_FILTER_CATEGORIES.common).toBe(COMMON_TOOLS);
             expect(TOOL_FILTER_CATEGORIES.platform).toEqual(['platform.']);
+        });
+    });
+
+    describe('specialist platform tool access (mcp__platform__*)', () => {
+        it('allows all 21 COMMON_PLATFORM_TOOLS for specialists', () => {
+            for (const tool of COMMON_PLATFORM_TOOLS) {
+                const result = validateToolAccess(tool, 'specialist');
+                expect(result.allowed).toBe(true);
+            }
+        });
+
+        it('denies orchestrator-only platform tools for specialists', () => {
+            for (const tool of ORCHESTRATOR_ONLY_PLATFORM_TOOLS) {
+                const result = validateToolAccess(tool, 'specialist');
+                expect(result.allowed).toBe(false);
+            }
+        });
+
+        it('allows all platform tools for master orchestrator', () => {
+            for (const tool of ALL_ORCHESTRATOR_PLATFORM_TOOLS) {
+                const result = validateToolAccess(tool, 'orchestrator', true);
+                expect(result.allowed).toBe(true);
+            }
+        });
+    });
+
+    describe('CONTRACT: prompt-rendered tools ⊆ filter-allowed tools', () => {
+        function extractToolsFromPrompt(promptText: string): string[] {
+            const match = promptText.match(/Your MCP tools: (.+)/);
+            if (!match) return [];
+            return match[1].split(', ').map(t => t.trim()).filter(Boolean);
+        }
+
+        it('specialist prompt tools are all allowed by the filter', () => {
+            const prompt = buildPlatformRules('some-specialist-agent');
+            const promptTools = extractToolsFromPrompt(prompt);
+            expect(promptTools.length).toBeGreaterThan(0);
+
+            for (const tool of promptTools) {
+                const result = validateToolAccess(tool, 'specialist');
+                expect({ tool, ...result }).toEqual(expect.objectContaining({
+                    tool,
+                    allowed: true,
+                }));
+            }
+        });
+
+        it('orchestrator prompt tools are all allowed by the filter for master', () => {
+            const prompt = buildPlatformRules('xerus-master');
+            const promptTools = extractToolsFromPrompt(prompt);
+            expect(promptTools.length).toBeGreaterThan(0);
+
+            for (const tool of promptTools) {
+                const result = validateToolAccess(tool, 'orchestrator', true);
+                expect({ tool, ...result }).toEqual(expect.objectContaining({
+                    tool,
+                    allowed: true,
+                }));
+            }
+        });
+
+        it('specialist prompt has exactly COMMON_PLATFORM_TOOLS', () => {
+            const prompt = buildPlatformRules('some-specialist-agent');
+            const promptTools = extractToolsFromPrompt(prompt);
+            expect(new Set(promptTools)).toEqual(new Set(COMMON_PLATFORM_TOOLS));
+        });
+
+        it('orchestrator prompt has exactly ALL_ORCHESTRATOR_PLATFORM_TOOLS', () => {
+            const prompt = buildPlatformRules('xerus-master');
+            const promptTools = extractToolsFromPrompt(prompt);
+            expect(new Set(promptTools)).toEqual(new Set(ALL_ORCHESTRATOR_PLATFORM_TOOLS));
         });
     });
 

--- a/xerus_backend/src/domains/platform-tools/orchestrator/tool-access.constants.ts
+++ b/xerus_backend/src/domains/platform-tools/orchestrator/tool-access.constants.ts
@@ -1,0 +1,75 @@
+// Canonical tool access constants — single source of truth for prompt and filter.
+// Both agent-config-resolver.ts (prompt rendering) and tool.filter.ts (runtime enforcement)
+// MUST import from here to prevent prompt/runtime drift.
+
+const PLATFORM_PREFIX = 'mcp__platform__';
+
+/**
+ * Platform tools available to ALL agents (orchestrator + specialist).
+ * These are the 21 tools every agent's prompt advertises.
+ * Changing this list changes both the prompt AND the runtime filter.
+ */
+export const COMMON_PLATFORM_TOOL_NAMES = [
+    'create_task',
+    'update_task',
+    'search_agents',
+    'list_agents',
+    'search_kb',
+    'query_memory',
+    'write_memory',
+    'analyze_memory_patterns',
+    'search_outputs',
+    'send_notification',
+    'get_status',
+    'get_billing_status',
+    'search_skills',
+    'search_tools',
+    'list_domains',
+    'list_triggers',
+    'list_schedules',
+    'pause_execution',
+    'resume_execution',
+    'get_session_state',
+    'complete_session',
+    'cancel_execution',
+] as const;
+
+export const COMMON_PLATFORM_TOOLS = COMMON_PLATFORM_TOOL_NAMES.map(
+    t => `${PLATFORM_PREFIX}${t}`,
+);
+
+/**
+ * Platform tools exclusive to the orchestrator (master Xerus).
+ * These manage workspace structure: agents, channels, KB, skills, tools, schedules.
+ */
+export const ORCHESTRATOR_ONLY_PLATFORM_TOOL_NAMES = [
+    'create_agent',
+    'clone_agent',
+    'update_agent',
+    'delete_agent',
+    'create_channel',
+    'add_to_channel',
+    'upload_kb',
+    'assign_kb',
+    'create_skill',
+    'install_skill',
+    'uninstall_skill',
+    'connect_tool',
+    'register_trigger',
+    'deregister_trigger',
+    'create_schedule',
+    'update_schedule',
+    'delete_schedule',
+] as const;
+
+export const ORCHESTRATOR_ONLY_PLATFORM_TOOLS = ORCHESTRATOR_ONLY_PLATFORM_TOOL_NAMES.map(
+    t => `${PLATFORM_PREFIX}${t}`,
+);
+
+/**
+ * All platform tools for the orchestrator (union of orchestrator-only + common).
+ */
+export const ALL_ORCHESTRATOR_PLATFORM_TOOLS = [
+    ...ORCHESTRATOR_ONLY_PLATFORM_TOOLS,
+    ...COMMON_PLATFORM_TOOLS,
+];

--- a/xerus_backend/src/domains/platform-tools/orchestrator/tool.filter.ts
+++ b/xerus_backend/src/domains/platform-tools/orchestrator/tool.filter.ts
@@ -3,6 +3,7 @@
 // See: docs/planning/execution/subagents.md, docs/planning/tools/system-tools.md
 
 import { DomainError } from '../../../utils/errors';
+import { COMMON_PLATFORM_TOOLS } from './tool-access.constants';
 
 // -----------------------------------------------------------------------------
 // Agent Types
@@ -121,10 +122,7 @@ export interface ToolFilterResult {
 // Helper Functions
 // -----------------------------------------------------------------------------
 
-const SPECIALIST_ALLOWED_PLATFORM_TOOLS = new Set([
-    'mcp__platform__create_task',
-    'mcp__platform__update_task',
-]);
+const SPECIALIST_ALLOWED_PLATFORM_TOOLS = new Set(COMMON_PLATFORM_TOOLS);
 
 function isPlatformTool(toolName: string): boolean {
     return PLATFORM_TOOL_PREFIXES.some(prefix => toolName.startsWith(prefix))

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/providers/__tests__/daytona-runner.test.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/providers/__tests__/daytona-runner.test.ts
@@ -147,6 +147,14 @@ describe('createAgentSession', () => {
         await expect(createAgentSession(sandbox, {}, defaultAgentOpts)).rejects.toThrow('Session creation failed');
     });
 
+    it('throws when agentSlug is empty (fail-fast — no identity for hooks)', async () => {
+        const sandbox = buildFakeSandbox();
+
+        await expect(
+            createAgentSession(sandbox, {}, { ...defaultAgentOpts, agentSlug: '' }),
+        ).rejects.toThrow('agentSlug is empty');
+    });
+
     it('throws when executeSessionCommand returns no cmdId', async () => {
         const sandbox = buildFakeSandbox({
             executeSessionCommandResult: { cmdId: '' },

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/providers/daytona-runner.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/providers/daytona-runner.ts
@@ -105,7 +105,16 @@ function buildSessionCommand(
     const cliArgs = adapter.buildCommand('', agentConfig);
 
     // Inject per-agent env vars that hooks need (XERUS_AGENT_SLUG identifies the agent
-    // to session-start.sh, task-context generation, and all other hook scripts)
+    // to session-start.sh, task-context generation, and all other hook scripts).
+    // Fail-fast: a blank slug would make every hook refuse to log activity (see
+    // _lib.sh resolve_activity_agent) — surface the launch-path bug here instead of
+    // spawning a CLI session with no identity.
+    if (!agentOpts.agentSlug) {
+        throw new Error(
+            'buildSessionCommand: agentOpts.agentSlug is empty — refusing to launch a CLI ' +
+            'session without an agent identity (hooks require XERUS_AGENT_SLUG).',
+        );
+    }
     const fullEnv: Record<string, string> = {
         ...envVars,
         XERUS_AGENT_SLUG: agentOpts.agentSlug,

--- a/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
+++ b/xerus_backend/src/domains/sandbox-infra/sandbox/sandbox-setup.ts
@@ -8,6 +8,7 @@ import { cloneWorkspaceTemplate } from './workspace-clone';
 import { installRunnerBundle } from './runner-installer';
 import { personalizeWorkspace } from '../workspace/workspace-personalizer.service';
 import { syncPipedreamMcpConfig } from '../workspace/mcp-config.service';
+import { toolsService } from '../../tools/service';
 import { ensureWorkspaceIntegrity, syncAgentsToWorkspace } from './workspace-health';
 import { syncWorkspaceTemplate } from './workspace-template-sync';
 import { GIT_MEMORY_CONFIG } from '../../memory/git-memory/git-memory.types';
@@ -74,6 +75,31 @@ export async function runMcpConfigSync(
     userId: string,
     deps: SetupDeps,
 ): Promise<void> {
+    // Reconcile connected_accounts against Pipedream (source of truth) BEFORE building
+    // the MCP config, so the .mcp.json we write reflects the converged set. This backfills
+    // connections dropped by fire-and-forget webhooks (and repairs every user broken by the
+    // old parse bug) with no manual intervention. Non-blocking: a Pipedream outage must not
+    // stop a user's sandbox from coming up — mirrors the syncWorkspaceTemplate resilience
+    // boundary below. The reconcile itself fail-fasts internally (no partial DB writes).
+    try {
+        const reconcile = await toolsService.reconcileConnectedAccounts({ user_id: userId });
+        if (reconcile.added > 0 || reconcile.removed > 0) {
+            log.info('Reconciled connected accounts from Pipedream', {
+                sandbox_id: sandboxId,
+                user_id: userId,
+                added: reconcile.added,
+                removed: reconcile.removed,
+                total: reconcile.total,
+            });
+        }
+    } catch (reconcileErr) {
+        log.warn('Connected-accounts reconciliation failed (non-blocking)', {
+            sandbox_id: sandboxId,
+            user_id: userId,
+            error: (reconcileErr as Error).message,
+        });
+    }
+
     const sandboxFs = await deps.getSandboxFs(sandboxId);
     const mcpJsonPath = `${SANDBOX_CONFIG.workspacePath}/.mcp.json`;
     const result = await syncPipedreamMcpConfig(sandboxFs, mcpJsonPath, userId, deps.db);

--- a/xerus_backend/src/domains/tools/connection-reconciler.ts
+++ b/xerus_backend/src/domains/tools/connection-reconciler.ts
@@ -1,0 +1,55 @@
+// Connected-accounts reconciliation.
+// connected_accounts is otherwise only written by one fire-and-forget webhook, so a
+// single missed delivery is a permanent gap. Reconciling against Pipedream (the source
+// of truth) on every sandbox MCP sync converges the table and automatically backfills
+// every connection lost to the old webhook parse bug — no manual repair.
+
+import type { BackendClient, Account } from '@pipedream/sdk';
+import { toolsRepository } from './repository';
+import type { SaveConnectionInput } from './types';
+
+const MAX_PAGES = 100;
+const PAGE_LIMIT = 100;
+
+/**
+ * Fetch ALL accounts Pipedream reports for an external user, following pagination.
+ * The complete set must be assembled before the DB is touched — a partial fetch would
+ * drive the convergence delete and drop live rows — so any Pipedream error throws here.
+ */
+async function fetchAllPipedreamAccounts(pipedream: BackendClient, externalUserId: string): Promise<Account[]> {
+    const all: Account[] = [];
+    let after: string | undefined;
+    let page = 0;
+    do {
+        const response = await pipedream.getAccounts({
+            external_user_id: externalUserId,
+            after,
+            limit: PAGE_LIMIT,
+        });
+        const data = response.data || [];
+        all.push(...data);
+        after = data.length > 0 ? response.page_info?.end_cursor : undefined;
+        page++;
+    } while (after && page < MAX_PAGES);
+    return all;
+}
+
+/**
+ * Converge a user's connected_accounts with Pipedream's authoritative account list.
+ * Returns counts of rows added/removed and the final total for the user.
+ */
+export async function reconcileConnectedAccounts(
+    pipedream: BackendClient,
+    userId: string,
+): Promise<{ added: number; removed: number; total: number }> {
+    const remoteAccounts = await fetchAllPipedreamAccounts(pipedream, userId);
+
+    const connections: SaveConnectionInput[] = remoteAccounts.map((account) => ({
+        user_id: userId,
+        pipedream_account_id: String(account.id),
+        app_slug: account.app.name_slug,
+        app_name: account.name,
+    }));
+
+    return toolsRepository.reconcileConnections(userId, connections);
+}

--- a/xerus_backend/src/domains/tools/pipedream-webhook.ts
+++ b/xerus_backend/src/domains/tools/pipedream-webhook.ts
@@ -1,0 +1,141 @@
+// Pipedream Connect Webhook Helpers
+// One place for everything about the Connect completion webhook:
+//  - resolving the canonical webhook URL both connect flows must converge on
+//  - verifying the x-pd-signature HMAC Pipedream attaches to every delivery
+//
+// Signature scheme (Pipedream Connect docs, https://pipedream.com/docs/connect/webhooks):
+//   header  x-pd-signature: t=<unix_seconds>,v1=<hex_hmac_sha256>
+//   signed  `${t}.${raw_request_body}`  (raw bytes, not re-serialized JSON)
+//   secret  the project's webhook signing key (PIPEDREAM_WEBHOOK_SECRET)
+
+import crypto from 'crypto';
+
+// Replay window: reject deliveries whose signed timestamp is older/newer than this.
+const SIGNATURE_TOLERANCE_SECONDS = 300;
+
+const WEBHOOK_PATH = '/api/v1/tools/webhook/connected';
+
+/**
+ * Thrown when a webhook delivery fails signature verification. The route maps
+ * this to a 401 — distinct from configuration errors (missing secret) which are
+ * genuine server faults and must surface as 500 (fail-fast, never skip verify).
+ */
+export class PipedreamWebhookSignatureError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PipedreamWebhookSignatureError';
+    }
+}
+
+/**
+ * Read the Connect webhook signing secret. Fail-fast if unset — a missing secret
+ * must never silently disable verification (that would re-open the spoofable-write
+ * hole this hardening closes).
+ */
+export function getPipedreamWebhookSecret(): string {
+    const secret = process.env.PIPEDREAM_WEBHOOK_SECRET;
+    if (!secret || secret.trim() === '') {
+        throw new Error('PIPEDREAM_WEBHOOK_SECRET is not configured');
+    }
+    return secret;
+}
+
+/**
+ * Build the canonical Connect completion webhook URL. Both the user-initiated
+ * (connect-token) and agent-initiated (connect_tool MCP) flows must pass the
+ * SAME url to Pipedream, or agent-initiated OAuth never persists.
+ *
+ * Prefers API_BASE_URL (the public URL Pipedream must reach); an internal MCP
+ * call has no trustworthy request host, so it relies on API_BASE_URL and
+ * fail-fasts if that is unset rather than emitting an unreachable localhost URL.
+ */
+export function resolvePipedreamWebhookUrl(requestBaseUrl?: string): string {
+    const rawBaseUrl = process.env.API_BASE_URL || requestBaseUrl;
+    if (!rawBaseUrl || rawBaseUrl.trim() === '') {
+        throw new Error('Cannot resolve Pipedream webhook URL: set API_BASE_URL');
+    }
+    const baseUrl = rawBaseUrl.replace(/\/api\/v1\/?$/, '');
+    return `${baseUrl}${WEBHOOK_PATH}`;
+}
+
+interface ParsedSignature {
+    timestamp: number;
+    v1: string;
+}
+
+function parseSignatureHeader(header: string): ParsedSignature {
+    const parts = header.split(',').reduce<Record<string, string>>((acc, part) => {
+        const idx = part.indexOf('=');
+        if (idx === -1) return acc;
+        acc[part.slice(0, idx).trim()] = part.slice(idx + 1).trim();
+        return acc;
+    }, {});
+
+    const t = parts.t;
+    const v1 = parts.v1;
+    if (!t || !v1) {
+        throw new PipedreamWebhookSignatureError('Malformed x-pd-signature header (expected t=,v1=)');
+    }
+
+    const timestamp = Number(t);
+    if (!Number.isFinite(timestamp)) {
+        throw new PipedreamWebhookSignatureError('Invalid timestamp in x-pd-signature header');
+    }
+
+    return { timestamp, v1 };
+}
+
+interface VerifyParams {
+    rawBody: string;
+    signatureHeader: string | undefined;
+    secret: string;
+    toleranceSeconds?: number;
+    now?: number;
+}
+
+/**
+ * Verify the x-pd-signature HMAC over the raw request body. Throws
+ * PipedreamWebhookSignatureError on any mismatch, missing header, malformed
+ * header, or stale timestamp. Returns void on success.
+ */
+export function verifyPipedreamWebhookSignature(params: VerifyParams): void {
+    const { rawBody, signatureHeader, secret } = params;
+    if (!signatureHeader) {
+        throw new PipedreamWebhookSignatureError('Missing x-pd-signature header');
+    }
+
+    const { timestamp, v1 } = parseSignatureHeader(signatureHeader);
+
+    const tolerance = params.toleranceSeconds ?? SIGNATURE_TOLERANCE_SECONDS;
+    const nowSeconds = Math.floor((params.now ?? Date.now()) / 1000);
+    if (Math.abs(nowSeconds - timestamp) > tolerance) {
+        throw new PipedreamWebhookSignatureError('x-pd-signature timestamp outside tolerance window');
+    }
+
+    const expectedHex = crypto
+        .createHmac('sha256', secret)
+        .update(`${timestamp}.${rawBody}`)
+        .digest('hex');
+
+    const expectedBuf = Buffer.from(expectedHex, 'hex');
+    const receivedBuf = Buffer.from(v1, 'hex');
+
+    // timingSafeEqual throws on length mismatch — guard so a malformed hex digest
+    // is a clean rejection, not an unhandled throw.
+    if (expectedBuf.length !== receivedBuf.length || !crypto.timingSafeEqual(expectedBuf, receivedBuf)) {
+        throw new PipedreamWebhookSignatureError('x-pd-signature verification failed');
+    }
+}
+
+/**
+ * Compute a valid x-pd-signature header value for a raw body. Used by tests that
+ * exercise the webhook end-to-end against a known secret; keeping it here means
+ * the signing and verifying logic can never drift apart.
+ */
+export function signPipedreamWebhookBody(rawBody: string, secret: string, timestampSeconds: number): string {
+    const v1 = crypto
+        .createHmac('sha256', secret)
+        .update(`${timestampSeconds}.${rawBody}`)
+        .digest('hex');
+    return `t=${timestampSeconds},v1=${v1}`;
+}

--- a/xerus_backend/src/domains/tools/repository.ts
+++ b/xerus_backend/src/domains/tools/repository.ts
@@ -1,7 +1,7 @@
 // Tools Domain Repository
 // Database operations for connected_accounts and tool_executions
 
-import { query } from '../../database/connection';
+import { query, transaction } from '../../database/connection';
 import type {
     ConnectedAccount,
     ConnectedAccountRow,
@@ -71,6 +71,57 @@ export class ToolsRepository {
         );
 
         return mapConnectedAccountRow(result.rows[0]);
+    }
+
+    /**
+     * Converge a user's connected_accounts with the authoritative set of accounts
+     * Pipedream reports for them. Backfills rows missed by dropped webhook deliveries
+     * (this is the automatic repair for connections broken by the old parse bug),
+     * repairs drifted app_slug/app_name, and removes rows Pipedream no longer knows
+     * (revoked/deleted upstream). Runs in one transaction so the table is never left
+     * half-converged. The caller MUST pass a complete list (all pages fetched) —
+     * a partial list would delete live rows.
+     */
+    async reconcileConnections(
+        user_id: string,
+        accounts: SaveConnectionInput[],
+    ): Promise<{ added: number; removed: number; total: number }> {
+        return transaction(async (client) => {
+            const existing = await client.query<{ pipedream_account_id: string }>(
+                `SELECT pipedream_account_id FROM connected_accounts WHERE user_id = $1`,
+                [user_id],
+            );
+            const existingIds = new Set(existing.rows.map((r) => r.pipedream_account_id));
+            const remoteIds = accounts.map((a) => a.pipedream_account_id);
+
+            for (const acct of accounts) {
+                await client.query(
+                    `INSERT INTO connected_accounts (user_id, pipedream_account_id, app_slug, app_name, created_at, last_used_at)
+                     VALUES ($1, $2, $3, $4, NOW(), NULL)
+                     ON CONFLICT (pipedream_account_id) DO UPDATE SET
+                        user_id = EXCLUDED.user_id,
+                        app_slug = EXCLUDED.app_slug,
+                        app_name = EXCLUDED.app_name`,
+                    [acct.user_id, acct.pipedream_account_id, acct.app_slug, acct.app_name],
+                );
+            }
+
+            const deleteResult = remoteIds.length > 0
+                ? await client.query(
+                    `DELETE FROM connected_accounts WHERE user_id = $1 AND NOT (pipedream_account_id = ANY($2::text[]))`,
+                    [user_id, remoteIds],
+                )
+                : await client.query(
+                    `DELETE FROM connected_accounts WHERE user_id = $1`,
+                    [user_id],
+                );
+
+            const added = remoteIds.filter((id) => !existingIds.has(id)).length;
+            const removed = deleteResult.rowCount ?? 0;
+            const total = new Set(remoteIds).size;
+
+            return { added, removed, total };
+        });
     }
 
     async getConnections(user_id: string): Promise<ConnectedAccount[]> {

--- a/xerus_backend/src/domains/tools/routes.ts
+++ b/xerus_backend/src/domains/tools/routes.ts
@@ -8,6 +8,13 @@ import { authenticateFirebaseToken, requireRole } from '../../middleware/auth';
 import { toolsService } from './service';
 import { toolsRepository } from './repository';
 import { getPipedreamClient } from '../../shared/clients/pipedream';
+import type { PipedreamConnectWebhookPayload } from './types';
+import {
+    resolvePipedreamWebhookUrl,
+    getPipedreamWebhookSecret,
+    verifyPipedreamWebhookSignature,
+    PipedreamWebhookSignatureError,
+} from './pipedream-webhook';
 import { logger } from '../../utils/logger';
 
 const log = logger('tools-routes');
@@ -54,9 +61,7 @@ router.post('/connect-token', auth, async (req: AuthenticatedRequest, res: Respo
             return;
         }
 
-        const rawBaseUrl = process.env.API_BASE_URL || `${req.protocol}://${req.get('host')}`;
-        const baseUrl = rawBaseUrl.replace(/\/api\/v1\/?$/, '');
-        const webhookUrl = `${baseUrl}/api/v1/tools/webhook/connected`;
+        const webhookUrl = resolvePipedreamWebhookUrl(`${req.protocol}://${req.get('host')}`);
         log.info('Connect token requested', { webhook_url: webhookUrl, user_id: req.user!.uid });
 
         const result = await toolsService.startConnection({
@@ -293,47 +298,93 @@ router.get('/:app_slug', auth, async (req: AuthenticatedRequest, res: Response, 
     }
 });
 
-// POST /api/v1/tools/webhook/connected - Pipedream OAuth completion webhook (no auth — server-to-server)
+// POST /api/v1/tools/webhook/connected - Pipedream OAuth completion webhook (no auth — server-to-server).
+// Body arrives as a raw Buffer (express.raw mounted for this path in index.ts) so the x-pd-signature
+// HMAC is checked over the exact bytes Pipedream signed — otherwise anyone could insert rows.
 router.post('/webhook/connected', async (req: Request, res: Response, next: NextFunction) => {
     try {
-        log.info('Webhook /connected received', {
-            body_keys: Object.keys(req.body),
-            has_id: !!req.body.id,
-            has_external_id: !!req.body.external_id,
-            has_app: !!req.body.app,
-            ip: req.ip,
-        });
-
-        const { id, name, external_id, app } = req.body;
-
-        if (!id || !external_id) {
-            log.info('Webhook /connected rejected: missing fields', { id, external_id });
-            res.status(400).json({ error: 'Missing required fields: id, external_id' });
+        const rawBody = Buffer.isBuffer(req.body) ? req.body.toString('utf-8')
+            : typeof req.body === 'string' ? req.body : '';
+        if (rawBody === '') {
+            res.status(400).json({ error: 'Empty webhook body' });
             return;
         }
 
-        const appSlug = app?.name_slug || 'unknown';
-        const appName = name || app?.name || appSlug;
+        // Fail-fast if the signing secret is unset — never skip verification silently.
+        const webhookSecret = getPipedreamWebhookSecret();
+        try {
+            verifyPipedreamWebhookSignature({
+                rawBody,
+                signatureHeader: req.header('x-pd-signature'),
+                secret: webhookSecret,
+            });
+        } catch (verifyError) {
+            if (verifyError instanceof PipedreamWebhookSignatureError) {
+                log.warn('Webhook /connected signature verification failed', {
+                    reason: verifyError.message,
+                    ip: req.ip,
+                });
+                res.status(401).json({ error: 'Invalid webhook signature' });
+                return;
+            }
+            throw verifyError;
+        }
 
-        const existing = await toolsRepository.getConnectionByPipedreamId(String(id));
+        const { event, account, error: connectionError } = JSON.parse(rawBody) as PipedreamConnectWebhookPayload;
+
+        log.info('Webhook /connected received', {
+            event,
+            has_account: !!account,
+            has_account_id: !!account?.id,
+            has_external_id: !!account?.external_id,
+            ip: req.ip,
+        });
+
+        if (event === 'CONNECTION_ERROR') {
+            log.warn('Pipedream connection error webhook received', {
+                event,
+                external_id: account?.external_id,
+                app_slug: account?.app?.name_slug,
+                error: connectionError,
+            });
+            res.status(200).json({ status: 'ignored', reason: 'connection_error' });
+            return;
+        }
+
+        if (!account || !account.id || !account.external_id || !account.name || !account.app?.name_slug) {
+            log.info('Webhook /connected rejected: missing fields', {
+                event,
+                has_account: !!account,
+                account_id: account?.id,
+                external_id: account?.external_id,
+                app_slug: account?.app?.name_slug,
+            });
+            res.status(400).json({ error: 'Missing required fields: account.id, account.external_id, account.name, account.app.name_slug' });
+            return;
+        }
+
+        const appSlug = account.app.name_slug;
+        const appName = account.name;
+
+        const existing = await toolsRepository.getConnectionByPipedreamId(String(account.id));
         if (existing) {
-            log.info('Pipedream account already connected', { pipedream_account_id: id, app_slug: appSlug });
+            log.info('Pipedream account already connected', { pipedream_account_id: account.id, app_slug: appSlug });
             res.status(200).json({ status: 'already_connected' });
             return;
         }
 
         await toolsRepository.saveConnection({
-            user_id: String(external_id),
-            pipedream_account_id: String(id),
+            user_id: String(account.external_id),
+            pipedream_account_id: String(account.id),
             app_slug: appSlug,
             app_name: appName,
         });
 
         log.info('Pipedream account connected successfully', {
-            user_id: external_id,
+            user_id: account.external_id,
             app_slug: appSlug,
             app_name: appName,
-            pipedream_account_id: id,
+            pipedream_account_id: account.id,
         });
         res.status(200).json({ status: 'connected' });
     } catch (error) {

--- a/xerus_backend/src/domains/tools/service.ts
+++ b/xerus_backend/src/domains/tools/service.ts
@@ -3,6 +3,7 @@
 
 import { getPipedreamClient } from '../../shared/clients/pipedream';
 import { toolsRepository } from './repository';
+import { reconcileConnectedAccounts } from './connection-reconciler';
 import { toolValidator } from './validators';
 import { toolsCache } from '../../shared/cache/tools-cache';
 import { ToolNotConnectedError, ToolExecutionError, UnauthorizedAccessError } from './errors';
@@ -124,6 +125,15 @@ export class ToolsService {
         }
 
         return connections;
+    }
+
+    /**
+     * Reconcile a user's connected_accounts against Pipedream (source of truth) so the
+     * table converges on every sandbox MCP sync and backfills connections dropped by
+     * fire-and-forget webhooks. Delegates to connection-reconciler; see that module.
+     */
+    async reconcileConnectedAccounts(input: { user_id: string }): Promise<{ added: number; removed: number; total: number }> {
+        return reconcileConnectedAccounts(this.pipedream, input.user_id);
     }
 
     async disconnectAccount(input: DisconnectAccountInput): Promise<void> {

--- a/xerus_backend/src/domains/tools/types.ts
+++ b/xerus_backend/src/domains/tools/types.ts
@@ -123,6 +123,17 @@ export interface PipedreamAccount {
     updated_at: string;
 }
 
+export type PipedreamConnectEvent = 'CONNECTION_SUCCESS' | 'CONNECTION_ERROR';
+
+// Payload delivered to the Connect webhook (webhook_uri) after an OAuth attempt.
+// Account fields are nested under `account`; the event distinguishes success from error.
+export interface PipedreamConnectWebhookPayload {
+    event: PipedreamConnectEvent;
+    account?: PipedreamAccount;
+    error?: string;
+    connect_token?: string;
+}
+
 export interface PipedreamAction {
     key: string;
     name: string;

--- a/xerus_backend/src/index.ts
+++ b/xerus_backend/src/index.ts
@@ -28,7 +28,9 @@ import { setKnowledgeBaseRoutesDeps } from './domains/platform-tools/internal-mc
 import { setChannelTaskRoutesDeps } from './domains/platform-tools/internal-mcp/channel-task.routes';
 import { setSkillManagementRoutesDeps } from './domains/platform-tools/internal-mcp/skill-management.routes';
 import { setSearchOutputsRoutesDeps } from './domains/platform-tools/internal-mcp/search-outputs.routes';
+import { setNotificationRoutesDeps } from './domains/platform-tools/internal-mcp/notification.routes';
 import { webhookReceiverRouter } from './domains/triggers';
+import { internalExecutionRouter, setInternalExecutionDeps } from './domains/execution/internal-execution.routes';
 import { ExecutionService, setExecutionApiKeyLookup } from './domains/execution/execution.service';
 import { apiKeyService } from './domains/users/api-key-service';
 import { query } from './database/connection';
@@ -56,6 +58,8 @@ import { ActiveStreamEmitter } from './domains/execution/hitl/active-stream-emit
 import { sseRegistry } from './domains/execution/streaming/sse-registry';
 import { createMemorySearchIndexService } from './domains/memory/git-memory/memory-search-index.service';
 import { startHeartbeatDaemon, stopHeartbeatDaemon } from './domains/execution/background/heartbeat-daemon';
+import { startWakeDaemon, stopWakeDaemon } from './domains/execution/background/wake-daemon';
+import { findInvalidPipedreamEnvVars } from './shared/clients/pipedream';
 
 const log = logger('Server');
 
@@ -86,9 +90,10 @@ app.use((req, res, next) => {
 });
 
 app.use(helmet());
-// Webhook route needs raw body as Buffer for HMAC signature verification.
+// Webhook routes need the raw body as a Buffer for HMAC signature verification.
 // Must come BEFORE express.json() which would parse the body into an object.
 app.use('/api/v1/billing/webhooks/polar', express.raw({ type: 'application/json' }));
+app.use('/api/v1/tools/webhook/connected', express.raw({ type: 'application/json' }));
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
 app.use(requestMeta);
@@ -126,6 +131,7 @@ app.use('/api/v1/skills', skillRoutes);
 app.use('/api/v1/invite-codes', inviteCodeRoutes);
 app.use('/api/v1/billing', billingRoutes);
 app.use('/api/v1/internal/mcp', internalMcpRouter);
+app.use('/internal/v1', internalExecutionRouter);
 
 app.use(notFoundHandler);
 app.use(errorHandler);
@@ -135,6 +141,15 @@ const PORT = parseInt(process.env.PORT || '5001', 10);
 async function startServer(): Promise<void> {
     await testConnection();
     await warmPool();
+
+    const invalidPipedreamVars = findInvalidPipedreamEnvVars();
+    if (invalidPipedreamVars.length > 0) {
+        log.warn('Pipedream integration disabled — connector tools will fail until these env vars are set to real values', {
+            missing_or_placeholder: invalidPipedreamVars,
+        });
+    } else {
+        log.info('Pipedream configuration validated');
+    }
 
     const server = app.listen(PORT, () => {
         log.info('Server running', { port: PORT });
@@ -163,6 +178,7 @@ async function startServer(): Promise<void> {
         shutdownSseAuth();
         sseRegistry.shutdown();
         stopHeartbeatDaemon();
+        stopWakeDaemon();
         server.close();
     });
 
@@ -271,6 +287,7 @@ async function startServer(): Promise<void> {
             activeStreamEmitter,
         });
         setExecutionService(executionService);
+        setInternalExecutionDeps({ executionService });
         setExecutionRoutesDeps({ sandboxService });
         setAgentFilesDeps({ sandboxService });
         setConversationRoutesDeps({ sandboxService });
@@ -282,6 +299,7 @@ async function startServer(): Promise<void> {
         setChannelTaskRoutesDeps({ sandboxService });
         setSkillManagementRoutesDeps({ sandboxService });
         setSearchOutputsRoutesDeps({ sandboxService });
+        setNotificationRoutesDeps({ sandboxService });
         setAgentRoutesDeps({ sandboxService });
         setAgentChannelsDeps({ sandboxService });
         setTaskRoutesDeps({ sandboxService, executionService });
@@ -320,6 +338,7 @@ async function startServer(): Promise<void> {
         // Gated by the same flag as cron jobs so ops can disable all background polling.
         if (process.env.ENABLE_CRON_JOBS !== 'false') {
             startHeartbeatDaemon({ sandboxService, executionService });
+            startWakeDaemon(sandboxService);
         } else {
             log.info('Heartbeat daemon disabled (ENABLE_CRON_JOBS=false)');
         }

--- a/xerus_backend/src/shared/clients/pipedream.ts
+++ b/xerus_backend/src/shared/clients/pipedream.ts
@@ -2,6 +2,32 @@ import { createBackendClient, type BackendClient } from '@pipedream/sdk';
 
 let client: BackendClient | null = null;
 
+const PIPEDREAM_ENV_VARS = [
+    'PIPEDREAM_CLIENT_ID',
+    'PIPEDREAM_CLIENT_SECRET',
+    'PIPEDREAM_PROJECT_ID',
+    'PIPEDREAM_PROJECT_ENVIRONMENT',
+] as const;
+
+const PLACEHOLDER_PATTERNS: RegExp[] = [
+    /^your[-_]/i,
+    /placeholder/i,
+    /^x{3,}$/i,
+    /^todo$/i,
+    /^changeme$/i,
+];
+
+function isPlaceholderValue(value: string | undefined): boolean {
+    if (value === undefined) return true;
+    const trimmed = value.trim();
+    if (trimmed === '') return true;
+    return PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+export function findInvalidPipedreamEnvVars(): string[] {
+    return PIPEDREAM_ENV_VARS.filter((name) => isPlaceholderValue(process.env[name]));
+}
+
 export function getPipedreamClient(): BackendClient {
     if (!client) {
         const clientId = process.env.PIPEDREAM_CLIENT_ID;

--- a/xerus_backend/tests/database/migrations/096_relax_memory_search_index_constraints.test.ts
+++ b/xerus_backend/tests/database/migrations/096_relax_memory_search_index_constraints.test.ts
@@ -1,0 +1,118 @@
+import { query } from '../../../src/database/connection';
+import fs from 'fs';
+import path from 'path';
+
+// Verifies migration 096 relaxes the memory_search_index scope/memory_type CHECK
+// constraints to accept the v2 hierarchical memory model. Runs against the test
+// database (real service, no mocks).
+
+const ZERO_VECTOR = `[${new Array(1536).fill(0).join(',')}]`;
+
+describe('Migration 096: relax memory_search_index constraints', () => {
+    beforeAll(async () => {
+        const migrationSQL = fs.readFileSync(
+            path.join(__dirname, '../../../src/database/migrations/096_relax_memory_search_index_constraints.sql'),
+            'utf-8',
+        );
+        await query(migrationSQL);
+    });
+
+    describe('constraint definitions', () => {
+        async function constraintDef(name: string): Promise<string> {
+            const result = await query<{ def: string }>(
+                `SELECT pg_get_constraintdef(con.oid) AS def
+                 FROM pg_constraint con
+                 JOIN pg_class rel ON rel.oid = con.conrelid
+                 WHERE rel.relname = 'memory_search_index' AND con.conname = $1`,
+                [name],
+            );
+            expect(result.rows.length).toBe(1);
+            return result.rows[0].def;
+        }
+
+        it('msi_scope_check accepts the v2 scopes', async () => {
+            const def = await constraintDef('msi_scope_check');
+            for (const scope of ['company', 'project', 'channel', 'agent', 'user', 'entity', 'topic']) {
+                expect(def).toContain(`'${scope}'`);
+            }
+        });
+
+        it('msi_memory_type_check accepts the v2 memory types', async () => {
+            const def = await constraintDef('msi_memory_type_check');
+            for (const type of ['working', 'expertise', 'context', 'learnings', 'patterns', 'decisions', 'standup', 'vision', 'preferences']) {
+                expect(def).toContain(`'${type}'`);
+            }
+        });
+    });
+
+    describe('data integrity', () => {
+        let testUserId: string;
+        let testWorkspaceId: string;
+
+        beforeAll(async () => {
+            testUserId = `test_msi_${Date.now()}`;
+            await query(
+                `INSERT INTO users (user_id, email, display_name, role, is_active)
+                 VALUES ($1, $2, 'MSI Test', 'user', true)`,
+                [testUserId, `${testUserId}@test.local`],
+            );
+            const ws = await query<{ id: string }>(
+                `INSERT INTO workspaces (user_id, slug, name)
+                 VALUES ($1, $2, 'MSI Test Workspace')
+                 RETURNING id`,
+                [testUserId, `msi-test-${Date.now()}`],
+            );
+            testWorkspaceId = ws.rows[0].id;
+        });
+
+        afterAll(async () => {
+            await query('DELETE FROM memory_search_index WHERE workspace_id = $1', [testWorkspaceId]);
+            await query('DELETE FROM workspaces WHERE id = $1', [testWorkspaceId]);
+            await query('DELETE FROM users WHERE user_id = $1', [testUserId]);
+        });
+
+        it('accepts a v2 row (memory_type=expertise, scope=agent) that the old constraint rejected', async () => {
+            const result = await query<{ id: string }>(
+                `INSERT INTO memory_search_index
+                    (workspace_id, file_path, chunk_start_line, chunk_end_line, content, content_hash, memory_type, scope, agent_slug, embedding)
+                 VALUES ($1, 'agents/seo-agent/expertise.md', 1, 5, 'expertise content', 'hash-expertise', 'expertise', 'agent', 'seo-agent', $2::vector)
+                 RETURNING id`,
+                [testWorkspaceId, ZERO_VECTOR],
+            );
+            expect(result.rows[0].id).toBeDefined();
+        });
+
+        it('accepts a company-scoped context row', async () => {
+            const result = await query<{ id: string }>(
+                `INSERT INTO memory_search_index
+                    (workspace_id, file_path, chunk_start_line, chunk_end_line, content, content_hash, memory_type, scope, embedding)
+                 VALUES ($1, 'company/decisions.md', 1, 3, 'company decision', 'hash-company', 'context', 'company', $2::vector)
+                 RETURNING id`,
+                [testWorkspaceId, ZERO_VECTOR],
+            );
+            expect(result.rows[0].id).toBeDefined();
+        });
+
+        it('still rejects an unknown scope value', async () => {
+            await expect(
+                query(
+                    `INSERT INTO memory_search_index
+                        (workspace_id, file_path, chunk_start_line, chunk_end_line, content, content_hash, memory_type, scope, embedding)
+                     VALUES ($1, 'agents/x/working.md', 1, 2, 'x', 'hash-bad-scope', 'working', 'bogus_scope', $2::vector)`,
+                    [testWorkspaceId, ZERO_VECTOR],
+                ),
+            ).rejects.toThrow();
+        });
+
+        it('still rejects an unknown memory_type value', async () => {
+            await expect(
+                query(
+                    `INSERT INTO memory_search_index
+                        (workspace_id, file_path, chunk_start_line, chunk_end_line, content, content_hash, memory_type, scope, embedding)
+                     VALUES ($1, 'agents/x/working.md', 1, 2, 'x', 'hash-bad-type', 'not_a_type', 'agent', $2::vector)`,
+                    [testWorkspaceId, ZERO_VECTOR],
+                ),
+            ).rejects.toThrow();
+        });
+    });
+});

--- a/xerus_backend/tests/e2e/client.ts
+++ b/xerus_backend/tests/e2e/client.ts
@@ -1,0 +1,62 @@
+import { REQUEST_TIMEOUT_MS } from './config';
+
+export interface TestResult {
+    name: string;
+    method: string;
+    path: string;
+    status: number;
+    passed: boolean;
+    duration: number;
+    error?: string;
+    body?: unknown;
+}
+
+export async function apiCall(
+    baseUrl: string,
+    token: string,
+    method: string,
+    path: string,
+    body?: unknown,
+): Promise<{ status: number; body: unknown; duration: number }> {
+    const url = `${baseUrl}${path}`;
+    const headers: Record<string, string> = {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+    };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    const start = Date.now();
+    try {
+        const resp = await fetch(url, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+            signal: controller.signal,
+        });
+        const duration = Date.now() - start;
+
+        let respBody: unknown;
+        const text = await resp.text();
+        try {
+            respBody = JSON.parse(text);
+        } catch {
+            respBody = text;
+        }
+
+        return { status: resp.status, body: respBody, duration };
+    } catch (err: unknown) {
+        const duration = Date.now() - start;
+        const message = err instanceof Error ? err.message : String(err);
+        return { status: 0, body: { error: message }, duration };
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+export function formatResult(r: TestResult): string {
+    const icon = r.passed ? '[PASS]' : '[FAIL]';
+    const base = `${icon} ${r.method} ${r.path} (${r.status}) ${r.duration}ms`;
+    return r.error ? `${base} - ${r.error}` : base;
+}

--- a/xerus_backend/tests/e2e/config.ts
+++ b/xerus_backend/tests/e2e/config.ts
@@ -1,0 +1,13 @@
+export const TARGETS: Record<string, string> = {
+    prod: process.env.E2E_API_URL || 'http://localhost:5001/api/v1',
+    local: 'http://localhost:5001/api/v1',
+};
+
+export const HEALTH_TARGETS: Record<string, string> = {
+    prod: process.env.E2E_API_BASE || 'http://localhost:5001',
+    local: 'http://localhost:5001',
+};
+
+export const TEST_USER_EMAIL = process.env.E2E_TEST_EMAIL || '';
+export const TOKEN_SCRIPT = 'scripts/get-token.js';
+export const REQUEST_TIMEOUT_MS = 15_000;

--- a/xerus_backend/tests/e2e/runner.ts
+++ b/xerus_backend/tests/e2e/runner.ts
@@ -1,0 +1,137 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import { TARGETS, TEST_USER_EMAIL, TOKEN_SCRIPT } from './config';
+import { TestResult } from './client';
+import { runSmoke } from './tier1-smoke';
+import { runContract } from './tier2-contract';
+import { runFlows } from './tier3-flows';
+
+function getToken(email: string): string {
+    const scriptPath = path.resolve(__dirname, '../../', TOKEN_SCRIPT);
+    try {
+        const token = execSync(`node "${scriptPath}" "${email}"`, {
+            cwd: path.resolve(__dirname, '../../'),
+            timeout: 30_000,
+            encoding: 'utf-8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+
+        if (!token || token.length < 50) {
+            throw new Error(`Token too short (${token.length} chars)`);
+        }
+        return token;
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`\nFailed to get auth token: ${msg}`);
+        console.error('Ensure GOOGLE_APPLICATION_CREDENTIALS is set in .env.local');
+        process.exit(1);
+    }
+}
+
+function parseArgs(): { target: string; tier: string; email: string } {
+    const args = process.argv.slice(2);
+    let target = 'prod';
+    let tier = 'all';
+    let email = TEST_USER_EMAIL;
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--target' && args[i + 1]) target = args[++i];
+        else if (args[i] === '--tier' && args[i + 1]) tier = args[++i];
+        else if (args[i] === '--email' && args[i + 1]) email = args[++i];
+        else if (args[i] === '--help') {
+            console.log(`
+Usage: npx ts-node tests/e2e/runner.ts [options]
+
+Options:
+  --target <prod|local>           API target (default: prod)
+  --tier <smoke|contract|flow|all> Test tier (default: all)
+  --email <email>                  Test user email (default: ${TEST_USER_EMAIL})
+  --help                           Show this help
+`);
+            process.exit(0);
+        }
+    }
+
+    if (!TARGETS[target]) {
+        console.error(`Unknown target: ${target}. Use: ${Object.keys(TARGETS).join(', ')}`);
+        process.exit(1);
+    }
+
+    return { target, tier, email };
+}
+
+async function main(): Promise<void> {
+    const { target, tier, email } = parseArgs();
+    const baseUrl = TARGETS[target];
+
+    console.log('╔══════════════════════════════════════╗');
+    console.log('║   Xerus API Regression Suite         ║');
+    console.log('╚══════════════════════════════════════╝');
+    console.log(`Target:  ${target} (${baseUrl})`);
+    console.log(`Tier:    ${tier}`);
+    console.log(`User:    ${email}`);
+    console.log('');
+
+    // Auth
+    console.log('Authenticating...');
+    const token = getToken(email);
+    console.log(`Token acquired (${token.length} chars)\n`);
+
+    const allResults: TestResult[] = [];
+    let totalPassed = 0;
+    let totalFailed = 0;
+    let totalSkipped = 0;
+
+    // Tier 1: Smoke
+    if (tier === 'smoke' || tier === 'all') {
+        const smoke = await runSmoke(baseUrl, token, target);
+        allResults.push(...smoke.results);
+        totalPassed += smoke.passed;
+        totalFailed += smoke.failed;
+        totalSkipped += smoke.skipped;
+    }
+
+    // Tier 2: Contract
+    if (tier === 'contract' || tier === 'all') {
+        const contract = await runContract(baseUrl, token);
+        allResults.push(...contract.results);
+        totalPassed += contract.passed;
+        totalFailed += contract.failed;
+    }
+
+    // Tier 3: Flows
+    if (tier === 'flow' || tier === 'all') {
+        const flows = await runFlows(baseUrl, token);
+        allResults.push(...flows.results);
+        totalPassed += flows.passed;
+        totalFailed += flows.failed;
+    }
+
+    // Summary
+    console.log('\n╔══════════════════════════════════════╗');
+    console.log('║   SUMMARY                            ║');
+    console.log('╚══════════════════════════════════════╝');
+    console.log(`Total:   ${totalPassed + totalFailed + totalSkipped}`);
+    console.log(`Passed:  ${totalPassed}`);
+    console.log(`Failed:  ${totalFailed}`);
+    console.log(`Skipped: ${totalSkipped}`);
+
+    if (totalFailed > 0) {
+        console.log('\n--- FAILURES ---');
+        for (const r of allResults.filter(r => !r.passed)) {
+            console.log(`  ${r.name}: ${r.method} ${r.path} (${r.status}) — ${r.error}`);
+            if (r.body) {
+                const preview = JSON.stringify(r.body).slice(0, 200);
+                console.log(`    Response: ${preview}`);
+            }
+        }
+    }
+
+    console.log(`\nResult: ${totalFailed === 0 ? 'ALL PASSED' : 'FAILURES DETECTED'}`);
+    process.exit(totalFailed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+    console.error('Runner crashed:', err);
+    process.exit(2);
+});

--- a/xerus_backend/tests/e2e/tier1-smoke.ts
+++ b/xerus_backend/tests/e2e/tier1-smoke.ts
@@ -1,0 +1,154 @@
+import { apiCall, TestResult, formatResult } from './client';
+import { HEALTH_TARGETS } from './config';
+
+interface Endpoint {
+    method: string;
+    path: string;
+    auth?: boolean;
+    body?: unknown;
+    skip?: string;
+}
+
+const ENDPOINTS: Endpoint[] = [
+    // health
+    { method: 'GET', path: '/health', auth: false },
+
+    // users
+    { method: 'GET', path: '/users/me' },
+    { method: 'GET', path: '/users/credits' },
+    { method: 'GET', path: '/users/credits/history' },
+    { method: 'GET', path: '/users/api-keys' },
+    { method: 'GET', path: '/users/cli-auth-status' },
+
+    // agents
+    { method: 'GET', path: '/agents' },
+    { method: 'GET', path: '/agents/marketplace' },
+    { method: 'GET', path: '/agents/mine' },
+
+    // execution
+    { method: 'GET', path: '/execute/sessions' },
+    { method: 'GET', path: '/execute/conversations' },
+    { method: 'GET', path: '/execute/schedules' },
+    { method: 'GET', path: '/execute/schedules/runs' },
+
+    // inbox
+    { method: 'GET', path: '/inbox' },
+
+    // company
+    { method: 'GET', path: '/company/domains' },
+
+    // tasks
+    { method: 'GET', path: '/tasks' },
+
+    // memory
+    { method: 'GET', path: '/memory' },
+
+    // models
+    { method: 'GET', path: '/models' },
+
+    // workspace
+    { method: 'GET', path: '/workspace/tree' },
+    { method: 'GET', path: '/workspace/overview' },
+    { method: 'GET', path: '/workspace/status' },
+    { method: 'GET', path: '/workspace/connections' },
+    { method: 'GET', path: '/workspace/tags/list' },
+    { method: 'GET', path: '/workspace/tags' },
+    { method: 'GET', path: '/workspace/snapshots' },
+
+    // skills
+    { method: 'GET', path: '/skills' },
+
+    // tools
+    { method: 'GET', path: '/tools' },
+    { method: 'GET', path: '/tools/accounts' },
+    { method: 'GET', path: '/tools/hidden' },
+
+    // billing
+    { method: 'GET', path: '/billing/subscription' },
+    { method: 'GET', path: '/billing/usage' },
+
+    // invite codes
+    { method: 'GET', path: '/invite-codes' },
+
+    // POST endpoints - send empty/minimal bodies, expect 400/422 (not 500)
+    { method: 'POST', path: '/users/find-or-create', body: {} },
+    { method: 'POST', path: '/execute/sse-token', body: {} },
+    { method: 'POST', path: '/inbox/sse-token', body: {} },
+    { method: 'POST', path: '/workspace/sse-token', body: {} },
+    { method: 'POST', path: '/execute/conversations', body: {} },
+    { method: 'POST', path: '/company/tasks/sync', body: {} },
+    { method: 'POST', path: '/workspace/ensure', body: {} },
+
+    // Skip destructive/dangerous endpoints
+    { method: 'DELETE', path: '/users/me', skip: 'destructive' },
+    { method: 'POST', path: '/workspace/stop', skip: 'destructive' },
+    { method: 'POST', path: '/workspace/backup', skip: 'slow' },
+    { method: 'POST', path: '/billing/subscription/cancel', skip: 'destructive' },
+    { method: 'POST', path: '/onboarding/start', skip: 'destructive' },
+];
+
+export async function runSmoke(
+    baseUrl: string,
+    token: string,
+    targetName: string,
+): Promise<{ results: TestResult[]; passed: number; failed: number; skipped: number }> {
+    console.log('\n=== TIER 1: SMOKE TESTS ===\n');
+
+    const results: TestResult[] = [];
+    let passed = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const ep of ENDPOINTS) {
+        if (ep.skip) {
+            skipped++;
+            console.log(`[SKIP] ${ep.method} ${ep.path} — ${ep.skip}`);
+            continue;
+        }
+
+        const url = ep.auth === false
+            ? HEALTH_TARGETS[targetName]
+            : baseUrl;
+
+        try {
+            const { status, body, duration } = await apiCall(
+                url, token, ep.method, ep.path, ep.body,
+            );
+
+            const pass = status > 0 && status < 500;
+            const result: TestResult = {
+                name: `smoke:${ep.method}:${ep.path}`,
+                method: ep.method,
+                path: ep.path,
+                status,
+                passed: pass,
+                duration,
+                error: pass ? undefined : `Server error ${status}`,
+                body: pass ? undefined : body,
+            };
+
+            results.push(result);
+            console.log(formatResult(result));
+
+            if (pass) passed++;
+            else failed++;
+        } catch (err: unknown) {
+            failed++;
+            const msg = err instanceof Error ? err.message : String(err);
+            const result: TestResult = {
+                name: `smoke:${ep.method}:${ep.path}`,
+                method: ep.method,
+                path: ep.path,
+                status: 0,
+                passed: false,
+                duration: 0,
+                error: msg,
+            };
+            results.push(result);
+            console.log(formatResult(result));
+        }
+    }
+
+    console.log(`\nSmoke: ${passed} passed, ${failed} failed, ${skipped} skipped\n`);
+    return { results, passed, failed, skipped };
+}

--- a/xerus_backend/tests/e2e/tier2-contract.ts
+++ b/xerus_backend/tests/e2e/tier2-contract.ts
@@ -1,0 +1,296 @@
+import { apiCall, TestResult, formatResult } from './client';
+
+type AssertFn = (body: unknown, status: number) => string | null;
+
+interface ContractTest {
+    name: string;
+    method: string;
+    path: string;
+    body?: unknown;
+    assert: AssertFn;
+    dependsOn?: string;
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+const TESTS: ContractTest[] = [
+    // users/me returns user object
+    {
+        name: 'users-me',
+        method: 'GET',
+        path: '/users/me',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            if (typeof data['email'] !== 'string') return 'missing email';
+            if (typeof data['user_id'] !== 'string') return 'missing user_id';
+            return null;
+        },
+    },
+    // agents list returns array (wrapped in data.agents)
+    {
+        name: 'agents-list',
+        method: 'GET',
+        path: '/agents',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            const agents = data['agents'] ?? data['data'];
+            if (!Array.isArray(agents)) return 'expected agents array in data';
+            return null;
+        },
+    },
+    // agents/mine returns array
+    {
+        name: 'agents-mine',
+        method: 'GET',
+        path: '/agents/mine',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            const agents = data['agents'] ?? data['data'];
+            if (!Array.isArray(agents)) return 'expected agents array in data';
+            return null;
+        },
+    },
+    // conversations list
+    {
+        name: 'conversations-list',
+        method: 'GET',
+        path: '/execute/conversations',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            if (!Array.isArray(data['conversations'])) return 'expected conversations array';
+            return null;
+        },
+    },
+    // company domains
+    {
+        name: 'company-domains',
+        method: 'GET',
+        path: '/company/domains',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            if (!Array.isArray(data['domains'])) return 'expected domains array';
+            return null;
+        },
+    },
+    // tasks list
+    {
+        name: 'tasks-list',
+        method: 'GET',
+        path: '/tasks',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            const tasks = data['tasks'];
+            if (!Array.isArray(tasks)) return 'expected tasks array';
+            return null;
+        },
+    },
+    // inbox list
+    {
+        name: 'inbox-list',
+        method: 'GET',
+        path: '/inbox',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            const data = isObj(body['data']) ? body['data'] : body;
+            if (!Array.isArray(data['items'])) return 'expected items array';
+            return null;
+        },
+    },
+    // workspace tree
+    {
+        name: 'workspace-tree',
+        method: 'GET',
+        path: '/workspace/tree',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // workspace status
+    {
+        name: 'workspace-status',
+        method: 'GET',
+        path: '/workspace/status',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // memory
+    {
+        name: 'memory',
+        method: 'GET',
+        path: '/memory',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // models list
+    {
+        name: 'models-list',
+        method: 'GET',
+        path: '/models',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            if (!Array.isArray(body['models']) && !Array.isArray(body['data']))
+                return 'expected models or data array';
+            return null;
+        },
+    },
+    // skills list
+    {
+        name: 'skills-list',
+        method: 'GET',
+        path: '/skills',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // tools list
+    {
+        name: 'tools-list',
+        method: 'GET',
+        path: '/tools',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // credits
+    {
+        name: 'credits',
+        method: 'GET',
+        path: '/users/credits',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // schedules
+    {
+        name: 'schedules-list',
+        method: 'GET',
+        path: '/execute/schedules',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+    // 404 contract: nonexistent task returns 404
+    {
+        name: 'task-404',
+        method: 'GET',
+        path: '/tasks/nonexistent-task-id-99999',
+        assert: (_body, status) => {
+            if (status !== 404) return `expected 404, got ${status}`;
+            return null;
+        },
+    },
+    // 404 contract: nonexistent task comments returns 404
+    {
+        name: 'task-comments-404',
+        method: 'GET',
+        path: '/tasks/nonexistent-task-id-99999/comments',
+        assert: (_body, status) => {
+            if (status !== 404) return `expected 404, got ${status}`;
+            return null;
+        },
+    },
+    // 404 contract: nonexistent task activities returns 404
+    {
+        name: 'task-activities-404',
+        method: 'GET',
+        path: '/tasks/nonexistent-task-id-99999/activities',
+        assert: (_body, status) => {
+            if (status !== 404) return `expected 404, got ${status}`;
+            return null;
+        },
+    },
+    // 404 contract: post comment on nonexistent task returns 404
+    {
+        name: 'task-comment-post-404',
+        method: 'POST',
+        path: '/tasks/nonexistent-task-id-99999/comments',
+        body: { content: 'test comment' },
+        assert: (_body, status) => {
+            if (status !== 404) return `expected 404, got ${status}`;
+            return null;
+        },
+    },
+    // billing subscription shape
+    {
+        name: 'billing-subscription',
+        method: 'GET',
+        path: '/billing/subscription',
+        assert: (body) => {
+            if (!isObj(body)) return 'expected object';
+            return null;
+        },
+    },
+];
+
+export async function runContract(
+    baseUrl: string,
+    token: string,
+): Promise<{ results: TestResult[]; passed: number; failed: number }> {
+    console.log('\n=== TIER 2: CONTRACT TESTS ===\n');
+
+    const results: TestResult[] = [];
+    let passed = 0;
+    let failed = 0;
+
+    for (const test of TESTS) {
+        try {
+            const { status, body, duration } = await apiCall(
+                baseUrl, token, test.method, test.path, test.body,
+            );
+
+            const assertError = test.assert(body, status);
+            const pass = assertError === null && status < 500;
+
+            const result: TestResult = {
+                name: `contract:${test.name}`,
+                method: test.method,
+                path: test.path,
+                status,
+                passed: pass,
+                duration,
+                error: assertError || (status >= 500 ? `Server error ${status}` : undefined),
+                body: pass ? undefined : body,
+            };
+
+            results.push(result);
+            console.log(formatResult(result));
+
+            if (pass) passed++;
+            else failed++;
+        } catch (err: unknown) {
+            failed++;
+            const msg = err instanceof Error ? err.message : String(err);
+            const result: TestResult = {
+                name: `contract:${test.name}`,
+                method: test.method,
+                path: test.path,
+                status: 0,
+                passed: false,
+                duration: 0,
+                error: msg,
+            };
+            results.push(result);
+            console.log(formatResult(result));
+        }
+    }
+
+    console.log(`\nContract: ${passed} passed, ${failed} failed\n`);
+    return { results, passed, failed };
+}

--- a/xerus_backend/tests/e2e/tier3-flows.ts
+++ b/xerus_backend/tests/e2e/tier3-flows.ts
@@ -1,0 +1,396 @@
+import { apiCall, TestResult, formatResult } from './client';
+
+function isObj(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+interface FlowStep {
+    label: string;
+    method: string;
+    path: string | ((ctx: Record<string, unknown>) => string);
+    body?: unknown | ((ctx: Record<string, unknown>) => unknown);
+    assert: (body: unknown, status: number) => string | null;
+    extract?: (body: unknown) => Record<string, unknown>;
+}
+
+interface Flow {
+    name: string;
+    steps: FlowStep[];
+}
+
+const FLOWS: Flow[] = [
+    {
+        name: 'agent-discovery',
+        steps: [
+            {
+                label: 'list user agents',
+                method: 'GET',
+                path: '/agents/mine',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    const data = isObj(body['data']) ? body['data'] : body;
+                    if (!Array.isArray(data['agents'])) return 'expected agents array';
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = (body as Record<string, unknown>)['data'] as Record<string, unknown>;
+                    const agents = (wrapper?.['agents'] ?? wrapper) as unknown[];
+                    const first = Array.isArray(agents) ? agents[0] as Record<string, unknown> | undefined : undefined;
+                    return {
+                        agentCount: Array.isArray(agents) ? agents.length : 0,
+                        agentId: first?.['id'] ?? '',
+                        agentSlug: first?.['slug'] ?? '',
+                    };
+                },
+            },
+            {
+                label: 'get agent detail',
+                method: 'GET',
+                path: (ctx) => `/agents/${ctx['agentId']}`,
+                assert: (body, status) => {
+                    if (status === 404) return null; // no agents yet is ok
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+            {
+                label: 'get agent channels',
+                method: 'GET',
+                path: (ctx) => `/agents/${ctx['agentId']}/channels`,
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+        ],
+    },
+    {
+        name: 'company-structure',
+        steps: [
+            {
+                label: 'list domains',
+                method: 'GET',
+                path: '/company/domains',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = (body as Record<string, unknown>)['data'] as Record<string, unknown> | undefined;
+                    const domains = (wrapper?.['domains'] ?? (body as Record<string, unknown>)['domains']) as unknown[];
+                    const first = domains?.[0] as Record<string, unknown> | undefined;
+                    return {
+                        domainId: first?.['id'] ?? first?.['slug'] ?? '',
+                        domainSlug: first?.['slug'] ?? '',
+                    };
+                },
+            },
+            {
+                label: 'get domain overview',
+                method: 'GET',
+                path: (ctx) => `/company/domains/${ctx['domainId']}/overview`,
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = (body as Record<string, unknown>)['data'] as Record<string, unknown> | undefined;
+                    const src = wrapper ?? body as Record<string, unknown>;
+                    const channels = src['channels'] as unknown[] | undefined;
+                    const first = channels?.[0] as Record<string, unknown> | undefined;
+                    return {
+                        channelId: first?.['id'] ?? first?.['slug'] ?? '',
+                    };
+                },
+            },
+            {
+                label: 'get channel agents',
+                method: 'GET',
+                path: (ctx) => `/company/channels/${ctx['channelId']}/agents`,
+                assert: (_body, status) => {
+                    if (status === 404) return null;
+                    return null;
+                },
+            },
+            {
+                label: 'get channel tasks',
+                method: 'GET',
+                path: (ctx) => `/company/channels/${ctx['channelId']}/tasks`,
+                assert: (_body, status) => {
+                    if (status === 404) return null;
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = (body as Record<string, unknown>)['data'] as Record<string, unknown> | undefined;
+                    const tasks = (wrapper?.['tasks'] ?? (body as Record<string, unknown>)['tasks']) as unknown[] | undefined;
+                    const first = tasks?.[0] as Record<string, unknown> | undefined;
+                    return { taskId: first?.['id'] ?? '' };
+                },
+            },
+        ],
+    },
+    {
+        name: 'task-lifecycle',
+        steps: [
+            {
+                label: 'list all tasks',
+                method: 'GET',
+                path: '/tasks',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = (body as Record<string, unknown>)['data'] as Record<string, unknown> | undefined;
+                    const tasks = (wrapper?.['tasks'] ?? (body as Record<string, unknown>)['tasks']) as unknown[] | undefined;
+                    const first = tasks?.[0] as Record<string, unknown> | undefined;
+                    return {
+                        taskId: first?.['id'] ?? '',
+                        taskTitle: first?.['title'] ?? '',
+                        hasTask: !!first,
+                    };
+                },
+            },
+            {
+                label: 'get task detail',
+                method: 'GET',
+                path: (ctx) => `/tasks/${ctx['taskId']}`,
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+            {
+                label: 'get task comments',
+                method: 'GET',
+                path: (ctx) => `/tasks/${ctx['taskId']}/comments`,
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (!isObj(body)) return 'expected object';
+                    const data = isObj(body['data']) ? body['data'] as Record<string, unknown> : body as Record<string, unknown>;
+                    if (!Array.isArray(data['comments'])) return 'comments should be array';
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = isObj(body) && isObj((body as Record<string, unknown>)['data'])
+                        ? (body as Record<string, unknown>)['data'] as Record<string, unknown>
+                        : body as Record<string, unknown>;
+                    const comments = wrapper['comments'] as unknown[];
+                    return { commentCountBefore: comments?.length ?? 0 };
+                },
+            },
+            {
+                label: 'post comment on task',
+                method: 'POST',
+                path: (ctx) => `/tasks/${ctx['taskId']}/comments`,
+                body: () => ({ content: `E2E test comment ${Date.now()}` }),
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (status !== 201) return `expected 201, got ${status}`;
+                    if (!isObj(body)) return 'expected object';
+                    const data = isObj(body['data']) ? body['data'] as Record<string, unknown> : body as Record<string, unknown>;
+                    if (data['posted'] !== true) return 'expected posted: true';
+                    return null;
+                },
+            },
+            {
+                label: 'verify comment persisted',
+                method: 'GET',
+                path: (ctx) => `/tasks/${ctx['taskId']}/comments`,
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (!isObj(body)) return 'expected object';
+                    const data = isObj(body['data']) ? body['data'] as Record<string, unknown> : body as Record<string, unknown>;
+                    const comments = data['comments'] as unknown[];
+                    if (!Array.isArray(comments)) return 'comments should be array';
+                    return null;
+                },
+            },
+            {
+                label: 'get task activities',
+                method: 'GET',
+                path: (ctx) => `/tasks/${ctx['taskId']}/activities`,
+                assert: (body, status) => {
+                    if (status === 404) return null;
+                    if (!isObj(body)) return 'expected object';
+                    const data = isObj(body['data']) ? body['data'] as Record<string, unknown> : body as Record<string, unknown>;
+                    if (!Array.isArray(data['activities'])) return 'activities should be array';
+                    return null;
+                },
+            },
+        ],
+    },
+    {
+        name: 'workspace-exploration',
+        steps: [
+            {
+                label: 'get workspace status',
+                method: 'GET',
+                path: '/workspace/status',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+                extract: (body) => {
+                    const data = body as Record<string, unknown>;
+                    return { workspaceActive: data['status'] === 'running' };
+                },
+            },
+            {
+                label: 'get workspace tree',
+                method: 'GET',
+                path: '/workspace/tree',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+            {
+                label: 'get workspace overview',
+                method: 'GET',
+                path: '/workspace/overview',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+            {
+                label: 'list connections',
+                method: 'GET',
+                path: '/workspace/connections',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+            {
+                label: 'list tags',
+                method: 'GET',
+                path: '/workspace/tags',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    return null;
+                },
+            },
+        ],
+    },
+    {
+        name: 'inbox-flow',
+        steps: [
+            {
+                label: 'list inbox items',
+                method: 'GET',
+                path: '/inbox',
+                assert: (body) => {
+                    if (!isObj(body)) return 'expected object';
+                    const data = isObj(body['data']) ? body['data'] as Record<string, unknown> : body as Record<string, unknown>;
+                    if (!Array.isArray(data['items'])) return 'items should be array';
+                    return null;
+                },
+                extract: (body) => {
+                    const wrapper = (body as Record<string, unknown>)['data'] as Record<string, unknown> | undefined;
+                    const items = (wrapper?.['items'] ?? (body as Record<string, unknown>)['items']) as unknown[];
+                    const first = items?.[0] as Record<string, unknown> | undefined;
+                    return {
+                        inboxItemId: first?.['id'] ?? '',
+                        hasInboxItems: items?.length > 0,
+                    };
+                },
+            },
+            {
+                label: 'get inbox item detail',
+                method: 'GET',
+                path: (ctx) => `/inbox/${ctx['inboxItemId']}`,
+                assert: (_body, status) => {
+                    if (status === 404) return null;
+                    return null;
+                },
+            },
+        ],
+    },
+];
+
+export async function runFlows(
+    baseUrl: string,
+    token: string,
+): Promise<{ results: TestResult[]; passed: number; failed: number }> {
+    console.log('\n=== TIER 3: FLOW TESTS ===\n');
+
+    const results: TestResult[] = [];
+    let passed = 0;
+    let failed = 0;
+
+    for (const flow of FLOWS) {
+        console.log(`\n--- Flow: ${flow.name} ---`);
+        const ctx: Record<string, unknown> = {};
+        let flowBroken = false;
+
+        for (const step of flow.steps) {
+            if (flowBroken) {
+                console.log(`[SKIP] ${step.label} — prior step failed`);
+                continue;
+            }
+
+            const path = typeof step.path === 'function' ? step.path(ctx) : step.path;
+
+            // skip steps that depend on data that doesn't exist
+            if (path.includes('/undefined') || path.includes('//')) {
+                console.log(`[SKIP] ${step.label} — no data available`);
+                continue;
+            }
+
+            const body = typeof step.body === 'function' ? step.body(ctx) : step.body;
+
+            try {
+                const resp = await apiCall(baseUrl, token, step.method, path, body);
+                const assertError = step.assert(resp.body, resp.status);
+                const pass = assertError === null && resp.status < 500;
+
+                const result: TestResult = {
+                    name: `flow:${flow.name}:${step.label}`,
+                    method: step.method,
+                    path,
+                    status: resp.status,
+                    passed: pass,
+                    duration: resp.duration,
+                    error: assertError || (resp.status >= 500 ? `Server error` : undefined),
+                    body: pass ? undefined : resp.body,
+                };
+
+                results.push(result);
+                console.log(formatResult(result));
+
+                if (pass) {
+                    passed++;
+                    if (step.extract && resp.status < 400) {
+                        Object.assign(ctx, step.extract(resp.body));
+                    }
+                } else {
+                    failed++;
+                    flowBroken = true;
+                }
+            } catch (err: unknown) {
+                failed++;
+                flowBroken = true;
+                const msg = err instanceof Error ? err.message : String(err);
+                const result: TestResult = {
+                    name: `flow:${flow.name}:${step.label}`,
+                    method: step.method,
+                    path,
+                    status: 0,
+                    passed: false,
+                    duration: 0,
+                    error: msg,
+                };
+                results.push(result);
+                console.log(formatResult(result));
+            }
+        }
+    }
+
+    console.log(`\nFlows: ${passed} passed, ${failed} failed\n`);
+    return { results, passed, failed };
+}

--- a/xerus_backend/tests/tools/pipedream-webhook.test.ts
+++ b/xerus_backend/tests/tools/pipedream-webhook.test.ts
@@ -1,0 +1,166 @@
+// Unit tests for the Pipedream Connect webhook helpers.
+// Pure functions — no DB, no network, no mocks.
+
+import {
+    resolvePipedreamWebhookUrl,
+    getPipedreamWebhookSecret,
+    verifyPipedreamWebhookSignature,
+    signPipedreamWebhookBody,
+    PipedreamWebhookSignatureError,
+} from '../../src/domains/tools/pipedream-webhook';
+
+const SECRET = 'whsec_unit_test_key';
+
+describe('resolvePipedreamWebhookUrl', () => {
+    let originalApiBaseUrl: string | undefined;
+
+    beforeEach(() => {
+        originalApiBaseUrl = process.env.API_BASE_URL;
+    });
+
+    afterEach(() => {
+        if (originalApiBaseUrl === undefined) delete process.env.API_BASE_URL;
+        else process.env.API_BASE_URL = originalApiBaseUrl;
+    });
+
+    it('builds the webhook URL from API_BASE_URL, stripping a trailing /api/v1', () => {
+        process.env.API_BASE_URL = 'https://api.xerus.ai/api/v1';
+        expect(resolvePipedreamWebhookUrl()).toBe('https://api.xerus.ai/api/v1/tools/webhook/connected');
+    });
+
+    it('builds the webhook URL from API_BASE_URL without an /api/v1 suffix', () => {
+        process.env.API_BASE_URL = 'https://api.xerus.ai';
+        expect(resolvePipedreamWebhookUrl()).toBe('https://api.xerus.ai/api/v1/tools/webhook/connected');
+    });
+
+    it('prefers API_BASE_URL over the request-derived base', () => {
+        process.env.API_BASE_URL = 'https://api.xerus.ai/api/v1';
+        expect(resolvePipedreamWebhookUrl('http://localhost:5001')).toBe(
+            'https://api.xerus.ai/api/v1/tools/webhook/connected',
+        );
+    });
+
+    it('falls back to the request-derived base when API_BASE_URL is unset', () => {
+        delete process.env.API_BASE_URL;
+        expect(resolvePipedreamWebhookUrl('http://localhost:5001')).toBe(
+            'http://localhost:5001/api/v1/tools/webhook/connected',
+        );
+    });
+
+    it('fail-fasts when neither API_BASE_URL nor a request base is available', () => {
+        delete process.env.API_BASE_URL;
+        expect(() => resolvePipedreamWebhookUrl()).toThrow(/API_BASE_URL/);
+    });
+
+    it('produces an identical URL for the user and agent flows (convergence)', () => {
+        process.env.API_BASE_URL = 'https://api.xerus.ai/api/v1';
+        const userFlow = resolvePipedreamWebhookUrl('http://localhost:5001');
+        const agentFlow = resolvePipedreamWebhookUrl();
+        expect(userFlow).toBe(agentFlow);
+    });
+});
+
+describe('getPipedreamWebhookSecret', () => {
+    let original: string | undefined;
+
+    beforeEach(() => {
+        original = process.env.PIPEDREAM_WEBHOOK_SECRET;
+    });
+
+    afterEach(() => {
+        if (original === undefined) delete process.env.PIPEDREAM_WEBHOOK_SECRET;
+        else process.env.PIPEDREAM_WEBHOOK_SECRET = original;
+    });
+
+    it('returns the configured secret', () => {
+        process.env.PIPEDREAM_WEBHOOK_SECRET = SECRET;
+        expect(getPipedreamWebhookSecret()).toBe(SECRET);
+    });
+
+    it('fail-fasts when the secret is unset', () => {
+        delete process.env.PIPEDREAM_WEBHOOK_SECRET;
+        expect(() => getPipedreamWebhookSecret()).toThrow(/PIPEDREAM_WEBHOOK_SECRET/);
+    });
+
+    it('fail-fasts when the secret is blank', () => {
+        process.env.PIPEDREAM_WEBHOOK_SECRET = '   ';
+        expect(() => getPipedreamWebhookSecret()).toThrow(/PIPEDREAM_WEBHOOK_SECRET/);
+    });
+});
+
+describe('verifyPipedreamWebhookSignature', () => {
+    const rawBody = JSON.stringify({ event: 'CONNECTION_SUCCESS', account: { id: 'apn_1' } });
+    const now = 1_700_000_000_000; // fixed ms clock
+    const timestamp = Math.floor(now / 1000);
+
+    function validHeader(body = rawBody, ts = timestamp): string {
+        return signPipedreamWebhookBody(body, SECRET, ts);
+    }
+
+    it('accepts a correctly signed body', () => {
+        expect(() =>
+            verifyPipedreamWebhookSignature({
+                rawBody,
+                signatureHeader: validHeader(),
+                secret: SECRET,
+                now,
+            }),
+        ).not.toThrow();
+    });
+
+    it('rejects a missing signature header', () => {
+        expect(() =>
+            verifyPipedreamWebhookSignature({ rawBody, signatureHeader: undefined, secret: SECRET, now }),
+        ).toThrow(PipedreamWebhookSignatureError);
+    });
+
+    it('rejects a malformed signature header', () => {
+        expect(() =>
+            verifyPipedreamWebhookSignature({ rawBody, signatureHeader: 'not-a-valid-header', secret: SECRET, now }),
+        ).toThrow(PipedreamWebhookSignatureError);
+    });
+
+    it('rejects a signature computed with a different secret', () => {
+        const header = signPipedreamWebhookBody(rawBody, 'whsec_other_key', timestamp);
+        expect(() =>
+            verifyPipedreamWebhookSignature({ rawBody, signatureHeader: header, secret: SECRET, now }),
+        ).toThrow(PipedreamWebhookSignatureError);
+    });
+
+    it('rejects when the body is tampered after signing', () => {
+        const header = validHeader();
+        const tampered = rawBody.replace('apn_1', 'apn_hacked');
+        expect(() =>
+            verifyPipedreamWebhookSignature({ rawBody: tampered, signatureHeader: header, secret: SECRET, now }),
+        ).toThrow(PipedreamWebhookSignatureError);
+    });
+
+    it('rejects a timestamp outside the tolerance window (replay protection)', () => {
+        const staleTs = timestamp - 3600;
+        const header = validHeader(rawBody, staleTs);
+        expect(() =>
+            verifyPipedreamWebhookSignature({ rawBody, signatureHeader: header, secret: SECRET, now }),
+        ).toThrow(/tolerance/);
+    });
+
+    it('accepts a timestamp within a custom tolerance window', () => {
+        const ts = timestamp - 100;
+        const header = validHeader(rawBody, ts);
+        expect(() =>
+            verifyPipedreamWebhookSignature({
+                rawBody,
+                signatureHeader: header,
+                secret: SECRET,
+                now,
+                toleranceSeconds: 200,
+            }),
+        ).not.toThrow();
+    });
+
+    it('rejects a malformed (non-hex, wrong-length) v1 digest cleanly', () => {
+        const header = `t=${timestamp},v1=zzzz`;
+        expect(() =>
+            verifyPipedreamWebhookSignature({ rawBody, signatureHeader: header, secret: SECRET, now }),
+        ).toThrow(PipedreamWebhookSignatureError);
+    });
+});

--- a/xerus_backend/tests/tools/reconciliation.test.ts
+++ b/xerus_backend/tests/tools/reconciliation.test.ts
@@ -1,0 +1,137 @@
+// Connected-accounts reconciliation tests.
+// Exercises toolsRepository.reconcileConnections against the real Neon test DB.
+// The Pipedream fetch (toolsService.reconcileConnectedAccounts) needs live Pipedream,
+// so we test the convergence logic directly with injected account data — no mocks.
+
+import { query } from '../setup';
+import { toolsRepository } from '../../src/domains/tools/repository';
+import type { SaveConnectionInput } from '../../src/domains/tools/types';
+
+const userA = 'test_recon_a_' + Date.now();
+const userB = 'test_recon_b_' + Date.now();
+
+function acct(userId: string, id: string, appSlug: string, appName: string): SaveConnectionInput {
+    return { user_id: userId, pipedream_account_id: id, app_slug: appSlug, app_name: appName };
+}
+
+async function insertUser(userId: string): Promise<void> {
+    await query(
+        `INSERT INTO users (user_id, email, display_name)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (user_id) DO NOTHING`,
+        [userId, `${userId}@example.com`, 'Reconciliation Test'],
+    );
+}
+
+async function seed(userId: string, id: string, appSlug: string, appName: string): Promise<void> {
+    await query(
+        `INSERT INTO connected_accounts (user_id, pipedream_account_id, app_slug, app_name, created_at)
+         VALUES ($1, $2, $3, $4, NOW())`,
+        [userId, id, appSlug, appName],
+    );
+}
+
+async function accountsFor(userId: string): Promise<Array<{ pipedream_account_id: string; app_slug: string; app_name: string }>> {
+    const result = await query<{ pipedream_account_id: string; app_slug: string; app_name: string }>(
+        `SELECT pipedream_account_id, app_slug, app_name
+         FROM connected_accounts WHERE user_id = $1 ORDER BY pipedream_account_id`,
+        [userId],
+    );
+    return result.rows;
+}
+
+describe('toolsRepository.reconcileConnections', () => {
+    beforeAll(async () => {
+        await insertUser(userA);
+        await insertUser(userB);
+    });
+
+    beforeEach(async () => {
+        await query('DELETE FROM connected_accounts WHERE user_id = ANY($1::text[])', [[userA, userB]]);
+    });
+
+    afterAll(async () => {
+        // ON DELETE CASCADE clears connected_accounts for these users.
+        await query('DELETE FROM users WHERE user_id = ANY($1::text[])', [[userA, userB]]);
+    });
+
+    it('backfills every account the DB is missing (repair for the webhook parse bug)', async () => {
+        const remote = [
+            acct(userA, `${userA}_1`, 'notion', 'Notion WS'),
+            acct(userA, `${userA}_2`, 'gmail', 'Work Gmail'),
+        ];
+
+        const summary = await toolsRepository.reconcileConnections(userA, remote);
+
+        expect(summary.added).toBe(2);
+        expect(summary.removed).toBe(0);
+        expect(summary.total).toBe(2);
+
+        const rows = await accountsFor(userA);
+        expect(rows.map((r) => r.pipedream_account_id)).toEqual([`${userA}_1`, `${userA}_2`]);
+        expect(rows.map((r) => r.app_slug)).toEqual(['notion', 'gmail']);
+    });
+
+    it('is idempotent — a second reconcile with the same set changes nothing', async () => {
+        const remote = [acct(userA, `${userA}_1`, 'notion', 'Notion WS')];
+
+        await toolsRepository.reconcileConnections(userA, remote);
+        const second = await toolsRepository.reconcileConnections(userA, remote);
+
+        expect(second.added).toBe(0);
+        expect(second.removed).toBe(0);
+        expect(second.total).toBe(1);
+        expect(await accountsFor(userA)).toHaveLength(1);
+    });
+
+    it('removes local rows the authoritative set no longer contains', async () => {
+        await seed(userA, `${userA}_stale`, 'slack', 'Old Slack');
+        await seed(userA, `${userA}_keep`, 'notion', 'Notion WS');
+
+        const remote = [acct(userA, `${userA}_keep`, 'notion', 'Notion WS')];
+        const summary = await toolsRepository.reconcileConnections(userA, remote);
+
+        expect(summary.added).toBe(0);
+        expect(summary.removed).toBe(1);
+        expect(summary.total).toBe(1);
+
+        const rows = await accountsFor(userA);
+        expect(rows.map((r) => r.pipedream_account_id)).toEqual([`${userA}_keep`]);
+    });
+
+    it('repairs drifted app_slug / app_name on an existing account', async () => {
+        await seed(userA, `${userA}_1`, 'wrong_slug', 'Stale Name');
+
+        const remote = [acct(userA, `${userA}_1`, 'notion', 'Correct Name')];
+        const summary = await toolsRepository.reconcileConnections(userA, remote);
+
+        expect(summary.added).toBe(0);
+        expect(summary.removed).toBe(0);
+
+        const rows = await accountsFor(userA);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].app_slug).toBe('notion');
+        expect(rows[0].app_name).toBe('Correct Name');
+    });
+
+    it('clears all of a user\'s rows when the authoritative set is empty', async () => {
+        await seed(userA, `${userA}_1`, 'notion', 'Notion WS');
+        await seed(userA, `${userA}_2`, 'gmail', 'Gmail');
+
+        const summary = await toolsRepository.reconcileConnections(userA, []);
+
+        expect(summary.added).toBe(0);
+        expect(summary.removed).toBe(2);
+        expect(summary.total).toBe(0);
+        expect(await accountsFor(userA)).toHaveLength(0);
+    });
+
+    it('never touches another user\'s rows', async () => {
+        await seed(userB, `${userB}_1`, 'github', 'Personal GitHub');
+
+        await toolsRepository.reconcileConnections(userA, [acct(userA, `${userA}_1`, 'notion', 'Notion WS')]);
+
+        const bRows = await accountsFor(userB);
+        expect(bRows.map((r) => r.pipedream_account_id)).toEqual([`${userB}_1`]);
+    });
+});

--- a/xerus_backend/tests/tools/webhook.routes.test.ts
+++ b/xerus_backend/tests/tools/webhook.routes.test.ts
@@ -1,0 +1,203 @@
+// Pipedream Connect Webhook Integration Tests
+// Exercises POST /api/v1/tools/webhook/connected against the real app and DB.
+// The webhook is unauthenticated and never calls Pipedream, so no mocks are used.
+// Every request carries a real x-pd-signature computed with the same helper the
+// route verifies against — so signing and verification can never silently drift.
+
+import request from 'supertest';
+import { app } from '../../src/index';
+import { getTestAuthHeaders, query } from '../setup';
+import { toolsRepository } from '../../src/domains/tools/repository';
+import { signPipedreamWebhookBody } from '../../src/domains/tools/pipedream-webhook';
+
+const WEBHOOK_SECRET = 'whsec_test_pipedream_signing_key';
+const WEBHOOK_PATH = '/api/v1/tools/webhook/connected';
+
+let originalSecret: string | undefined;
+
+function buildSuccessPayload(externalUserId: string, pipedreamAccountId: string) {
+    return {
+        event: 'CONNECTION_SUCCESS',
+        connect_token: 'ctok_test_token',
+        account: {
+            id: pipedreamAccountId,
+            name: 'My Notion Workspace',
+            external_id: externalUserId,
+            healthy: true,
+            dead: false,
+            app: {
+                name_slug: 'notion',
+                name: 'Notion',
+            },
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        },
+    };
+}
+
+// Sends the payload as the exact raw bytes the signature is computed over, so the
+// route verifies against identical input. `signature: null` omits the header entirely.
+function postSignedWebhook(
+    payload: unknown,
+    opts: { secret?: string; timestamp?: number; signature?: string | null } = {},
+) {
+    const rawBody = JSON.stringify(payload);
+    const timestamp = opts.timestamp ?? Math.floor(Date.now() / 1000);
+    const signature = opts.signature === undefined
+        ? signPipedreamWebhookBody(rawBody, opts.secret ?? WEBHOOK_SECRET, timestamp)
+        : opts.signature;
+
+    const req = request(app).post(WEBHOOK_PATH).set('Content-Type', 'application/json');
+    if (signature !== null) {
+        req.set('x-pd-signature', signature);
+    }
+    return req.send(rawBody);
+}
+
+describe('POST /api/v1/tools/webhook/connected', () => {
+    const testUserId = 'test_webhook_' + Date.now();
+    const testEmail = `webhook_${Date.now()}@example.com`;
+    const createdAccountIds: string[] = [];
+
+    beforeAll(async () => {
+        originalSecret = process.env.PIPEDREAM_WEBHOOK_SECRET;
+        process.env.PIPEDREAM_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+        await request(app)
+            .post('/api/v1/users/find-or-create')
+            .set(getTestAuthHeaders(testUserId))
+            .send({
+                uid: testUserId,
+                email: testEmail,
+                display_name: 'Webhook Test User',
+            });
+    });
+
+    afterAll(async () => {
+        for (const accountId of createdAccountIds) {
+            await query('DELETE FROM connected_accounts WHERE pipedream_account_id = $1', [accountId]);
+        }
+        await query('DELETE FROM users WHERE user_id = $1', [testUserId]);
+
+        if (originalSecret === undefined) {
+            delete process.env.PIPEDREAM_WEBHOOK_SECRET;
+        } else {
+            process.env.PIPEDREAM_WEBHOOK_SECRET = originalSecret;
+        }
+    });
+
+    it('writes a connected_accounts row from a signed, nested CONNECTION_SUCCESS payload', async () => {
+        const pipedreamAccountId = 'apn_success_' + Date.now();
+        createdAccountIds.push(pipedreamAccountId);
+
+        const response = await postSignedWebhook(buildSuccessPayload(testUserId, pipedreamAccountId)).expect(200);
+
+        expect(response.body.status).toBe('connected');
+
+        const saved = await toolsRepository.getConnectionByPipedreamId(pipedreamAccountId);
+        expect(saved).not.toBeNull();
+        expect(saved!.user_id).toBe(testUserId);
+        expect(saved!.app_slug).toBe('notion');
+        expect(saved!.app_name).toBe('My Notion Workspace');
+        expect(saved!.pipedream_account_id).toBe(pipedreamAccountId);
+    });
+
+    it('is idempotent — a repeated payload reports already_connected and writes no duplicate', async () => {
+        const pipedreamAccountId = 'apn_dupe_' + Date.now();
+        createdAccountIds.push(pipedreamAccountId);
+        const payload = buildSuccessPayload(testUserId, pipedreamAccountId);
+
+        const first = await postSignedWebhook(payload).expect(200);
+        expect(first.body.status).toBe('connected');
+
+        const second = await postSignedWebhook(payload).expect(200);
+        expect(second.body.status).toBe('already_connected');
+
+        const countResult = await query<{ count: string }>(
+            'SELECT COUNT(*) as count FROM connected_accounts WHERE pipedream_account_id = $1',
+            [pipedreamAccountId]
+        );
+        expect(parseInt(countResult.rows[0].count, 10)).toBe(1);
+    });
+
+    it('ignores a CONNECTION_ERROR event without writing a row', async () => {
+        const pipedreamAccountId = 'apn_error_' + Date.now();
+        createdAccountIds.push(pipedreamAccountId);
+
+        const response = await postSignedWebhook({
+            event: 'CONNECTION_ERROR',
+            connect_token: 'ctok_test_token',
+            error: 'user_denied_access',
+            account: {
+                id: pipedreamAccountId,
+                external_id: testUserId,
+                app: { name_slug: 'notion', name: 'Notion' },
+            },
+        }).expect(200);
+
+        expect(response.body.status).toBe('ignored');
+
+        const saved = await toolsRepository.getConnectionByPipedreamId(pipedreamAccountId);
+        expect(saved).toBeNull();
+    });
+
+    it('rejects a malformed payload with no account (fail-fast 400)', async () => {
+        const response = await postSignedWebhook({ event: 'CONNECTION_SUCCESS' }).expect(400);
+        expect(response.body.error).toBeDefined();
+    });
+
+    it('rejects a payload whose account is missing required identity fields (fail-fast 400)', async () => {
+        const response = await postSignedWebhook({
+            event: 'CONNECTION_SUCCESS',
+            account: {
+                name: 'Nameless',
+                app: { name: 'Notion' },
+            },
+        }).expect(400);
+
+        expect(response.body.error).toBeDefined();
+    });
+
+    it('rejects a request with no x-pd-signature header (401, writes no row)', async () => {
+        const pipedreamAccountId = 'apn_nosig_' + Date.now();
+        createdAccountIds.push(pipedreamAccountId);
+
+        const response = await postSignedWebhook(
+            buildSuccessPayload(testUserId, pipedreamAccountId),
+            { signature: null },
+        ).expect(401);
+
+        expect(response.body.error).toBe('Invalid webhook signature');
+        const saved = await toolsRepository.getConnectionByPipedreamId(pipedreamAccountId);
+        expect(saved).toBeNull();
+    });
+
+    it('rejects a request signed with the wrong secret (401, writes no row)', async () => {
+        const pipedreamAccountId = 'apn_badsig_' + Date.now();
+        createdAccountIds.push(pipedreamAccountId);
+
+        const response = await postSignedWebhook(
+            buildSuccessPayload(testUserId, pipedreamAccountId),
+            { secret: 'whsec_wrong_key' },
+        ).expect(401);
+
+        expect(response.body.error).toBe('Invalid webhook signature');
+        const saved = await toolsRepository.getConnectionByPipedreamId(pipedreamAccountId);
+        expect(saved).toBeNull();
+    });
+
+    it('rejects a request whose signature timestamp is stale (401, replay protection)', async () => {
+        const pipedreamAccountId = 'apn_stale_' + Date.now();
+        createdAccountIds.push(pipedreamAccountId);
+
+        const staleTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour old
+        const response = await postSignedWebhook(
+            buildSuccessPayload(testUserId, pipedreamAccountId),
+            { timestamp: staleTimestamp },
+        ).expect(401);
+
+        expect(response.body.error).toBe('Invalid webhook signature');
+        const saved = await toolsRepository.getConnectionByPipedreamId(pipedreamAccountId);
+        expect(saved).toBeNull();
+    });
+});

--- a/xerus_web/app/inbox/[domain]/page.tsx
+++ b/xerus_web/app/inbox/[domain]/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import { useAuth } from '@/utils/AuthContext'
 import { ErrorBoundary } from '@/components/common/ErrorBoundary'
+import { BusinessDataSection } from '@/components/company/BusinessDataSection'
 
 interface ChannelOverview {
   slug: string
@@ -171,6 +172,9 @@ function ProjectHubInner() {
           <p className="text-sm text-text-tertiary italic">No agents assigned to this project</p>
         )}
       </section>
+
+      {/* Company knowledge — business data agents write to company.db */}
+      <BusinessDataSection />
 
       {/* Recent activity */}
       {overview.recent_sessions.length > 0 && (

--- a/xerus_web/components/channels/ChannelActivity.tsx
+++ b/xerus_web/components/channels/ChannelActivity.tsx
@@ -20,6 +20,7 @@ import { Users, AlertCircle, RotateCcw } from 'lucide-react'
 import { isMascotConfig } from '@/lib/mascot-config'
 import { MascotAvatar } from '@/components/agents/MascotAvatar'
 import { useExecutionStream } from '@/hooks/useExecutionStream'
+import type { DoneEventContent } from '@/hooks/useExecutionStream'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -172,7 +173,21 @@ export function ChannelActivity({ channelId, className, assignedAgents, onManage
       const shortName = toolName.replace(/^mcp__platform__/, '').replace(/^mcp__/, '')
       setExecution(prev => prev ? { ...prev, status: 'tool_call', currentLine: `using ${shortName}` } : prev)
     },
-    onDone: () => {
+    onDone: (evt) => {
+      // A `done` event with success:false (or an error payload) is a failed run,
+      // not a completion. Surface it as the error card instead of clearing —
+      // otherwise the failure vanishes silently.
+      const content = evt.content as DoneEventContent
+      if (evt.success === false || content?.error) {
+        setExecution(prev => prev ? {
+          ...prev,
+          status: 'error',
+          currentLine: '',
+          errorMessage: content?.error?.message ?? 'The agent run failed',
+        } : prev)
+        lastLineRef.current = ''
+        return
+      }
       setExecution(null)
       lastLineRef.current = ''
       executionContextRef.current = null
@@ -316,6 +331,9 @@ export function ChannelActivity({ channelId, className, assignedAgents, onManage
   // mid-execution from error logging without meaning the agent is done).
   useEffect(() => {
     if (!execution) return
+    // A surfaced error stays until the user dismisses it — don't let a
+    // coincidental agent message clear the failure silently.
+    if (execution.status === 'error') return
     const latest = messages[messages.length - 1]
     if (!latest) return
     if (latest.sender_type === 'agent') {

--- a/xerus_web/components/company/BusinessDataSection.tsx
+++ b/xerus_web/components/company/BusinessDataSection.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { TrendingUp, TrendingDown, Minus, FlaskConical, Users, Building2, User } from 'lucide-react'
+import {
+  useCompanyBusinessData,
+  type Topic,
+  type ResearchReport,
+  type Prospect,
+} from '@/hooks/useCompanyBusinessData'
+
+// Business data agents produce in company.db — surfaced read-only on the project hub.
+// company.db is workspace-wide, so this reflects company knowledge across all projects.
+
+function SectionLabel({ children, count }: { children: React.ReactNode; count: number }) {
+  return (
+    <div className="flex items-baseline gap-2 mb-3">
+      <h3 className="text-xs font-medium uppercase tracking-wider text-text-muted">{children}</h3>
+      <span className="text-xs text-text-muted tabular-nums">{count}</span>
+    </div>
+  )
+}
+
+function RelevancePill({ score }: { score: number | null }) {
+  if (score === null || score === undefined) return null
+  return (
+    <span className="text-[10px] font-medium text-text-muted tabular-nums px-1.5 py-0.5 rounded bg-surface-hover">
+      {score}/10
+    </span>
+  )
+}
+
+function TrendBadge({ direction }: { direction: Topic['trend_direction'] }) {
+  if (!direction) return null
+  const config = {
+    rising: { icon: TrendingUp, className: 'text-success' },
+    declining: { icon: TrendingDown, className: 'text-warning' },
+    stable: { icon: Minus, className: 'text-text-muted' },
+  }[direction]
+  const Icon = config.icon
+  return (
+    <span className={`inline-flex items-center gap-1 text-[11px] ${config.className}`}>
+      <Icon className="w-3 h-3" />
+      {direction}
+    </span>
+  )
+}
+
+function TopicCard({ topic }: { topic: Topic }) {
+  return (
+    <div className="px-3 py-2.5 rounded-lg bg-surface hover:bg-surface-hover transition-colors">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-text truncate">{topic.name}</span>
+        <div className="flex items-center gap-2 shrink-0">
+          <TrendBadge direction={topic.trend_direction} />
+          <RelevancePill score={topic.relevance_score} />
+        </div>
+      </div>
+      {topic.description && (
+        <p className="text-xs text-text-secondary line-clamp-2 mt-1">{topic.description}</p>
+      )}
+      <div className="flex items-center gap-2 mt-1.5">
+        <span className="text-[10px] text-text-muted">{topic.source_agent}</span>
+        {topic.research_count > 0 && (
+          <span className="text-[10px] text-text-muted">
+            {topic.research_count} research run{topic.research_count !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ResearchReportCard({ report }: { report: ResearchReport }) {
+  const preview = report.summary || report.key_findings
+  return (
+    <div className="px-3 py-2.5 rounded-lg bg-surface hover:bg-surface-hover transition-colors">
+      <div className="flex items-start gap-2">
+        <FlaskConical className="w-4 h-4 text-text-muted shrink-0 mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <span className="text-sm font-medium text-text block truncate">{report.topic}</span>
+          {preview && (
+            <p className="text-xs text-text-secondary line-clamp-2 mt-0.5">{preview}</p>
+          )}
+          <div className="flex items-center gap-2 mt-1.5">
+            <span className="text-[10px] text-text-muted">{report.source_agent}</span>
+            <span className="text-[10px] text-text-muted">{report.source_skill}</span>
+            <span className="text-[10px] text-text-muted">
+              {new Date(report.created_at).toLocaleDateString()}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StatusPill({ status }: { status: string }) {
+  return (
+    <span className="text-[10px] font-medium text-text-secondary px-1.5 py-0.5 rounded-full bg-surface-hover capitalize">
+      {status}
+    </span>
+  )
+}
+
+function ProspectCard({ prospect }: { prospect: Prospect }) {
+  const Icon = prospect.type === 'person' ? User : Building2
+  return (
+    <div className="px-3 py-2.5 rounded-lg bg-surface hover:bg-surface-hover transition-colors">
+      <div className="flex items-center gap-2">
+        <Icon className="w-4 h-4 text-text-muted shrink-0" />
+        <span className="text-sm font-medium text-text truncate flex-1">{prospect.name}</span>
+        <div className="flex items-center gap-2 shrink-0">
+          <StatusPill status={prospect.status} />
+          <RelevancePill score={prospect.relevance_score} />
+        </div>
+      </div>
+      {prospect.notes && (
+        <p className="text-xs text-text-secondary line-clamp-2 mt-1 pl-6">{prospect.notes}</p>
+      )}
+      <div className="flex items-center gap-2 mt-1.5 pl-6">
+        <span className="text-[10px] text-text-muted">{prospect.source_agent}</span>
+      </div>
+    </div>
+  )
+}
+
+export function BusinessDataSection() {
+  const { data, isLoading } = useCompanyBusinessData()
+  const { topics, research_reports, prospects } = data
+  const total = topics.length + research_reports.length + prospects.length
+
+  // Nothing to show yet — keep the hub uncluttered on projects without data.
+  if (isLoading || total === 0) return null
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-2 mb-4">
+        <Users className="w-4 h-4 text-text-muted" />
+        <h2 className="text-xs font-medium uppercase tracking-wider text-text-muted">
+          Company Knowledge
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {topics.length > 0 && (
+          <div>
+            <SectionLabel count={topics.length}>Topics</SectionLabel>
+            <div className="flex flex-col gap-2">
+              {topics.map((t) => <TopicCard key={t.id} topic={t} />)}
+            </div>
+          </div>
+        )}
+
+        {research_reports.length > 0 && (
+          <div>
+            <SectionLabel count={research_reports.length}>Research Reports</SectionLabel>
+            <div className="flex flex-col gap-2">
+              {research_reports.map((r) => <ResearchReportCard key={r.id} report={r} />)}
+            </div>
+          </div>
+        )}
+
+        {prospects.length > 0 && (
+          <div>
+            <SectionLabel count={prospects.length}>Prospects</SectionLabel>
+            <div className="flex flex-col gap-2">
+              {prospects.map((p) => <ProspectCard key={p.id} prospect={p} />)}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/xerus_web/hooks/useCompanyBusinessData.ts
+++ b/xerus_web/hooks/useCompanyBusinessData.ts
@@ -1,0 +1,105 @@
+'use client'
+
+import { useCallback } from 'react'
+import useSWR from 'swr'
+import { apiGet } from '@/lib/api/client'
+import { useAuth } from '@/utils/AuthContext'
+
+// ---------------------------------------------------------------------------
+// Company business data — topics, research reports, and prospects that agents
+// write to company.db (the structured layer of the workspace data model).
+// Read-only surface backed by GET /company/business.
+// ---------------------------------------------------------------------------
+
+export interface Topic {
+  id: number
+  name: string
+  description: string | null
+  relevance_score: number | null
+  trend_direction: 'rising' | 'stable' | 'declining' | null
+  research_count: number
+  last_researched_at: string | null
+  source_agent: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ResearchReport {
+  id: number
+  topic: string
+  source_skill: string
+  source_agent: string
+  key_findings: string | null
+  summary: string | null
+  sheet_url: string | null
+  created_at: string
+}
+
+export interface Prospect {
+  id: number
+  name: string
+  type: string
+  status: string
+  relevance_score: number | null
+  source_agent: string
+  source_url: string | null
+  notes: string | null
+  created_at: string
+}
+
+export interface CompanyBusinessData {
+  topics: Topic[]
+  research_reports: ResearchReport[]
+  prospects: Prospect[]
+}
+
+const EMPTY_DATA: CompanyBusinessData = { topics: [], research_reports: [], prospects: [] }
+
+const POLL_INTERVAL_MS = 30_000
+const POLL_MAX_BACKOFF_MS = 120_000
+
+interface UseCompanyBusinessDataReturn {
+  data: CompanyBusinessData
+  isLoading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+const fetchCompanyBusinessData = async (): Promise<CompanyBusinessData> => {
+  const raw = await apiGet<{ data?: CompanyBusinessData } & Partial<CompanyBusinessData>>(
+    '/company/business',
+  )
+  const payload = raw.data ?? raw
+  return {
+    topics: payload.topics ?? [],
+    research_reports: payload.research_reports ?? [],
+    prospects: payload.prospects ?? [],
+  }
+}
+
+export function useCompanyBusinessData(): UseCompanyBusinessDataReturn {
+  const { isAuthReady } = useAuth()
+  const swrKey = isAuthReady ? (['company-business'] as const) : null
+
+  const { data, isLoading, error, mutate } = useSWR<CompanyBusinessData>(
+    swrKey,
+    fetchCompanyBusinessData,
+    {
+      refreshInterval: POLL_INTERVAL_MS,
+      refreshWhenHidden: false,
+      onErrorRetry: (_err, _key, _config, revalidate, { retryCount }) => {
+        const delay = Math.min(POLL_MAX_BACKOFF_MS, POLL_INTERVAL_MS * 2 ** retryCount)
+        setTimeout(() => revalidate({ retryCount }), delay)
+      },
+    },
+  )
+
+  const refetch = useCallback(() => { mutate() }, [mutate])
+
+  return {
+    data: data ?? EMPTY_DATA,
+    isLoading,
+    error: error instanceof Error ? error.message : (error ? 'Failed to load business data' : null),
+    refetch,
+  }
+}

--- a/xerus_web/hooks/useDomains.ts
+++ b/xerus_web/hooks/useDomains.ts
@@ -9,6 +9,8 @@ export interface Channel {
   name: string
   description?: string
   agent_count: number
+  message_count: number
+  last_message_at: string | null
 }
 
 export interface Domain {
@@ -38,6 +40,7 @@ export function useDomains(): UseDomainReturn {
 
   const { data, error, isLoading, mutate } = useSWR<{ data: DomainsResponse }>(
     isAuthReady ? SWR_KEY : null,
+    { refreshInterval: 10_000, refreshWhenHidden: false },
   )
 
   const response = data?.data ?? data

--- a/xerus_web/hooks/useOfficeData.ts
+++ b/xerus_web/hooks/useOfficeData.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import useSWR from 'swr'
 import { toast } from '@/lib/toast'
 import { getAssistants, getUserAgents } from '@/lib/api/agents'
@@ -125,54 +125,73 @@ interface UseCompanyTasksReturn {
   refetch: () => void
 }
 
+const COMPANY_TASK_POLL_INTERVAL_MS = 10_000
+const POLL_MAX_BACKOFF_MS = 60_000
+
+interface CompanyBoardData {
+  tasks: KanbanTask[]
+  agents: KanbanAgent[]
+}
+
+const fetchCompanyBoard = async (): Promise<CompanyBoardData> => {
+  const result = await getAssistants({ limit: 100 })
+  const agents: KanbanAgent[] = result.agents.map(a => ({
+    id: String(a.id),
+    name: a.name,
+    slug: a.name.toLowerCase().replace(/\s+/g, '-'),
+    status: a.status === 'active' ? 'active' as const : 'idle' as const,
+  }))
+  let tasks: KanbanTask[] = []
+  try {
+    const tasksRaw = await apiGet<unknown>('/tasks')
+    const tasksData = unwrap<{ tasks?: KanbanTask[] }>(tasksRaw)
+    tasks = tasksData.tasks ?? []
+  } catch {
+    // API not available yet — show empty state, not dummy data
+    tasks = []
+  }
+  return { tasks, agents }
+}
+
 export function useCompanyTasks(): UseCompanyTasksReturn {
-  const [tasks, setTasks] = useState<KanbanTask[]>([])
-  const [agents, setAgents] = useState<KanbanAgent[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const { data, isLoading, error: swrError, mutate } = useSWR<CompanyBoardData>(
+    'company-board',
+    fetchCompanyBoard,
+    {
+      refreshInterval: COMPANY_TASK_POLL_INTERVAL_MS,
+      refreshWhenHidden: false,
+      onErrorRetry: (_err, _key, _config, revalidate, { retryCount }) => {
+        const delay = Math.min(POLL_MAX_BACKOFF_MS, COMPANY_TASK_POLL_INTERVAL_MS * 2 ** retryCount)
+        setTimeout(() => revalidate({ retryCount }), delay)
+      },
+    },
+  )
 
-  const fetchData = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const result = await getAssistants({ limit: 100 })
-      const agentPool = result.agents.map(a => ({
-        id: String(a.id),
-        name: a.name,
-        slug: a.name.toLowerCase().replace(/\s+/g, '-'),
-        status: a.status === 'active' ? 'active' as const : 'idle' as const,
-      }))
-      setAgents(agentPool)
-      try {
-        const tasksRaw = await apiGet<unknown>('/tasks')
-        const tasksData = unwrap<{ tasks?: KanbanTask[] }>(tasksRaw)
-        setTasks(tasksData.tasks ?? [])
-      } catch {
-        // API not available yet — show empty state, not dummy data
-        setTasks([])
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load board data')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  // Use SWR-style: fetch on mount
-  const { mutate } = useSWR('company-tasks-trigger', () => {
-    fetchData()
-    return null
-  })
+  const tasks = data?.tasks ?? []
+  const agents = data?.agents ?? []
+  const error = swrError instanceof Error ? swrError.message : (swrError ? 'Failed to load board data' : null)
 
   const updateTaskStatus = useCallback(async (taskId: string, newStatus: string) => {
-    setTasks(prev => prev.map(t => (t.id === taskId ? { ...t, status: newStatus } : t)))
-    try {
-      await apiPost(`/tasks/${taskId}/status`, { status: newStatus })
-    } catch {
-      toast.error("Couldn't move that task — reverting", { description: 'The task has been moved back to its original position.' })
-      fetchData()
+    const applyStatus = (current: CompanyBoardData | undefined): CompanyBoardData => {
+      const base = current ?? { tasks: [], agents: [] }
+      return { ...base, tasks: base.tasks.map(t => (t.id === taskId ? { ...t, status: newStatus } : t)) }
     }
-  }, [fetchData])
+    await mutate(
+      async (current) => {
+        await apiPost(`/tasks/${taskId}/status`, { status: newStatus })
+        return applyStatus(current)
+      },
+      {
+        optimisticData: applyStatus,
+        rollbackOnError: true,
+        revalidate: false,
+      },
+    ).catch(() => {
+      toast.error("Couldn't move that task — reverting", { description: 'The task has been moved back to its original position.' })
+    })
+  }, [mutate])
 
-  return { tasks, agents, isLoading, error, updateTaskStatus, refetch: fetchData }
+  const refetch = useCallback(() => { mutate() }, [mutate])
+
+  return { tasks, agents, isLoading, error, updateTaskStatus, refetch }
 }

--- a/xerus_web/hooks/useUnreadCounts.ts
+++ b/xerus_web/hooks/useUnreadCounts.ts
@@ -1,27 +1,22 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useDomains } from './useDomains'
 
-const STORAGE_KEY = 'xerus_unread_counts'
-const UNREAD_UPDATE_EVENT = 'xerus:unread_update'
+const SEEN_KEY = 'xerus_last_seen_counts'
 
-interface UnreadCounts {
+interface SeenCounts {
   [channelId: string]: number
 }
 
-interface UnreadUpdateDetail {
-  channelId: string
-  count: number
-}
-
-function loadFromStorage(): UnreadCounts {
+function loadSeen(): SeenCounts {
   if (typeof window === 'undefined') return {}
-  const stored = localStorage.getItem(STORAGE_KEY)
+  const stored = localStorage.getItem(SEEN_KEY)
   if (!stored) return {}
   try {
     const parsed: unknown = JSON.parse(stored)
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
-    const result: UnreadCounts = {}
+    const result: SeenCounts = {}
     for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
       if (typeof value === 'number' && value >= 0) {
         result[key] = value
@@ -29,64 +24,67 @@ function loadFromStorage(): UnreadCounts {
     }
     return result
   } catch {
-    localStorage.removeItem(STORAGE_KEY)
+    localStorage.removeItem(SEEN_KEY)
     return {}
   }
 }
 
-function persistToStorage(counts: UnreadCounts): void {
+function persistSeen(seen: SeenCounts): void {
   if (typeof window === 'undefined') return
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(counts))
+  localStorage.setItem(SEEN_KEY, JSON.stringify(seen))
 }
 
 export function useUnreadCounts() {
-  const [counts, setCounts] = useState<UnreadCounts>(loadFromStorage)
+  const { domains } = useDomains()
+  const [seen, setSeen] = useState<SeenCounts>(loadSeen)
 
-  const totalUnread = Object.values(counts).reduce((sum, count) => sum + count, 0)
+  const counts = useMemo(() => {
+    const result: Record<string, number> = {}
+    for (const domain of domains) {
+      for (const channel of domain.channels) {
+        const lastSeen = seen[channel.id] ?? 0
+        const unread = Math.max(0, (channel.message_count ?? 0) - lastSeen)
+        if (unread > 0) {
+          result[channel.id] = unread
+        }
+      }
+    }
+    return result
+  }, [domains, seen])
+
+  const totalUnread = useMemo(
+    () => Object.values(counts).reduce((sum, n) => sum + n, 0),
+    [counts],
+  )
 
   const markRead = useCallback((channelId: string) => {
-    setCounts((prev) => {
-      const next = { ...prev }
-      delete next[channelId]
-      persistToStorage(next)
+    const channel = domains
+      .flatMap(d => d.channels)
+      .find(c => c.id === channelId)
+    if (!channel) return
+
+    setSeen(prev => {
+      const next = { ...prev, [channelId]: channel.message_count ?? 0 }
+      persistSeen(next)
       return next
     })
-  }, [])
+  }, [domains])
 
   const resetAll = useCallback(() => {
-    setCounts({})
-    persistToStorage({})
-  }, [])
-
-  useEffect(() => {
-    function handleUnreadUpdate(event: Event) {
-      const customEvent = event as CustomEvent<UnreadUpdateDetail>
-      const { channelId, count } = customEvent.detail
-      if (typeof channelId !== 'string' || typeof count !== 'number') return
-
-      setCounts((prev) => {
-        const next = { ...prev }
-        if (count <= 0) {
-          delete next[channelId]
-        } else {
-          next[channelId] = count
-        }
-        persistToStorage(next)
-        return next
-      })
+    const next: SeenCounts = {}
+    for (const domain of domains) {
+      for (const channel of domain.channels) {
+        next[channel.id] = channel.message_count ?? 0
+      }
     }
+    setSeen(next)
+    persistSeen(next)
+  }, [domains])
 
-    window.addEventListener(UNREAD_UPDATE_EVENT, handleUnreadUpdate)
-    return () => {
-      window.removeEventListener(UNREAD_UPDATE_EVENT, handleUnreadUpdate)
-    }
-  }, [])
-
-  // Sync across tabs via storage event
   useEffect(() => {
     function handleStorageChange(event: StorageEvent) {
-      if (event.key !== STORAGE_KEY) return
-      setCounts(loadFromStorage())
+      if (event.key !== SEEN_KEY) return
+      setSeen(loadSeen())
     }
 
     window.addEventListener('storage', handleStorageChange)


### PR DESCRIPTION
## Summary
- **Pipedream tools**: connection reconciler, HMAC-verified webhook handler (`POST /api/v1/tools/webhook/connected`), tool repository/routes/service updates for the Connect flow
- **Execution**: `wake-daemon` replaces heartbeat-daemon's polling loop; new `execution-lifecycle`/`internal-execution` routes, `execution-service` registry, post-session memory indexer, and continuation engine (`intent-gate`, `todo-enforcer`)
- **Company**: new `company-business-db` service/routes for structured business data, surfaced in `xerus_web` via `useCompanyBusinessData` + `BusinessDataSection`
- **Drive**: `deliverables-projection` reworked around a new `deliverables-scan` module
- **Memory**: `git-memory` path inference for workspace-scoped memory writes
- **Migrations**: `095_sandbox_wake_schedule.sql`, `096_relax_memory_search_index_constraints.sql`
- **e2e**: `seam.api.test.ts` covering the schedule-fire → sandbox → agent run chain, plus new `E2E_INTERNAL_URL`/`XERUS_INTERNAL_API_TOKEN`/`E2E_RUN_SEAM` env vars

No secrets committed — `.env.example` changes only add empty placeholder vars with explanatory comments.

## Test plan
- [ ] `npm run lint && npm run typecheck` in `xerus_backend`
- [ ] `npm test` for new/changed unit tests (`company-business-db`, `deliverables-projection`, `pipedream-webhook`, `reconciliation`, `webhook.routes`, `memory-path-inference`, `post-session-memory-indexer`, `096_relax_memory_search_index_constraints`, `tool.filter`, `daytona-runner`, `execution-pipeline-resilience`, `runner-event-router`)
- [ ] Run migrations 095 and 096 against a scratch DB
- [ ] `E2E_RUN_SEAM=1` run of `e2e/api/seam.api.test.ts` against a local backend + Daytona sandbox
- [ ] Manually verify Pipedream connect → webhook → tool-connection flow end-to-end
- [ ] Verify company business data renders in `xerus_web` inbox/domain page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oTWcvBUcpm2qhKirafkae